### PR TITLE
Make glance upload and neutron net tasks work with CA-cert.

### DIFF
--- a/roles/openstack-setup/tasks/images.yml
+++ b/roles/openstack-setup/tasks/images.yml
@@ -7,8 +7,10 @@
       container_format=bare
       disk_format=qcow2
       auth_url=http://{{ endpoints.main }}:5000/v2.0/
-      cacert=/opt/stack/ssl/openstack.crt
       login_tenant_name=admin
       login_password={{ secrets.admin_password }}
       timeout=12000
+      {% if client_self_signed_cert is defined -%}
+      cacert=/opt/stack/ssl/openstack.crt
+      {% endif -%}
   with_items: glance.images

--- a/roles/openstack-setup/tasks/networks.yml
+++ b/roles/openstack-setup/tasks/networks.yml
@@ -12,7 +12,9 @@
       auth_url=https://{{ endpoints.main }}:5001/v2.0/
       login_tenant_name=admin
       login_password={{ secrets.admin_password }}
+      {% if client_self_signed_cert is defined -%}
       cacert=/opt/stack/ssl/openstack.crt
+      {% endif -%}
   with_items: neutron.networks
 
 - name: neutron subnets
@@ -28,7 +30,9 @@
       auth_url=https://{{ endpoints.main }}:5001/v2.0/
       login_tenant_name=admin
       login_password={{ secrets.admin_password }}
+      {% if client_self_signed_cert is defined -%}
       cacert=/opt/stack/ssl/openstack.crt
+      {% endif -%}
   with_items: neutron.subnets
 
 - name: neutron routers
@@ -41,7 +45,9 @@
       auth_url=https://{{ endpoints.main }}:5001/v2.0/
       login_tenant_name=admin
       login_password={{ secrets.admin_password }}
+      {% if client_self_signed_cert is defined -%}
       cacert=/opt/stack/ssl/openstack.crt
+      {% endif -%}
   with_items: neutron.routers
 
 - name: neutron router interfaces
@@ -54,5 +60,7 @@
       auth_url=https://{{ endpoints.main }}:5001/v2.0/
       login_tenant_name=admin
       login_password={{ secrets.admin_password }}
+      {% if client_self_signed_cert is defined -%}
       cacert=/opt/stack/ssl/openstack.crt
+      {% endif -%}
   with_items: neutron.router_interfaces


### PR DESCRIPTION
Before, a ca-cert file was unconditionally specified in
these tasks, which broke environments using ca-signed certs.

Now, a ca-cert file is specified only if a self-signed cert is in use.
