### PR TITLE
Need better internal grep

### DIFF
--- a/test/setup
+++ b/test/setup
@@ -35,7 +35,7 @@ for port in "${default_ports[@]}"; do
 done
 
 echo "booting vms"
-net_id=$(nova net-list | grep internal | awk '{print $2}')
+net_id=$(nova net-list | grep " internal " | awk '{print $2}')
 for vm in $vms; do
   nova boot --image $image --flavor $flavor --key_name $key_name --nic net-id=$net_id --security-groups $security_group_id $vm >/dev/null
   sleep 15


### PR DESCRIPTION
Now that we have two internal networks, need to find the correct
one.

```
| 0b2f1eae-6abf-432c-b740-a72742abda24 | internal    | None |
| f1d1b0a6-de3a-4ae3-9c31-4af074f7659c | internal-cf | None |
```
