### PR TITLE
Add an example post-deploy test:

### DIFF
--- a/test/common
+++ b/test/common
@@ -6,7 +6,7 @@ net_name=external
 key_name=int-test
 key_path=$HOME/.ssh/$key_name.pem
 login_user=ubuntu
-ssh_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $key_path -o ControlMaster=auto -o ControlPath=~/.ssh/ursula-%l-%r@%h:%p -o ControlPersist=yes"
+ssh_args="-o LogLevel=quiet -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $key_path -o ControlMaster=auto -o ControlPath=~/.ssh/ursula-%l-%r@%h:%p -o ControlPersist=yes"
 root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 
 die() {
@@ -53,9 +53,9 @@ ensure_free_floating_ip() {
 
 # given an ansible host match string, and a command,
 # run the command on the host(s)
-run_cmd_on_hosts() {
-  local hosts=$(ansible -i $root/envs/example/hosts --list-hosts "$1" | awk '{print $1}')
+run_on_hosts() {
+  local hosts=$(ansible -i $root/envs/test/hosts --list-hosts "$1" | awk '{print $1}')
   for host in $hosts; do
-    ssh $ssh_args $login_user@$host "$2"
+    ssh $ssh_args root@$host "$2"
   done
 }

--- a/test/run
+++ b/test/run
@@ -14,3 +14,11 @@ ansible-playbook \
   --user $login_user \
   --sudo \
   site.yml
+
+for test in $(ls $root/test/tests.d); do
+  echo
+  echo
+  echo "### running test:  $test"
+  echo
+  $root/test/tests.d/$test
+done

--- a/test/setup
+++ b/test/setup
@@ -34,8 +34,13 @@ for vm in $vms; do
     sleep 1
   done
 
+  ssh $ssh_args $login_user@$ip "echo '127.0.1.1 $vm' | sudo tee -a /etc/hosts"
+
   # TODO: this is a workaround for an MTU issue. it should be removed once fixed.
   ssh $ssh_args $login_user@$ip sudo ifconfig eth0 mtu 1454 2>&1 >/dev/null
+
+  ssh $ssh_args $login_user@$ip sudo mkdir -p /root/.ssh 2>&1 >/dev/null
+  ssh $ssh_args $login_user@$ip sudo cp /home/$login_user/.ssh/authorized_keys /root/.ssh/. 2>&1 >/dev/null
 done
 controller_ip=$(public_ip test-controller-0)
 

--- a/test/tests.d/glance
+++ b/test/tests.d/glance
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+source $(dirname $0)/../common
+
+# an example test.
+
+echo "ensure glance is up, and contains the cirros image"
+run_on_hosts controller[0] "source /root/stackrc; glance index | grep cirros"


### PR DESCRIPTION
- add a hoook to run all scripts under test/tests.d
- add an example test which verifies glance is up and contains
  the cirros image.
- configure root ssh key, so that tests over ssh don't need to
  use sudo everywhere.
- add an /etc/hosts entry to each vm to avoid extraneous 'unknown
  hosts' output.
- use ssh loglevel=none to avoid 'permananently added key' output
