### PR TITLE
Configured keystone to use memcached for tokens

### DIFF
--- a/playbooks/tests/tasks/keystone.yml
+++ b/playbooks/tests/tasks/keystone.yml
@@ -1,0 +1,10 @@
+---
+- name: keystone config has memcached servers
+  hosts: controller
+  tasks:
+    - shell: egrep 'backend_argument = url:[0-9.]+,[0-9.]+' /etc/keystone/keystone.conf
+
+- name: patched python-memcache system library
+  hosts: controller
+  tasks:
+    - shell: egrep "servers = ['[0-9.]+:11211','[0-9.]+:11211']" /usr/lib/python2.7/dist-packages/memcache.py

--- a/playbooks/tests/tasks/main.yml
+++ b/playbooks/tests/tasks/main.yml
@@ -4,6 +4,7 @@
 - include: common.yml
 - include: glance.yml
 - include: horizon.yml
+- include: keystone.yml
 - include: neutron.yml
 - include: nova.yml
 - include: nova-common.yml

--- a/playbooks/tests/tasks/nova-common.yml
+++ b/playbooks/tests/tasks/nova-common.yml
@@ -1,5 +1,5 @@
 ---
-- name: nova_common nova config has memcached servers
+- name: nova config has memcached servers
   hosts: controller
   tasks:
     - shell: egrep memcached_servers=[0-9.]+:11211,[0-9.]+ /etc/nova/nova.conf

--- a/roles/keystone-common/tasks/main.yml
+++ b/roles/keystone-common/tasks/main.yml
@@ -28,3 +28,10 @@
 
 - name: keystone pki - TODO generate once and distribute
   command: keystone-manage pki_setup --keystone-user keystone --keystone-group keystone
+
+# TODO(retr0h): This is an extremely naughty hack.  Need some time to debug why
+# this is happening.
+- name: patch memcached.py with servers https://bugs.launchpad.net/keystone/+bug/1245060
+  lineinfile: dest=/usr/lib/python2.7/dist-packages/memcache.py regexp=^\s{8} insertbefore=self.set_servers line="        servers = [{% for host in groups['controller'] %}{% if not loop.last %}'{{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}:{{ memcached_port }}',{% else %}'{{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}:{{ memcached_port }}'{% endif %}{% endfor %}]"
+  notify:
+    - restart keystone services

--- a/roles/keystone-common/templates/etc/keystone/keystone.conf
+++ b/roles/keystone-common/templates/etc/keystone/keystone.conf
@@ -13,10 +13,24 @@ driver = keystone.identity.backends.sql.Identity
 driver = keystone.catalog.backends.sql.Catalog
 
 [token]
-driver = keystone.token.backends.kvs.Token
+driver = keystone.token.backends.memcache.Token
 
 # Amount of time a token should remain valid (in seconds)
 # expiration = 86400
+
+{% macro memcached_hosts() -%}
+{% for host in groups['controller'] -%}
+   {% if loop.last -%}
+{{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}
+   {%- else -%}
+{{ hostvars[host]['ansible_eth0']['ipv4']['address'] }},
+   {%- endif -%}
+{% endfor -%}
+{% endmacro -%}
+
+[cache]
+backend = dogpile.cache.memcached
+backend_argument = url:{{ memcached_hosts() }}
 
 [policy]
 # driver = keystone.policy.backends.sql.Policy

--- a/site.yml
+++ b/site.yml
@@ -35,6 +35,7 @@
 - name: keystone code and config
   hosts: controller:db
   roles:
+    - memcached
     - keystone-common
 
 - name: cinder code and config


### PR DESCRIPTION
Configured the [cache] and [token] sections for use with a memcached backend.
This contains an epic hack to memcache.py, until we can solve the caching
bug in keystone.
