### PR TITLE
Removed auth creds from paste files

### DIFF
--- a/roles/glance-common/templates/etc/glance/glance-api-paste.ini
+++ b/roles/glance-common/templates/etc/glance/glance-api-paste.ini
@@ -54,9 +54,4 @@ paste.filter_factory = glance.api.middleware.context:UnauthenticatedContextMiddl
 
 [filter:authtoken]
 paste.filter_factory = keystone.middleware.auth_token:filter_factory
-auth_host = {{ endpoints.keystone }}
-auth_port = 35357
-auth_protocol = http
-admin_tenant_name = service
-admin_user = glance
-admin_password = {{ secrets.service_password }}
+delay_auth_decision = true

--- a/roles/glance-common/templates/etc/glance/glance-registry-paste.ini
+++ b/roles/glance-common/templates/etc/glance/glance-registry-paste.ini
@@ -17,9 +17,4 @@ paste.filter_factory = glance.api.middleware.context:UnauthenticatedContextMiddl
 
 [filter:authtoken]
 paste.filter_factory = keystone.middleware.auth_token:filter_factory
-auth_host = {{ endpoints.keystone }}
-auth_port = 35357
-auth_protocol = http
-admin_tenant_name = service
-admin_user = glance
-admin_password = {{ secrets.service_password }}
+delay_auth_decision = true


### PR DESCRIPTION
The paste files do not need auth creds.  Only required in the
[keystone_authtoken] section of the api and registry configs.

See:
https://github.com/stackforge/cookbook-openstack-image/blob/master/templates/default/glance-api-paste.ini.erb
https://github.com/stackforge/cookbook-openstack-image/blob/master/templates/default/glance-registry-paste.ini.erb
