### PR TITLE
Attempt to consolidate test and ursula

### DIFF
--- a/bin/install-osx
+++ b/bin/install-osx
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -eu
 
 die() {

--- a/bin/install-ubuntu
+++ b/bin/install-ubuntu
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -ex
 
 if ! grep Ubuntu /etc/lsb-release; then

--- a/bin/shells
+++ b/bin/shells
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+
 require 'yaml'
 
 screenrc = "/tmp/ansible-screen-#{ENV['USER']}"

--- a/bin/ursula
+++ b/bin/ursula
@@ -1,20 +1,17 @@
-#!/bin/bash
-env=$1
-playbook=$2
+#!/usr/bin/env bash
 
-hosts=$1/hosts
-ssh_config=$1/ssh_config
+source $(dirname $0)/../share/common
 
-export ANSIBLE_SSH_ARGS="-o ControlMaster=auto -o ControlPath=~/.ssh/ursula-%l-%r@%h:%p -o ControlPersist=yes "
-if [ -e $ssh_config ]; then
-  export ANSIBLE_SSH_ARGS="$ANSIBLE_SSH_ARGS -F $ssh_config"
+ENV=$1
+PLAYBOOK=$2
+HOSTS=${ENV}/hosts
+SSH_CONFIG=${ENV}/ssh_config
+
+if [ -e ${SSH_CONFIG} ]; then
+  export ANSIBLE_SSH_ARGS="$ANSIBLE_SSH_ARGS -F ${SSH_CONFIG}"
 fi
 
-export ANSIBLE_NOCOWS=1
-
-ansible-playbook \
-  --inventory-file $hosts \
-  --user root \
-  --module-path ./library \
-  --connection ssh \
-  $playbook
+$(ansible_command \
+  ${HOSTS} \
+  "root" \
+  ${PLAYBOOK})

--- a/share/common
+++ b/share/common
@@ -1,0 +1,25 @@
+ansible_command() {
+  local inventory=$1
+  local user=$2
+  local playbook=$3
+  local sudo=${4:-}
+
+  cmd[0]="ansible-playbook"
+  cmd[1]="--inventory-file ${inventory}"
+  cmd[2]="--user ${user}"
+  cmd[3]='--module-path ./library'
+  cmd[4]='--connection ssh'
+  if [[ -n "${sudo}" ]]; then
+    cmd[5]='--sudo'
+  fi
+  cmd[6]=${playbook}
+
+  echo ${cmd[@]}
+}
+
+export ANSIBLE_NOCOWS=1
+export ANSIBLE_FORCE_COLOR=yes
+export ANSIBLE_SSH_ARGS=\
+' -o ControlMaster=auto'\
+' -o ControlPath=~/.ssh/ursula-%l-%r@%h:%p'\
+' -o ControlPersist=yes'

--- a/test/check-deps
+++ b/test/check-deps
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -eu
+#!/usr/bin/env bash
+
 source $(dirname $0)/common
 
 which nova >/dev/null || die "nova client must be present"
@@ -7,4 +7,4 @@ which nova >/dev/null || die "nova client must be present"
 which ansible-playbook >/dev/null || die "ansible-playbook must be present"
 ansible --version | grep "ansible 1.4" >/dev/null || die "ansible 1.4 is required"
 
-[ -e $HOME/.stackrc ] || die "\$HOME/.stackrc must be present"
+[ -e ~/.stackrc ] || die "~/.stackrc must be present"

--- a/test/cleanup
+++ b/test/cleanup
@@ -1,7 +1,6 @@
-#!/bin/bash
-set -eu
+#!/usr/bin/env bash
+
 source $(dirname $0)/common
-source $HOME/.stackrc
 
 ansible-playbook \
   --inventory-file envs/test/hosts \

--- a/test/common
+++ b/test/common
@@ -1,12 +1,22 @@
-#!/bin/bash
+set -eu
+
+[[ -f ~/.stackrc ]] && source ~/.stackrc
+source $(dirname $0)/../share/common
+
 vms="test-controller-0 test-controller-1 test-compute-0"
 image=ubuntu-12.04
 flavor=m1.medium
 net_name=external
 key_name=int-test
-key_path=$HOME/.ssh/$key_name.pem
+key_path=~/.ssh/$key_name.pem
 login_user=ubuntu
-ssh_args="-o LogLevel=quiet -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $key_path -o ControlMaster=auto -o ControlPath=~/.ssh/ursula-%l-%r@%h:%p -o ControlPersist=yes"
+ssh_args=\
+" $ANSIBLE_SSH_ARGS"\
+' -o LogLevel=quiet'\
+' -o StrictHostKeyChecking=no'\
+' -o UserKnownHostsFile=/dev/null'\
+" -i $key_path"
+
 security_group=ursula
 root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 

--- a/test/run
+++ b/test/run
@@ -1,27 +1,19 @@
-#!/bin/bash
-set -eu
+#!/usr/bin/env bash
+
 source $(dirname $0)/common
-source $HOME/.stackrc
 
-cd $root
-export ANSIBLE_SSH_ARGS="$ssh_args"
-echo $ANSIBLE_SSH_ARGS
+cd ${root}
+export ANSIBLE_SSH_ARGS="${ssh_args}"
+echo ${ANSIBLE_SSH_ARGS}
 
-export ANSIBLE_FORCE_COLOR=yes
-export ANSIBLE_NOCOWS=yes
+time $(ansible_command \
+  "envs/test/hosts" \
+  ${login_user} \
+  "site.yml" \
+  "true")
 
-time ansible-playbook \
-  --inventory-file envs/test/hosts \
-  --module-path ./library \
-  --connection ssh \
-  --user $login_user \
-  --sudo \
-  site.yml
-
-time ansible-playbook \
-  --inventory-file envs/test/hosts \
-  --module-path ./library \
-  --connection ssh \
-  --user $login_user \
-  --sudo \
-  $root/playbooks/tests/tasks/main.yml
+time $(ansible_command \
+  "envs/test/hosts" \
+  ${login_user} \
+  ${root}/playbooks/tests/tasks/main.yml \
+  "true")

--- a/test/setup
+++ b/test/setup
@@ -1,7 +1,6 @@
-#!/bin/bash
-set -eu
+#!/usr/bin/env bash
+
 source $(dirname $0)/common
-source $HOME/.stackrc
 
 $root/test/check-deps
 


### PR DESCRIPTION
These steps were made to cleanup some of the duplication across
ursula and testing.  Over time I would like most of this code handled
inside ansible modules.  Also, initial steps in possibly breaking
out env/ into it's own repo.
- test/run and bin/ursula now using the same ansible command function.
- added a shared library that can be used between test and ursula.
- moved similar items into the shared libary.
