### PR TITLE
Require TLS with AES cipher

### DIFF
--- a/roles/controller/templates/etc/haproxy/haproxy.cfg
+++ b/roles/controller/templates/etc/haproxy/haproxy.cfg
@@ -39,7 +39,8 @@ frontend {{ name }}
   bind :80
   redirect scheme https if !{ ssl_fc }
   {% endif -%}
-  bind :{{ enc_port }} ssl crt /etc/haproxy/openstack.pem no-sslv3 ciphers RC4-SHA:AES128-SHA:AES256-SHA
+  # Require TLS with AES
+  bind :{{ enc_port }} ssl crt /etc/haproxy/openstack.pem no-sslv3 ciphers AES128-SHA:AES256-SHA
   default_backend {{ name }}
 
 backend {{ name }}


### PR DESCRIPTION
Disabling the RC4 cipher: the number of clients connecting to our
OpenStack controller node is relatively limited and we can force them to
use a modern cipher. Additionally commenting the cipher configuration so
save referencing the HAProxy configuration manual to ensure we are not
forcing SSLv2.
