### PR TITLE
Corrected floating ip allocation

### DIFF
--- a/test/common
+++ b/test/common
@@ -35,7 +35,7 @@ add_floating_ip() {
 
   nova floating-ip-list | grep $net_name | while read line; do
     ip=$(echo "$line" | awk '{print $2}')
-    instance=$(echo "$line" | awk '{print $4}')
+    instance=$(echo "$line" | awk -F\| '{print $4}' | tr -d ' ')
     if [ "$instance" == "None" ]; then
       echo "reusing floating ip: " $ip
       nova add-floating-ip $1 $ip


### PR DESCRIPTION
Floating IPs were not getting allocated to the test VMs, and causing
the test/setup script to hang on "waiting for vms to come up".  The awk
was returning the wrong field to compare against.

```
++ echo '| 173.247.112.56 |           | None     | external |'
++ awk '{print $4}'
+ instance='|'
+ '[' '|' == None ']'
```
