### PR TITLE
When bringing up a vm test environment, use m1.medium.

### DIFF
--- a/playbooks/tests/tasks/instances/create.yml
+++ b/playbooks/tests/tasks/instances/create.yml
@@ -17,7 +17,7 @@
         key_name: "{{ test_keypair_name }}"
         security_groups: "{{ test_security_group_id.stdout }}"
         wait_for: 200
-        flavor_id: 2
+        flavor_id: 3
         nics:
           - net-id: "{{ test_net_id }}"
       with_items: test_instance_names


### PR DESCRIPTION
When vm creation was moved from shell into ansible,
flavor changed to small, which results in OOM errors.
