### PR TITLE
Add an Ursula metadata motd entry

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+roles/common/templates/etc/motd.tail ident

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -32,3 +32,7 @@
 - include: ssl.yml
 - include: networking.yml
 - include: system_tools.yml
+
+# run this last so we only update if run was successful
+- name: drop an motd with ursula metadata
+  action: template src=etc/motd.tail dest=/etc/motd.tail mode=0644

--- a/roles/common/templates/etc/motd.tail
+++ b/roles/common/templates/etc/motd.tail
@@ -1,0 +1,7 @@
+
+Ursula Node Data:
+Release: $Id$
+Deployed: {{ ansible_date_time['iso8601'] }}
+Groups: {{ group_names | join(', ') }}
+
+


### PR DESCRIPTION
This change simply adds a motd entry for all Ursula hosts. This is
Ubuntu-specific (but that's OK, because so is Ursula). Intention is
that this will evolve over time.
