### PR TITLE
Make sshd handlers visible by the common role.

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -13,3 +13,5 @@
 
 - name: apply-sysctl
   shell: "cat /etc/sysctl.d/*.conf /etc/sysctl.conf | sysctl -e -p -"
+
+- include: ssh.yml


### PR DESCRIPTION
The new sshd task was calling a handler which was not in
scope - make sure the handler is included.
