### PR TITLE
Corrected keypair OOO issue

### DIFF
--- a/playbooks/tests/tasks/instances/keypair.yml
+++ b/playbooks/tests/tasks/instances/keypair.yml
@@ -4,7 +4,9 @@
   vars_files:
   - ../../vars/main.yml
   tasks:
-    - name: create the keypair
+    - name: remove the keypair
+      local_action: nova_keypair name={{ test_keypair_name }} state=absent
+    - name: always create a new keypair
       register: test_keypair
       local_action: nova_keypair name={{ test_keypair_name }} state=present
     - name: persist the keypair


### PR DESCRIPTION
We always destroy envs/test/ on test/setup.  Need to destroy
the keypair from the API, so a new keypair can be persisted
to disk.
