### PR TITLE
The db checks should not be on arbiter

### DIFF
--- a/playbooks/monitoring.yml
+++ b/playbooks/monitoring.yml
@@ -24,7 +24,7 @@
   - include: ../handlers/main.yml
 
 - name: Install database checks
-  hosts: db:db_arbiter
+  hosts: db
   tasks:
   - include: monitoring/tasks/database.yml
   handlers:


### PR DESCRIPTION
The arbiter does not get mysql client installed.  The checks depend
on mysql client.  Only apply the db checks to the db hosts.
