### PR TITLE
[sensu-api-checks] fix 'critical' typo

### DIFF
--- a/roles/sensu-client/files/check-os-api.rb
+++ b/roles/sensu-client/files/check-os-api.rb
@@ -58,7 +58,7 @@ class CheckOSApi < Sensu::Plugin::Check::CLI
     res = http.request(req)
 
     if res.body.empty? || JSON.parse(res.body)[config[:match_str]].nil?
-      crit "no results from API at: #{config[:host]}, #{config[:port]} #{config[:path]}"
+      critical "no results from API at: #{config[:host]}, #{config[:port]} #{config[:path]}"
     else
       ok
     end


### PR DESCRIPTION
fix typo of sensu's plugin "critical" method call
