### PR TITLE
Remove conflicting lineinfiles for horizon requirements.

### DIFF
--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -52,13 +52,7 @@
   notify: restart sensu-client
 
 - name: add python-memcached to venv
-  lineinfile: dest=/opt/stack/horizon/requirements.txt regexp='' insertafter=EOF line='python-memcached'
-  notify:
-    - horizon venv
-    - restart apache
-
-- name: add required lockfile package to venv
-  lineinfile: dest=/opt/stack/horizon/requirements.txt regexp='' insertafter=EOF line='lockfile'
+  lineinfile: dest=/opt/stack/horizon/requirements.txt regexp=python-memcached line=python-memcached
   notify:
     - horizon venv
     - restart apache


### PR DESCRIPTION
Ansible's lineinfile wasn't behaving as expected, and
the lineinfile for lockfile package was overwriting the one
for python-memcached.

Turns out that the lockfile requirement no longer needs to
be added, since it is already included in the upstream
horizon version we are now using (havana).

lockfile was not present in horizon's requirements on HEAD,
which was why it was added initially.
