### PR TITLE
Disabled nova conductor service

### DIFF
--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -96,3 +96,6 @@ libvirt_type={{ nova.libvirt_type }}
 compute_driver={{ nova.compute_driver }}
 libvirt_use_virtio_for_bridges=true
 resume_guests_state_on_host_boot=true
+
+[conductor]
+use_local=false


### PR DESCRIPTION
I am not completely sold on this service.  We should avoid
pumping rabbit with more requests, until rabbit is clustered
and HAed, and even then, would rather keep conductor disabled.
