### PR TITLE
fixing sensu check name for glance api check

### DIFF
--- a/roles/controller/tasks/glance.yml
+++ b/roles/controller/tasks/glance.yml
@@ -17,5 +17,5 @@
 - sensu_process_check: service=glance-registry
   notify: restart sensu-client
 
-- sensu_check: name=check-nova-api plugin=check-os-api.rb use_sudo=true args="--stackrc /root/stackrc --host {{ fqdn }} --port 9292 --path /v1/images --match-str images --use-ssl true"
+- sensu_check: name=check-glance-api plugin=check-os-api.rb use_sudo=true args="--stackrc /root/stackrc --host {{ fqdn }} --port 9292 --path /v1/images --match-str images --use-ssl true"
   notify: restart sensu-client


### PR DESCRIPTION
Both nova and glance sensu_checks had inadvertently been given the same name causing the generated json file for the "check-nova-api" to contain glance's api check configuration, as it would overwrite the previously configured nova-api configuration. 

This commit makes glance's sensu check properly write out its own "check-glance-api.json" file and resolves the issue of incorrectly overwriting the nova-api-check.
