### PR TITLE
Install nbd-client on compute servers.

### DIFF
--- a/roles/cinder-volume/tasks/main.yml
+++ b/roles/cinder-volume/tasks/main.yml
@@ -3,6 +3,7 @@
   with_items:
     - lvm2
     - tgt
+    - nbd-client
 
 - file: dest=/etc/tgt/conf.d state=directory
 - template: src=etc/tgt/targets.conf dest=/etc/tgt/targets.conf mode=0644


### PR DESCRIPTION
This is required to mount cinder volumes, and was somehow
missing before.
