### PR TITLE
Allow specification of non-default mtu for instances:

### DIFF
--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 - apt: pkg=dnsmasq
 
+- name: set instance mtu, if different than default
+  lineinfile: dest=/etc/dnsmasq.conf regexp=^dhcp-option=26, line=dhcp-option=26,{{ neutron_dhcp_mtu }}
+  when: neutron_dhcp_mtu is defined
+
 - name: ovs ex bridge
   ovs_bridge: name=br-ex state=present
 

--- a/roles/neutron-common/templates/etc/neutron/dhcp_agent.ini
+++ b/roles/neutron-common/templates/etc/neutron/dhcp_agent.ini
@@ -9,3 +9,5 @@ interface_driver = neutron.agent.linux.interface.OVSInterfaceDriver
 dhcp_driver = neutron.agent.linux.dhcp.Dnsmasq
 root_helper = sudo /usr/local/bin/neutron-rootwrap /etc/neutron/rootwrap.conf
 use_namespaces = True
+
+dnsmasq_config_file = /etc/dnsmasq.conf


### PR DESCRIPTION
When using GRE tunelling, large packets are sometimes corrupted,
unless a smaller mtu is used.

This change allows setting a non-default MTU in var `neutron_dhcp_mtu`,
which is passed to dnsmasq, and provided to instances when they DHCP.
