### PR TITLE
Update glance config to use keystoneclient instead of keystone.

### DIFF
--- a/roles/glance-common/templates/etc/glance/glance-api-paste.ini
+++ b/roles/glance-common/templates/etc/glance/glance-api-paste.ini
@@ -53,5 +53,5 @@ paste.filter_factory = glance.api.middleware.context:ContextMiddleware.factory
 paste.filter_factory = glance.api.middleware.context:UnauthenticatedContextMiddleware.factory
 
 [filter:authtoken]
-paste.filter_factory = keystone.middleware.auth_token:filter_factory
+paste.filter_factory = keystoneclient.middleware.auth_token:filter_factory
 delay_auth_decision = true

--- a/roles/glance-common/templates/etc/glance/glance-registry-paste.ini
+++ b/roles/glance-common/templates/etc/glance/glance-registry-paste.ini
@@ -16,5 +16,5 @@ paste.filter_factory = glance.api.middleware.context:ContextMiddleware.factory
 paste.filter_factory = glance.api.middleware.context:UnauthenticatedContextMiddleware.factory
 
 [filter:authtoken]
-paste.filter_factory = keystone.middleware.auth_token:filter_factory
+paste.filter_factory = keystoneclient.middleware.auth_token:filter_factory
 delay_auth_decision = true


### PR DESCRIPTION
On havana, without this change, glance was crashing with this error:

```
arguments already parsed: cannot register CLI option
```
