### PR TITLE
Enable UUID token format vs PKI

### DIFF
--- a/playbooks/tests/tasks/keystone.yml
+++ b/playbooks/tests/tasks/keystone.yml
@@ -2,9 +2,4 @@
 - name: keystone config has memcached servers
   hosts: controller
   tasks:
-    - shell: egrep 'backend_argument = url:[0-9.]+,[0-9.]+' /etc/keystone/keystone.conf
-
-- name: patched python-memcache system library
-  hosts: controller
-  tasks:
-    - shell: egrep "servers = ['[0-9.]+:11211','[0-9.]+:11211']" /usr/lib/python2.7/dist-packages/memcache.py
+    - shell: egrep "servers = [0-9.]+:11211,[0-9.]+" /etc/keystone/keystone.conf

--- a/roles/keystone-common/tasks/main.yml
+++ b/roles/keystone-common/tasks/main.yml
@@ -25,13 +25,3 @@
   template: src=etc/keystone/policy.json dest=/etc/keystone/policy.json mode=0644
   notify:
     - restart keystone services
-
-- name: keystone pki - TODO generate once and distribute
-  command: keystone-manage pki_setup --keystone-user keystone --keystone-group keystone
-
-# TODO(retr0h): This is an extremely naughty hack.  Need some time to debug why
-# this is happening.
-- name: patch memcached.py with servers https://bugs.launchpad.net/keystone/+bug/1245060
-  lineinfile: dest=/usr/lib/python2.7/dist-packages/memcache.py regexp=^\s{8} insertbefore=self.set_servers line="        servers = [{% for host in groups['controller'] %}{% if not loop.last %}'{{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}:{{ memcached_port }}',{% else %}'{{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}:{{ memcached_port }}'{% endif %}{% endfor %}]"
-  notify:
-    - restart keystone services

--- a/roles/keystone-common/templates/etc/keystone/keystone.conf
+++ b/roles/keystone-common/templates/etc/keystone/keystone.conf
@@ -21,16 +21,15 @@ driver = keystone.token.backends.memcache.Token
 {% macro memcached_hosts() -%}
 {% for host in groups['controller'] -%}
    {% if loop.last -%}
-{{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}
+{{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}:{{ memcached_port }}
    {%- else -%}
-{{ hostvars[host]['ansible_eth0']['ipv4']['address'] }},
+{{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}:{{ memcached_port }},
    {%- endif -%}
 {% endfor -%}
 {% endmacro -%}
 
-[cache]
-backend = dogpile.cache.memcached
-backend_argument = url:{{ memcached_hosts() }}
+[memcache]
+servers = {{ memcached_hosts() }}
 
 [policy]
 # driver = keystone.policy.backends.sql.Policy
@@ -39,14 +38,14 @@ backend_argument = url:{{ memcached_hosts() }}
 # driver = keystone.contrib.ec2.backends.kvs.Ec2
 
 [ssl]
-#enable = True
+enable = False
 #certfile = /etc/keystone/ssl/certs/keystone.pem
 #keyfile = /etc/keystone/ssl/private/keystonekey.pem
 #ca_certs = /etc/keystone/ssl/certs/ca.pem
 #cert_required = True
 
 [signing]
-#token_format = PKI
+token_format = UUID
 #certfile = /etc/keystone/ssl/certs/signing_cert.pem
 #keyfile = /etc/keystone/ssl/private/signing_key.pem
 #ca_certs = /etc/keystone/ssl/certs/ca.pem


### PR DESCRIPTION
PKI is good when you have a lot of clients, and want to offload
to the client side vs server validation.  We should use PKI down
the road, but requires syncing of /etc/keystone/ssl/.  Lets use
UUID for now, which allows auth to work properly accross our
haproxy keystones.

Also, allows us to remove the huge memcache system library hack.
