### PR TITLE
Install python-memcache package

### DIFF
--- a/roles/memcached/tasks/main.yml
+++ b/roles/memcached/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
-- name: install memcached
-  apt: pkg=memcached
+- apt: pkg={{ item }}
+  with_items:
+    - memcached
+    - python-memcache
 
 - template: src=memcached.conf dest=/etc/memcached.conf mode=0644
   notify:


### PR DESCRIPTION
The OpenStack components cannot use memcached without the python package.
