### PR TITLE
Optionally ship syslog to a log aggregation server.

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: refresh CAs
   command: update-ca-certificates
+
+- name: restart rsyslog
+  service: name=rsyslog state=restarted

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -34,5 +34,6 @@
 - name: sensu check directory
   file: dest=/etc/sensu/conf.d/checks/ state=directory mode=0755
 
+- include: syslog.yml
 - include: ssl.yml
 - include: networking.yml

--- a/roles/common/tasks/syslog.yml
+++ b/roles/common/tasks/syslog.yml
@@ -1,0 +1,13 @@
+---
+- name: install tls encryption library
+  apt: pkg=rsyslog-gnutls state=installed
+
+- name: install syslog server certs
+  get_url: url={{ syslog_cert_url }} dest=/etc/syslog.ursula.crt mode=0644
+  when: syslog_cert_url is defined
+
+- name: configure syslog to ship across the wire
+  template: src=syslog.conf dest=/etc/rsyslog.d/90-ursula.conf
+  when: syslog_server is defined
+  notify:
+    - restart rsyslog

--- a/roles/common/templates/syslog.conf
+++ b/roles/common/templates/syslog.conf
@@ -1,0 +1,5 @@
+$DefaultNetstreamDriverCAFile /etc/syslog.ursula.crt     # trust these CAs
+$ActionSendStreamDriver gtls                             # use gtls netstream driver
+$ActionSendStreamDriverMode 1                            # require TLS
+
+*.*                                         @@{{ syslog_server }}


### PR DESCRIPTION
If the following vars are defined in an environment,
  syslog_server
  syslog_cert_url

then all servers will have their system rsyslogs configured to ship
syslog entries to the named server using TLS encryption over TCP.

Syslog cert url should name an SSL CA file which is saved to /etc/syslog.ursula.crt,
and is used to authenticate the syslog server's identity when establishing connections.
