### PR TITLE
Define neutron internal subnet in example env.

### DIFF
--- a/envs/example/group_vars/all.yml
+++ b/envs/example/group_vars/all.yml
@@ -67,6 +67,13 @@ neutron:
       external: false
       network_type: gre
       segmentation_id: 256
+  subnets:
+    - name: internal
+      network_name: internal
+      cidr: 172.16.255.0/24
+      enable_dhcp: "true"
+      gateway_ip: 172.16.255.1
+      ip_version: 4
 
 glance:
   rev: 563c71c1

--- a/roles/openstack-setup/tasks/networks.yml
+++ b/roles/openstack-setup/tasks/networks.yml
@@ -13,20 +13,20 @@
       login_password={{ secrets.admin_password }}
   with_items: neutron.networks
 
-#- name: neutron subnets
-#  action: |
-#    neutron_subnet
-#      name={{ item.name }}
-#      network_name={{ item.network_name }}
-#      cidr={{ item.cidr }}
-#      enable_dhcp={{ item.enable_dhcp }}
-#      gateway_ip={{ item.gateway_ip }}
-#      ip_version={{ item.ip_version }}
-#      state=present
-#      auth_url=http://{{ endpoints.main }}:5000/v2.0/
-#      login_tenant_name=admin
-#      login_password={{ secrets.admin_password }}
-#  with_items: neutron.subnets
+- name: neutron subnets
+  action: |
+    neutron_subnet
+      name={{ item.name }}
+      network_name={{ item.network_name }}
+      cidr={{ item.cidr }}
+      enable_dhcp={{ item.enable_dhcp }}
+      gateway_ip={{ item.gateway_ip }}
+      ip_version={{ item.ip_version }}
+      state=present
+      auth_url=http://{{ endpoints.main }}:5000/v2.0/
+      login_tenant_name=admin
+      login_password={{ secrets.admin_password }}
+  with_items: neutron.subnets
 
 #- name: neutron routers
 #  action: |


### PR DESCRIPTION
This is the last thing necessary to boot nested
(kvm(qemu)) instances during integration testing.
