### PR TITLE
Allow the setting of default dnsmasq settings

### DIFF
--- a/doc/todo.md
+++ b/doc/todo.md
@@ -1,30 +1,8 @@
-
-
 # TODO
 
 ## restart affected services when code or config changes
 
 ## update db (once) when code changes
-
-## mtu issue
-
-to repro:
-
-    curl -v https://github.com    # on instance
-    tcpdump host $GITHUB_IP       # on net node
-
-error:
-
-    IP 173.247.112.18 > github.com: ICMP 173.247.112.18 unreachable - need to frag (mtu 1454), length 556
-
-to workaround:
-
-    sudo ifconfig eth0 mtu 1454   # on instance
-
-## dns
-
-set working nameserver by default in config. (added manually for now)
-
 
 ## split into global/default config and site config
 

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -1,10 +1,6 @@
 ---
 - apt: pkg=dnsmasq
 
-- name: set instance mtu, if different than default
-  lineinfile: dest=/etc/dnsmasq.conf regexp=^dhcp-option=26, line=dhcp-option=26,{{ neutron_dhcp_mtu }}
-  when: neutron_dhcp_mtu is defined
-
 - name: ovs ex bridge
   ovs_bridge: name=br-ex state=present
 

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -1,2 +1,5 @@
 ---
 neutron_common_rev: 02cd640e4a7ef9b
+
+neutron_common_dhcp_dns_servers:
+  - 8.8.8.8

--- a/roles/neutron-common/templates/etc/neutron/dhcp_agent.ini
+++ b/roles/neutron-common/templates/etc/neutron/dhcp_agent.ini
@@ -10,4 +10,4 @@ dhcp_driver = neutron.agent.linux.dhcp.Dnsmasq
 root_helper = sudo /usr/local/bin/neutron-rootwrap /etc/neutron/rootwrap.conf
 use_namespaces = True
 
-dnsmasq_config_file = /etc/dnsmasq.conf
+dnsmasq_config_file = /etc/neutron/dnsmasq.conf

--- a/roles/neutron-common/templates/etc/neutron/dnsmasq.conf
+++ b/roles/neutron-common/templates/etc/neutron/dnsmasq.conf
@@ -1,0 +1,3 @@
+{% for server in neutron_common_dhcp_dns_servers -%}
+server={{ server }}
+{% endfor -%}


### PR DESCRIPTION
We can provide default upstream dns servers to dnsmasq.  This will
allow instances's resolv.conf to point to the local name server,
and resolve local domains, as well as resolve upstream domains.
We are no longer using GRE, removed the MTU twiddling.
