### PR TITLE
Use ssh option ControlPersist.

### DIFF
--- a/bin/ursula
+++ b/bin/ursula
@@ -5,8 +5,9 @@ playbook=$2
 hosts=$1/hosts
 ssh_config=$1/ssh_config
 
+export ANSIBLE_SSH_ARGS="-o ControlMaster=auto -o ControlPath=~/.ssh/ursula-%l-%r@%h:%p -o ControlPersist=yes "
 if [ -e $ssh_config ]; then
-  export ANSIBLE_SSH_ARGS="-F $ssh_config"
+  export ANSIBLE_SSH_ARGS="$ANSIBLE_SSH_ARGS -F $ssh_config"
 fi
 
 export ANSIBLE_NOCOWS=1

--- a/test/common
+++ b/test/common
@@ -6,7 +6,7 @@ net_name=external
 key_name=int-test
 key_path=$HOME/.ssh/$key_name.pem
 login_user=ubuntu
-ssh_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $key_path"
+ssh_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $key_path -o ControlMaster=auto -o ControlPath=~/.ssh/ursula-%l-%r@%h:%p -o ControlPersist=yes"
 root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 
 die() {


### PR DESCRIPTION
Configure ssh to use "ControlPersist", which dramatically
speeds up ansible runs, by maintaining an open ssh connection
for the duration of the run, avoiding (TCP + authentication + reverse
DNS + shell startup) costs for all but the first task.
