### PR TITLE
Prefer macro syntax

### DIFF
--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -52,6 +52,19 @@ novncproxy_port=6080
 vncserver_proxyclient_address={{ ansible_eth0["ipv4"]["address"] }}
 vncserver_listen=0.0.0.0
 
+{% macro memcached_hosts() -%}
+{% for host in groups['controller'] -%}
+   {% if loop.last -%}
+{{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}:{{ memcached_port }}
+   {%- else -%}
+{{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}:{{ memcached_port }},
+   {%- endif -%}
+{% endfor -%}
+{% endmacro -%}
+
+# Consoleauth tokens in memcached
+memcached_servers={{ memcached_hosts() }}
+
 # Networking #
 network_api_class=nova.network.quantumv2.api.API
 quantum_url=http://{{ endpoints.neutron }}:9696


### PR DESCRIPTION
The macro syntax is cleaner when dealing with semi-complex
looping in templates.  I have not found a better way to
do this with ansible.
