### PR TITLE
Apache and haproxy port 80 OOO issue

### DIFF
--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -53,4 +53,3 @@
   notify:
     - horizon venv
     - restart apache
-

--- a/site.yml
+++ b/site.yml
@@ -53,9 +53,9 @@
   roles:
     - rabbit
     - client
+    - horizon
     - controller
     - memcached
-    - horizon
 
 - hosts: compute
   roles:


### PR DESCRIPTION
When apache installs it binds to port 80, we then move it to 8080.
Haproxy should get installed after apache has been installed, and
pivoted to different port.
