### PR TITLE
Corrected OOO with sensu needing rabbit

### DIFF
--- a/roles/cinder-volume/meta/main.yml
+++ b/roles/cinder-volume/meta/main.yml
@@ -1,5 +1,3 @@
 ---
 dependencies:
-  - role: common
-  - role: rabbit
   - role: sensu-client

--- a/roles/compute/meta/main.yml
+++ b/roles/compute/meta/main.yml
@@ -1,5 +1,3 @@
 ---
 dependencies:
-  - role: common
-  - role: rabbit
   - role: sensu-client

--- a/roles/controller/meta/main.yml
+++ b/roles/controller/meta/main.yml
@@ -1,5 +1,3 @@
 ---
 dependencies:
-  - role: common
-  - role: rabbit
   - role: sensu-client

--- a/roles/horizon/meta/main.yml
+++ b/roles/horizon/meta/main.yml
@@ -1,5 +1,3 @@
 ---
 dependencies:
-  - role: common
-  - role: rabbit
   - role: sensu-client

--- a/roles/network/meta/main.yml
+++ b/roles/network/meta/main.yml
@@ -1,5 +1,3 @@
 ---
 dependencies:
-  - role: common
-  - role: rabbit
   - role: sensu-client

--- a/roles/nova-common/meta/main.yml
+++ b/roles/nova-common/meta/main.yml
@@ -1,5 +1,3 @@
 ---
 dependencies:
-  - role: common
-  - role: rabbit
   - role: sensu-client

--- a/roles/openvswitch/meta/main.yml
+++ b/roles/openvswitch/meta/main.yml
@@ -1,5 +1,3 @@
 ---
 dependencies:
-  - role: common
-  - role: rabbit
   - role: sensu-client

--- a/site.yml
+++ b/site.yml
@@ -1,7 +1,13 @@
 ---
+- name: rabbit used by openstack and monitoring
+  hosts: controller
+  roles:
+    - rabbit
+
 - hosts: all
   roles:
     - common
+    - sensu-client
 
 # - name: Install corosync and pacemaker
 #   hosts: controller
@@ -68,10 +74,6 @@
 - hosts: controller[0]
   roles:
     - openstack-setup
-
-- hosts: all
-  roles:
-    - sensu-client
 
 # Only configure pacemaker on the primary node.
 # Settings will replicate to the secondary node.


### PR DESCRIPTION
We have meta configs in some roles to run common, rabbit, and
sensu-client. However, common and sensu-client are already
applied to every node.  Rabbit and common should not be
necessary in the roles/x/meta/main.yml dependencies.
