### PR TITLE
`ursula` script uses ssh_config file, if one is found.

### DIFF
--- a/bin/ursula
+++ b/bin/ursula
@@ -1,7 +1,18 @@
 #!/bin/bash
+env=$1
+playbook=$2
+
+hosts=$1/hosts
+ssh_config=$1/ssh_config
+
+if [ -e $ssh_config ]; then
+  export ANSIBLE_SSH_ARGS="-F $ssh_config"
+fi
+
 export ANSIBLE_NOCOWS=1
+
 ansible-playbook \
-  --inventory-file $1/hosts \
+  --inventory-file $hosts \
   --user root \
   --module-path ./library \
-  $2
+  $playbook


### PR DESCRIPTION
For cases where not all nodes are publicly addressable,
ursula now uses the ssh_config file, if one is found in
the same directory as the hosts inventory file.

This allows greater configurability of how ansible uses ssh,
such as using ProxyCommand to operate on hosts which are not
addressable from the machine running ansible.
