### PR TITLE
Update horizon to latest trunk revision.

### DIFF
--- a/envs/example/group_vars/all.yml
+++ b/envs/example/group_vars/all.yml
@@ -74,9 +74,6 @@ novnc:
   repo: https://github.com/kanaka/noVNC.git
   rev: 292f6a5d
 
-horizon:
-  rev: fe659b23
-
 cinder:
   rev: e5b6d4d
   volume_file: /opt/stack/cinder-volumes

--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+horizon_rev: a93c611e71

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -1,16 +1,21 @@
 ---
-- name: get horizon source repo
-  git: |
-    repo={{ openstack.git_mirror}}/horizon.git dest=/opt/stack/horizon version={{ horizon.rev }}
-  notify:
-    - horizon venv
-    - restart apache
-
 - apt: pkg={{ item }}
   with_items:
     - python-dev
     - nodejs
     - libapache2-mod-wsgi
+    - libxml2-dev
+    - libxslt1-dev
+
+- name: lesscpy must be in apache's PATH
+  pip: name=lesscpy
+
+- name: get horizon source repo
+  git: |
+    repo={{ openstack.git_mirror}}/horizon.git dest=/opt/stack/horizon version={{ horizon_rev }}
+  notify:
+    - horizon venv
+    - restart apache
 
 - apt: pkg=apache2
   notify:
@@ -51,3 +56,10 @@
   notify:
     - horizon venv
     - restart apache
+
+- name: add required lockfile package to venv
+  lineinfile: dest=/opt/stack/horizon/requirements.txt regexp='' insertafter=EOF line='lockfile'
+  notify:
+    - horizon venv
+    - restart apache
+


### PR DESCRIPTION
This was motivated by the desire to pick up this change:
  https://review.openstack.org/#/c/46804/

This prevents floating ips for other tenants from showing
up in horizon, which has been a problem for us and for customers.

Additionally, add the horizon revision as a role default,
so that it need not be specified in per-env config.
