### PR TITLE
Remove `remove-iscsitarget` playbook.

### DIFF
--- a/playbooks/remove-iscsitarget.yml
+++ b/playbooks/remove-iscsitarget.yml
@@ -1,6 +1,0 @@
----
-# TODO: remove this playbook once it has been applied everywhere
-- hosts: compute
-  tasks:
-    - shell: apt-get remove --purge --yes iscsitarget
-    - shell: apt-get remove --purge --yes iscsitarget-dkms


### PR DESCRIPTION
This playbook was intended to be temporary, until it had
been applied to all environments, which it now has.
