### PR TITLE
Need to install dnsmasq-utils

### DIFF
--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
-- apt: pkg=dnsmasq
+- apt: pkg={{ item }}
+  with_items:
+    - dnsmasq
+    - dnsmasq-utils
 
 - name: ovs ex bridge
   ovs_bridge: name=br-ex state=present


### PR DESCRIPTION
2013-10-30 19:00:17.371 3306 TRACE neutron.agent.dhcp_agent Command: ['sudo', '/usr/local/bin/neutron-rootwrap', '/etc/neutron/rootwrap.conf', 'ip', 'netns', 'exec', 'qdhcp-0b2f1eae-6abf-432c-b740-a72742abda24', 'dhcp_release', 'ns-51099f14-4e', '10.10.10.11', 'fa:16:3e:53:4b:1a']
2013-10-30 19:00:17.371 3306 TRACE neutron.agent.dhcp_agent Stderr: '/usr/local/bin/neutron-rootwrap: Executable not found: dhcp_release (filter match = dhcp_release)\n'
