### PR TITLE
Fixes for shared memcached to work

### DIFF
--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -17,7 +17,7 @@
     - disable default apache site
 
 - file: dest=/opt/stack/horizon/static state=directory owner=www-data
-
+- file: dest=/opt/stack/horizon/static/dashboard state=directory owner=www-data
 
 - template: src=etc/apache2/ports.conf dest=/etc/apache2/ports.conf
   notify:
@@ -45,3 +45,9 @@
 
 - sensu_process_check: service=apache2
   notify: restart sensu-client
+
+- name: add python-memcached to venv
+  lineinfile: dest=/opt/stack/horizon/requirements.txt regexp='' insertafter=EOF line='python-memcached'
+  notify:
+    - horizon venv
+    - restart apache

--- a/roles/horizon/templates/opt/stack/horizon/openstack_dashboard/local/local_settings.py
+++ b/roles/horizon/templates/opt/stack/horizon/openstack_dashboard/local/local_settings.py
@@ -97,10 +97,13 @@ SECRET_KEY = "{{ secrets.horizon_secret_key }}"
 {% endfor -%}
 {% endmacro -%}
 
+SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 CACHES = {
     'default': {
-        'BACKEND' : 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION' : {{ memcached_hosts() }}
+        'BACKEND' : 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION' : [
+            {{ memcached_hosts() }}
+        ]
     }
 }
 

--- a/roles/memcached/defaults/main.yml
+++ b/roles/memcached/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-memcached_listen: 127.0.0.1
 memcached_port: 11211
 memcached_user: nobody
 memcached_memory: 1024

--- a/roles/memcached/templates/memcached.conf
+++ b/roles/memcached/templates/memcached.conf
@@ -32,7 +32,7 @@ logfile /var/log/memcached.log
 # Specify which IP address to listen on. The default is to listen on all IP addresses
 # This parameter is one of the only security measures that memcached has, so make sure
 # it's listening on a firewalled interface.
--l {{ memcached_listen }}
+-l {{ ansible_eth0["ipv4"]["address"] }}
 
 # Limit the number of simultaneous incoming connections. The daemon default is 1024
 -c {{ memcached_max_connections }}

--- a/test/setup
+++ b/test/setup
@@ -21,7 +21,7 @@ fi
 
 echo "setting up security group rules"
 default_proto=tcp
-default_ports=(22 80 443 3306 4444 4567 4568 5000 5001 5672 8777 8778 9393 9797 35357 35358)
+default_ports=(22 80 443 3306 4444 4567 4568 5000 5001 5672 8777 8778 9393 9797 11211 35357 35358)
 default_cidr=0.0.0.0/0
 rules=$(nova secgroup-list-rules $security_group)
 security_group_id=$(nova secgroup-list | grep $security_group | awk -F\| '{print $2}' | tr -d ' ')


### PR DESCRIPTION
- Horizon was not configured properly to use a shared memcached.  It had
  syntax error with config.
- Configured horizon to store sessions into the cache, this is necessary
  for HA horizon.
- Memcached was not configured to listen on it's internal interface, was
  bound to localhost.
- Opened up memcached port for VM testing.
- Proper ownership of /opt/stack/horizon/static/dashboard, which allows
  horizon to create it's css and js dirs.
- The python-memcached module needs added to horizon's venv.
