### PR TITLE
Set the default memcached in role

### DIFF
--- a/envs/example/group_vars/all.yml
+++ b/envs/example/group_vars/all.yml
@@ -34,8 +34,6 @@ endpoints:
   glance:   *controller
   neutron:  *controller
 
-memcached_memory: 1024
-
 mysql:
   root_password: asdf
 xtradb:

--- a/roles/memcached/defaults/main.yml
+++ b/roles/memcached/defaults/main.yml
@@ -2,5 +2,5 @@
 memcached_listen: 127.0.0.1
 memcached_port: 11211
 memcached_user: nobody
-memcached_memory: 64
+memcached_memory: 1024
 memcached_max_connections: 1024

--- a/test/tests.d/memcached
+++ b/test/tests.d/memcached
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-source $(dirname $0)/../common
-
-echo "it overrides memcached_memory var default"
-run_on_hosts controller[0] "ps -ef | grep [m]emcached | grep '\-m 1024'"


### PR DESCRIPTION
We don't need to override this.  Lets have the defaults at a good
starting point.
