### PR TITLE
Corrected floating ip allocation

### DIFF
--- a/test/common
+++ b/test/common
@@ -46,7 +46,7 @@ add_floating_ip() {
 }
 
 ensure_free_floating_ip() {
-  if ! nova floating-ip-list | grep $net_name | awk '{print $4}' | grep None >/dev/null; then
+  if ! nova floating-ip-list | grep $net_name | awk -F\| '{print $4}' | grep None >/dev/null; then
     echo "creating new floating ip"
     nova floating-ip-create $net_name
   fi


### PR DESCRIPTION
Ran into another OSX awk issue with `ensure_free_floating_ip`.
Is a similar issue to 2f3baad677656a104d561bb95d730ba314972f80.
Continue to hit my tenant floating IP quota, b/c unused floating
IPs are not reused.
