### PR TITLE
Perform a shallow clone of nova.git.

### DIFF
--- a/roles/nova-common/tasks/main.yml
+++ b/roles/nova-common/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: get nova source repo
   git: |
-    repo={{ openstack.git_mirror }}/nova.git dest=/opt/stack/nova version={{ nova_common_rev }} depth=30
+    repo={{ openstack.git_mirror }}/nova.git dest=/opt/stack/nova version={{ nova_common_rev }} depth=1
   notify:
     - pip install nova
     - nova rootwrap


### PR DESCRIPTION
Change nova clone depth from 30 to 1, for faster
test runs and deploys.

This reduces the data pulled down for this repo from >300MB
to 66MB.
