### PR TITLE
Only use memcached role on controller

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -18,8 +18,9 @@
 
 - name: nova code and config
   hosts: controller:db:compute
+  vars_files:
+  - roles/memcached/defaults/main.yml
   roles:
-    - memcached
     - nova-common
 
 - name: neutron code and config
@@ -34,8 +35,9 @@
 
 - name: keystone code and config
   hosts: controller:db
+  vars_files:
+  - roles/memcached/defaults/main.yml
   roles:
-    - memcached
     - keystone-common
 
 - name: cinder code and config


### PR DESCRIPTION
We use variables from the memcached role when other roles are executing.
However, this installs memcached on servers it should not be installed on.
Using vars_files to bring in the dependant vars.  This is not ideal, b/c
it does not allow overriding, but at this point, I am starting to question
the usefulness of roles' defaults.

Ansible vars are really really annoying -- at least for me.
