### PR TITLE
add arbiter to percona playbook

### DIFF
--- a/playbooks/percona.yml
+++ b/playbooks/percona.yml
@@ -1,4 +1,13 @@
 ---
+# compute node needs Percona apt repo in order
+# to obtain garbd and act as abriter for two-node cluster
+- name: Install Percona Apt Repository
+  hosts: db:compute
+  tasks:
+  - apt_key: url=http://www.percona.com/redir/downloads/RPM-GPG-KEY-percona state=present
+  - apt_repository: repo='deb http://repo.percona.com/apt precise main'
+  - apt: update_cache=yes
+
 - name: Install Percona Xtradb and Configure Quorum
   hosts: db
   tasks:
@@ -20,3 +29,8 @@
     - name: check wsrep_cluster_size
       shell: mysql --silent -e 'show global status like "wsrep_cluster_size"' | tail -1 | cut -f 2 | grep {{ groups['db']|count }}
       changed_when: False
+
+- name: Install Percona Arbiter
+  hosts: compute
+  tasks:
+  - include: percona/tasks/arbiter.yml

--- a/playbooks/percona/tasks/arbiter.yml
+++ b/playbooks/percona/tasks/arbiter.yml
@@ -1,0 +1,17 @@
+---
+# the arbiter node only needs the garbd daemon
+# (provided by galera pkg).
+- name: install percona galera package
+  register: pkg_installed
+  apt: pkg=$item state=installed
+  with_items:
+  - percona-xtradb-cluster-galera-2.x
+
+- name: install garbd upstart script
+  template: src=etc/init/garbd.conf dest=/etc/init/garbd.conf mode=0400
+
+- name: populate garbd upstart script with cluster IPs 
+  lineinfile: dest=/etc/init/garbd.conf regexp='-a gcomm' line="-a gcomm://{% for host in groups['db'] %}{% if not loop.last %}{{ hostvars[host]['ansible_eth0']['ipv4']['address'] }},{% else %}{{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}{% endif %}{% endfor %} &"
+
+- name: start garbd
+  shell: /sbin/start garbd

--- a/playbooks/percona/tasks/main.yml
+++ b/playbooks/percona/tasks/main.yml
@@ -4,11 +4,6 @@
   register: my_cnf_exists
   changed_when: False
 
-- name: percona apt source
-  apt_key: url=http://www.percona.com/redir/downloads/RPM-GPG-KEY-percona state=present
-- apt_repository: repo='deb http://repo.percona.com/apt precise main'
-- apt: update_cache=yes
-
 - name: install percona xtradb packages
   register: pkg_installed
   apt: pkg=$item state=installed

--- a/playbooks/percona/templates/etc/init/garbd.conf
+++ b/playbooks/percona/templates/etc/init/garbd.conf
@@ -1,0 +1,10 @@
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+expect fork
+
+exec start-stop-daemon  --start \
+                        --make-pidfile --pidfile /var/run/garbd.pid \
+                        --exec /usr/bin/garbd -- -g mstack_db_cluster -l /var/log/garbd.log \
+                        -a gcomm://


### PR DESCRIPTION
This adds the arbiter task to the percona playbook which does the following:
- Installs the garbd binary via percona's galera pkg on the compute node 
- Installs a garbd upstart script 
- Configures garbd's gcomm URL within the upstart script so it will join the existing DB quorum on startup
