### PR TITLE
Install only tgt, not iscsitarget, for cinder.

### DIFF
--- a/playbooks/remove-iscsitarget.yml
+++ b/playbooks/remove-iscsitarget.yml
@@ -1,0 +1,6 @@
+---
+# TODO: remove this playbook once it has been applied everywhere
+- hosts: compute
+  tasks:
+    - shell: apt-get remove --purge --yes iscsitarget
+    - shell: apt-get remove --purge --yes iscsitarget-dkms

--- a/roles/cinder-volume/tasks/main.yml
+++ b/roles/cinder-volume/tasks/main.yml
@@ -3,15 +3,12 @@
   with_items:
     - lvm2
     - tgt
-    - iscsitarget
-    - iscsitarget-dkms
 
 - file: dest=/etc/tgt/conf.d state=directory
 - template: src=etc/tgt/targets.conf dest=/etc/tgt/targets.conf mode=0644
 - template: src=etc/tgt/conf.d/cinder_tgt.conf dest=/etc/tgt/conf.d/cinder_tgt.conf mode=0644
 
-- lineinfile: dest=/etc/default/iscsitarget regexp=^ISCSITARGET_ENABLE= line=ISCSITARGET_ENABLE=true
-  notify: restart iscsitarget
+- service: name=tgt state=started
 
 # TODO: allow for device-backed VGs in addition to file-backed VGs
 - name: cinder volume group

--- a/roles/compute/handlers/main.yml
+++ b/roles/compute/handlers/main.yml
@@ -1,3 +1,1 @@
 ---
-- name: restart iscsitarget
-  service: name=iscsitarget state=restarted


### PR DESCRIPTION
Having both installed causes cinder to glitch out periodically.
