### PR TITLE
Create a new sec group with open ports for testing

### DIFF
--- a/doc/dev-test.md
+++ b/doc/dev-test.md
@@ -30,8 +30,6 @@ On your workstation, you'll need:
     export SERVICE_TYPE="compute"
 ```
 
-  - your default security group must have all tcp ports opened up for access. this can be done in horizon (easiest), or with neutron client.
-
 ## spin up a new environment
 
 ```bash

--- a/test/common
+++ b/test/common
@@ -7,6 +7,7 @@ key_name=int-test
 key_path=$HOME/.ssh/$key_name.pem
 login_user=ubuntu
 ssh_args="-o LogLevel=quiet -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $key_path -o ControlMaster=auto -o ControlPath=~/.ssh/ursula-%l-%r@%h:%p -o ControlPersist=yes"
+security_group=ursula
 root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 
 die() {

--- a/test/setup
+++ b/test/setup
@@ -14,10 +14,30 @@ if ! nova keypair-list | grep $key_name >/dev/null; then
   chmod 600 $key_path
 fi
 
+echo "setting up security group"
+if ! nova secgroup-list-rules $security_group >/dev/null; then
+  nova secgroup-create $security_group "Rules for testing ursula" >/dev/null
+fi
+
+echo "setting up security group rules"
+default_proto=tcp
+default_ports=(22 80 443 3306 5000 5001 5672 8777 8778 9393 9797 35357 35358)
+default_cidr=0.0.0.0/0
+rules=$(nova secgroup-list-rules $security_group)
+security_group_id=$(nova secgroup-list | grep $security_group | awk -F\| '{print $2}' | tr -d ' ')
+
+for port in "${default_ports[@]}"; do
+  regexp="$default_proto .* \| $port .* \| $port .* \| $default_cidr"
+  if ! echo "$rules" | egrep "$regexp" >/dev/null; then
+    echo "- creating new security group rule for port $port"
+    nova secgroup-add-rule $security_group $default_proto $port $port $default_cidr >/dev/null
+  fi
+done
+
 echo "booting vms"
 net_id=$(nova net-list | grep internal | awk '{print $2}')
 for vm in $vms; do
-  nova boot --image $image --flavor $flavor --key_name $key_name --nic net-id=$net_id $vm >/dev/null
+  nova boot --image $image --flavor $flavor --key_name $key_name --nic net-id=$net_id --security-groups $security_group_id $vm >/dev/null
   sleep 15
   add_floating_ip $vm
 done


### PR DESCRIPTION
Rather than just opening up everything, only allow necessary ports.
Also, stick these rules inside a new sec group named 'ursula', and
boot VMs with this sec group.
