### PR TITLE
Install lesscpy 0.9j for horizon.

### DIFF
--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -8,7 +8,7 @@
     - libxslt1-dev
 
 - name: lesscpy must be in apache's PATH
-  pip: name=lesscpy
+  pip: name=lesscpy version=0.9j
 
 - name: get horizon source repo
   git: |


### PR DESCRIPTION
This is a dependency of havana horizon.
Older versions of lesscpy (0.6) contain non-ascii
quote characters in the source, which causes python to flip out.
