### PR TITLE
Cease use of fireball mode.

### DIFF
--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -1,20 +1,17 @@
 ---
 - hosts: all
   gather_facts: false
-  connection: ssh
   tasks:
     - name: update dpkg index
       apt: update_cache=yes
 
 - hosts: all
   gather_facts: false
-  connection: ssh
   tasks:
     - include: common/tasks/fireball.yml
     - action: fireball
 
 - hosts: all
-  connection: fireball
   roles:
     - sensu-client
   tasks:

--- a/playbooks/compute.yml
+++ b/playbooks/compute.yml
@@ -1,6 +1,5 @@
 ---
 - hosts: compute
-  connection: fireball
   roles:
     - common
     - nova

--- a/playbooks/controller.yml
+++ b/playbooks/controller.yml
@@ -1,6 +1,5 @@
 ---
 - hosts: controller
-  connection: fireball
   roles:
     - common
     - client


### PR DESCRIPTION
Fireball mode starts an ephemeral damon on the ansible nodes
to avoid initiating multiple ssh connections.

Fireball can't work when non-addressible nodes are accessed via
an ssh ProxyCommand, and the performance benefit it provides is
minimal, so I have removed it.
