### PR TITLE
Standardized signing_dir in configs

### DIFF
--- a/roles/cinder-common/tasks/main.yml
+++ b/roles/cinder-common/tasks/main.yml
@@ -13,9 +13,9 @@
 - name: /etc/cinder
   file: dest=/etc/cinder state=directory
 
-- name: /var/lib/cinder
-  file: dest=/var/lib/cinder state=directory owner=cinder group=cinder
+- file: dest=/var/lib/cinder state=directory owner=cinder group=cinder
 - file: dest=/var/lib/cinder/images state=directory owner=cinder group=cinder
+- file: dest=/var/cache/cinder state=directory mode=0700 owner=cinder group=cinder
 
 - name: cinder config
   action: template src={{ item }} dest=/etc/cinder mode=0644

--- a/roles/cinder-common/templates/etc/cinder/api-paste.ini
+++ b/roles/cinder-common/templates/etc/cinder/api-paste.ini
@@ -50,7 +50,6 @@ paste.filter_factory = cinder.api.middleware.auth:CinderKeystoneContext.factory
 
 [filter:authtoken]
 paste.filter_factory = keystoneclient.middleware.auth_token:filter_factory
-signing_dir = /var/lib/cinder
 service_protocol = http
 service_host = {{ endpoints.main }}
 service_port = 5000
@@ -60,3 +59,4 @@ auth_protocol = http
 admin_tenant_name = service
 admin_user = cinder
 admin_password = {{ secrets.service_password }}
+signing_dir = /var/cache/cinder/api

--- a/roles/glance-common/tasks/main.yml
+++ b/roles/glance-common/tasks/main.yml
@@ -13,9 +13,9 @@
 - name: /etc/glance
   file: dest=/etc/glance state=directory
 
-- name: /var/lib/glance
-  file: dest=/var/lib/glance state=directory owner=glance group=glance
+- file: dest=/var/lib/glance state=directory owner=glance group=glance
 - file: dest=/var/lib/glance/images state=directory owner=glance group=glance
+- file: dest=/var/cache/glance state=directory mode=0700 owner=glance group=glance
 
 - name: glance config
   action: template src={{ item }} dest=/etc/glance mode=0644

--- a/roles/glance-common/templates/etc/glance/glance-api.conf
+++ b/roles/glance-common/templates/etc/glance/glance-api.conf
@@ -54,6 +54,7 @@ auth_protocol = http
 admin_tenant_name = service
 admin_user = glance
 admin_password = {{ secrets.service_password }}
+signing_dir = /var/cache/glance/api
 
 [paste_deploy]
 flavor = keystone

--- a/roles/glance-common/templates/etc/glance/glance-registry.conf
+++ b/roles/glance-common/templates/etc/glance/glance-registry.conf
@@ -50,6 +50,7 @@ auth_protocol = http
 admin_tenant_name = service
 admin_user = glance
 admin_password = {{ secrets.service_password }}
+signing_dir = /var/cache/glance/registry
 
 [paste_deploy]
 flavor = keystone

--- a/roles/neutron-common/tasks/main.yml
+++ b/roles/neutron-common/tasks/main.yml
@@ -14,6 +14,7 @@
 - file: dest=/etc/neutron state=directory
 - file: dest=/etc/neutron/plugins/openvswitch state=directory
 - file: dest=/var/lib/neutron state=directory owner=neutron
+- file: dest=/var/cache/neutron state=directory mode=0700 owner=neutron group=neutron
 
 - name: neutron config
   action: template src={{ item }} dest=/etc/neutron mode=0644

--- a/roles/neutron-common/templates/etc/neutron/api-paste.ini
+++ b/roles/neutron-common/templates/etc/neutron/api-paste.ini
@@ -18,6 +18,7 @@ auth_port = 35357
 admin_tenant_name = service
 admin_user = neutron
 admin_password = {{ secrets.service_password }}
+signing_dir = /var/cache/neutron/api
 
 [filter:extensions]
 paste.filter_factory = neutron.api.extensions:plugin_aware_extension_middleware_factory

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -38,7 +38,7 @@ auth_protocol = http
 admin_tenant_name = service
 admin_user = neutron
 admin_password = {{ secrets.service_password }}
-signing_dir = /var/lib/neutron/keystone-signing
+signing_dir = /var/cache/neutron/api
 
 [DATABASE]
 sqlalchemy_pool_size = 60

--- a/roles/nova-common/tasks/main.yml
+++ b/roles/nova-common/tasks/main.yml
@@ -29,6 +29,7 @@
 
 - file: dest=/etc/nova state=directory
 - file: dest=/var/lib/nova state=directory owner=nova
+- file: dest=/var/cache/nova state=directory mode=0700 owner=nova group=nova
 
 - name: nova config
   action: template src={{ item }} dest=/etc/nova mode=0644

--- a/roles/nova-common/templates/etc/nova/api-paste.ini
+++ b/roles/nova-common/templates/etc/nova/api-paste.ini
@@ -104,4 +104,4 @@ admin_password = {{ secrets.service_password }}
 auth_protocol = http
 admin_tenant_name = service
 admin_user = nova
-signing_dir = /tmp/keystone-signing-nova
+signing_dir = /var/cache/nova/api


### PR DESCRIPTION
While debugging API noticed the following error when starting cinder.
    2013-10-21 15:57:43.793 4789 WARNING keystoneclient.middleware.auth_token [-] signing_dir mode is 0755 instead of 0700
I know we are not using PKI, but the configs should be standardized with proper
owner/modes.
