### PR TITLE
Issues with tr interpreting it's input as UTF-8

### DIFF
--- a/test/gen-cert
+++ b/test/gen-cert
@@ -24,7 +24,7 @@ fail_if_error() {
 }
 
 # Generate a passphrase
-export PASSPHRASE=$(head -c 500 /dev/urandom | tr -dc a-z0-9A-Z | head -c 128; echo)
+export PASSPHRASE=$(head -c 500 /dev/urandom | LC_ALL=C tr -dc a-z0-9A-Z | head -c 128; echo)
 
 # Certificate details; replace items in angle brackets with your own info
 subj="


### PR DESCRIPTION
Setting LC_ALL will export the variable into tr's environment.

```
building config
generating ssl cert for 173.247.112.56
/var/folders/7l/cxk0c90d16j0m6spkw74kpx40000gp/T/setup.fS3aKaDW ~/git/ursula
tr: Illegal byte sequence
```
