### PR TITLE
Disable IPv6 privacy extensions

### DIFF
--- a/playbooks/tests/tasks/common.yml
+++ b/playbooks/tests/tasks/common.yml
@@ -5,3 +5,7 @@
     shell: grep Etc/UTC /etc/timezone
   - name: common date command has utc
     shell: date | grep UTC
+- hosts: all
+  tasks:
+  - name: disable IPv6 privacy extensions
+    shell: grep 0 /proc/sys/net/ipv6/conf/all/use_tempaddr

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -10,3 +10,6 @@
 
 - name: update timezone
   command: dpkg-reconfigure --frontend noninteractive tzdata
+
+- name: apply-sysctl
+  shell: "cat /etc/sysctl.d/*.conf /etc/sysctl.conf | sysctl -e -p -"

--- a/roles/common/tasks/networking.yml
+++ b/roles/common/tasks/networking.yml
@@ -4,3 +4,11 @@
 
 - lineinfile: dest=/etc/hosts regexp=^{{ item.ip }} line="{{ item.ip }} {{ item.name }}"
   with_items: etc_hosts
+
+- lineinfile: dest=/etc/sysctl.d/10-ipv6-privacy.conf regexp=^net\.ipv6\.conf\.all\.use_tempaddr line="net.ipv6.conf.all.use_tempaddr = 2"
+  notify:
+    - apply-sysctl
+
+- lineinfile: dest=/etc/sysctl.d/10-ipv6-privacy.conf regexp=^net\.ipv6\.conf\.default\.use_tempaddr line="net.ipv6.conf.default.use_tempaddr = 2"
+  notify:
+    - apply-sysctl


### PR DESCRIPTION
These are unnecessary on servers and increase the required number of network resources.
