### PR TITLE
Optionally manage node networking with ansible:

### DIFF
--- a/envs/example/group_vars/all.yml
+++ b/envs/example/group_vars/all.yml
@@ -10,9 +10,15 @@ secrets:
   metadata_proxy_shared_secret: asdf
   horizon_secret_key:           asdf
 
+fqdn: &fqdn openstack.example.com
+floating_ip: &floating_ip 173.247.112.252
+
+etc_hosts:
+  - name: *fqdn
+    ip: *floating_ip
 
 corosync:
-  floating_ipv4: 173.247.112.252
+  floating_ipv4: *floating_ip
   # authkey generation command: openssl rand 128 -base64
   authkey: |
     1Fq2vvgLrzjTkYB1J4HE2/NvZnVcqUyz83d+Ds/uYtZ7TRxbwBmPtywdY4axyWSQ

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -35,3 +35,4 @@
   file: dest=/etc/sensu/conf.d/checks/ state=directory mode=0755
 
 - include: ssl.yml
+- include: interfaces.yml

--- a/roles/common/tasks/networking.yml
+++ b/roles/common/tasks/networking.yml
@@ -1,0 +1,6 @@
+---
+- template: src=etc/network/interfaces dest=/etc/network/interfaces owner=root group=root mode=0644
+  when: network_interfaces is defined
+
+- lineinfile: dest=/etc/hosts regexp=^{{ item.ip }} line="{{ item.ip }} {{ item.name }}"
+  with_items: etc_hosts

--- a/roles/common/templates/etc/network/interfaces
+++ b/roles/common/templates/etc/network/interfaces
@@ -1,0 +1,1 @@
+{{ network_interfaces }}


### PR DESCRIPTION
- write `network_interfaces` var to /etc/network/interfaces, if defined.
  this is very useful on network nodes, where iptables rules, floatingips,
  etc. must be defined.
- set /etc/hosts entries from var `etc_hosts` to allow for static lookup
  when DNS is not available.
  e.g.
    etc_hosts:
      - name: controller.example.com
        ip: 1.2.3.4
