### PR TITLE
Correct invalid byte sequence with check-log.rb

### DIFF
--- a/playbooks/monitoring/files/check-log.rb
+++ b/playbooks/monitoring/files/check-log.rb
@@ -67,7 +67,7 @@ class CheckLog < Sensu::Plugin::Check::CLI
          :short => '-s',
          :long => '--silent',
          :boolean => false
-  
+
   def run
     unknown "No log file specified" unless config[:log_file]
     unknown "No pattern specified" unless config[:pattern]
@@ -90,7 +90,7 @@ class CheckLog < Sensu::Plugin::Check::CLI
 
   def open_log
     state_dir = config[:state_auto] || config[:state_dir]
-    @log = File.open(config[:log_file])
+    @log = File.open(config[:log_file], 'r:ISO-8859-1')
     @state_file = File.join(state_dir, File.expand_path(config[:log_file]))
     @bytes_to_skip = begin
       File.open(@state_file) do |file|


### PR DESCRIPTION
The log should be parsed with ISO-8859-1 encoding.

```
root@ds1217:/var/log/upstart# grep --color='auto' -P -n "[\x80-\xFF]"  /var/log/upstart/neutron-server.log
1878:10.100.2.83 - - [21/Nov/2013 22:30:33] "��R����,��EM�4r0��y�?��{��eL�?}x��" 400 -
1881:10.100.2.83 - - [21/Nov/2013 22:30:41] "��R�������D���v�y��w������P#n���x��" 400 -

root@ds1217:/var/log/upstart# /etc/sensu/plugins/check-log.rb -f /var/log/upstart/neutron-server.log -q ERROR
CheckLog CRITICAL: Check failed to run: invalid byte sequence in UTF-8, ["/etc/sensu/plugins/check-log.rb:117:in `match'", "/etc/sensu/plugins/check-log.rb:117:in `match'", "/etc/sensu/plugins/check-log.rb:117:in `block in search_log'", "/etc/sensu/plugins/check-log.rb:115:in `each_line'", "/etc/sensu/plugins/check-log.rb:115:in `search_log'", "/etc/sensu/plugins/check-log.rb:80:in `run'", "/var/lib/gems/1.9.1/gems/sensu-plugin-0.2.2/lib/sensu-plugin/cli.rb:56:in `block in <class:CLI>'"]
```
