### PR TITLE
Decrease token expiration

### DIFF
--- a/roles/keystone-common/templates/etc/keystone/keystone.conf
+++ b/roles/keystone-common/templates/etc/keystone/keystone.conf
@@ -16,7 +16,7 @@ driver = keystone.catalog.backends.sql.Catalog
 driver = keystone.token.backends.memcache.Token
 
 # Amount of time a token should remain valid (in seconds)
-# expiration = 86400
+expiration = 900
 
 {% macro memcached_hosts() -%}
 {% for host in groups['controller'] -%}


### PR DESCRIPTION
This sets the token's memcached ttl.  Memcached will not return
expired keys so it is a temporary work-a-round.  A bug has already
been reported upstream [1].

The ideal configuration is not to use memcached or sql for token
backends at all.  Keystone devs are working on fully ephemeral tokens
in Icehouse.

[1] https://bugs.launchpad.net/keystone/+bug/1251123
