### PR TITLE
Don't show changed on 'kvm-ok' task.

### DIFF
--- a/playbooks/nova/tasks/compute.yml
+++ b/playbooks/nova/tasks/compute.yml
@@ -8,8 +8,7 @@
 - name: ensure kvm is supported by cpu and enabled in bios
   command: kvm-ok
   when: "'{{ nova.libvirt_type }}' == 'kvm'"
-  # TODO: available in ansible 1.3
-  # changed_when: "False"
+  changed_when: False
 
 - user: name=nova groups=libvirtd
 - file: dest=/var/lib/nova/instances state=directory owner=nova


### PR DESCRIPTION
Use changed_when keyword to force 'kvm-ok' check to never show changed.

With this changed, nova compute nodes run completely green on runs
after the initial install.
