### PR TITLE
Disable haproxy http-server-close

### DIFF
--- a/roles/controller/templates/etc/haproxy/haproxy.cfg
+++ b/roles/controller/templates/etc/haproxy/haproxy.cfg
@@ -11,7 +11,6 @@ defaults
   mode http
   option httplog
   option dontlognull
-  option http-server-close
   option redispatch
   timeout client 30s
   timeout server 30s


### PR DESCRIPTION
This causes haproxy to send 'Connection: close'.
This wreaks havoc on horizon's keystone client,
causes different aspects of the dashboard to
timeout (e.g. project page).

```
http://paste.openstack.org/show/50374/
```
