### PR TITLE
Increased API workers

### DIFF
--- a/playbooks/tests/tasks/glance.yml
+++ b/playbooks/tests/tasks/glance.yml
@@ -3,3 +3,8 @@
   hosts: controller[0]
   tasks:
     - shell: . /root/stackrc; glance index | grep cirros
+
+- name: glance api has proper workers
+  hosts: controller
+  tasks:
+    - shell: grep 'workers = 5' /etc/glance/glance-api.conf

--- a/playbooks/tests/tasks/nova-common.yml
+++ b/playbooks/tests/tasks/nova-common.yml
@@ -3,3 +3,10 @@
   hosts: controller
   tasks:
     - shell: egrep memcached_servers=[0-9.]+:11211,[0-9.]+ /etc/nova/nova.conf
+
+- hosts: controller
+  tasks:
+  - name: nova api has proper workers
+    shell: grep 'osapi_compute_workers=5' /etc/nova/nova.conf
+  - name: nova metadata api has proper workers
+    shell: grep 'metadata_workers=5' /etc/nova/nova.conf

--- a/roles/glance-common/defaults/main.yml
+++ b/roles/glance-common/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+glance_common_api_workers: 5

--- a/roles/glance-common/templates/etc/glance/glance-api.conf
+++ b/roles/glance-common/templates/etc/glance/glance-api.conf
@@ -11,7 +11,7 @@ sql_connection=mysql://glance:{{ secrets.db_password }}@{{ endpoints.db }}/glanc
 
 sql_idle_timeout = 3600
 
-workers = 1
+workers = {{ glance_common_api_workers }}
 
 use_syslog = True
 syslog_log_facility = LOG_LOCAL0

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+nova_common_api_workers: 5
+nova_common_metadata_api_workers: 5

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -85,6 +85,10 @@ quantum_metadata_proxy_shared_secret={{ secrets.metadata_proxy_shared_secret }}
 dhcpbridge_flagfile = /etc/nova/nova.conf
 dhcpbridge=/usr/local/bin/nova-dhcpbridge
 
+# Workers #
+osapi_compute_workers={{ nova_common_api_workers }}
+metadata_workers={{ nova_common_metadata_api_workers }}
+
 # Cinder #
 volume_api_class=nova.volume.cinder.API
 osapi_volume_listen_port=5900


### PR DESCRIPTION
Increased the workers for nova-api, metadata, and glance.  Keystone,
cinder, and neutron, do not have options for this ATM.
