### PR TITLE
Corrected variable usage

### DIFF
--- a/playbooks/percona/tasks/main.yml
+++ b/playbooks/percona/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: install percona xtradb packages
   register: pkg_installed
-  apt: pkg=$item state=installed
+  apt: pkg={{ item }} state=installed
   with_items:
   - percona-xtradb-cluster-client-{{ xtradb.client_version }}
   - percona-xtradb-cluster-server-{{ xtradb.server_version }}


### PR DESCRIPTION
[DEPRECATION WARNING]: Legacy variable substitution, such as using ${foo} or
$foo instead of {{ foo }} is currently valid but will be phased out and has
been out of favor since version 1.2. This is the last of legacy features on our
deprecation list. You may continue to use this if you have specific needs for
now. This feature will be removed in version 1.5. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg.
