### PR TITLE
Correctly corrected sensu-plugin gem requires

### DIFF
--- a/playbooks/monitoring/tasks/main.yml
+++ b/playbooks/monitoring/tasks/main.yml
@@ -9,7 +9,7 @@
 - apt: update_cache=True
 
 - apt: pkg=sensu
-- gem: name=sensu-plugin state=latest
+- gem: name=sensu-plugin state=latest user_install=no include_dependencies=yes
 
 - name: sensu sudoers
   template: src=sensu-sudoers dest=/etc/sudoers.d/sensu owner=root group=root mode=0440

--- a/roles/common/tasks/system_tools.yml
+++ b/roles/common/tasks/system_tools.yml
@@ -24,4 +24,4 @@
     - vim
 
 - name: requried by custom ansible modules
-  gem: name=antsy state=latest
+  gem: name=antsy state=latest user_install=no include_dependencies=yes


### PR DESCRIPTION
Sensu was unable to find the sensu-plugin gem.  It needed to get installed
into the system path, not the user gem path.  This explains why the manual
gem install on demo-1 corrected the issue.  Also, the manual install installed
gem deps (e.g. json).

```
output /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- sensu-plugin/check/cli (LoadError) from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require' from /etc/sensu/plugins/check-log.rb:18:in `<main>'
```
