### PR TITLE
Simple API checking using existing CLIs

### DIFF
--- a/playbooks/monitoring/files/check-os-api.rb
+++ b/playbooks/monitoring/files/check-os-api.rb
@@ -3,102 +3,41 @@
 # Check OS API
 # ===
 #
-# Purpose: to manage a request to an openstack service api endpoint.
+# Purpose: to check openstack service api endpoint.
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
-require 'net/http'
-require 'net/https'
-require 'json'
 
 class CheckOSApi < Sensu::Plugin::Check::CLI
+  option :service, :long  => '--service SERVICE_TYPE'
 
-  # path to openstack rc file.
-  # expected stackrc format: http://docs.openstack.org/trunk/install-guide/install/yum/content/novarc-file.html
-  option :stackrc, :long  => '--stackrc STACKRC_PATH'
+  ##
+  # Build a command to execute, since this is passed directly
+  # to Kernel#system.
 
-  # service endpoint opts
-  option :host, :long => '--host FQDN or IP'
-  option :port, :long => '--port PORT'
-  option :path, :long => '--path PATH'
-  option :match_str, :long => '--match-str STRING'
-  option :use_ssl, :long => '--use-ssl BOOLEAN'
+  def safe_command
+    cmd = case config[:service]
+    when "nova"
+      "nova list"
+    when "glance"
+      "glance index"
+    when "keystone"
+      "keystone endpoint-list"
+    end
+
+    ". /root/stackrc; #{cmd}"
+  end
 
   def run
-    @http_timeout = 15
+    system("#{safe_command}")
 
-    stackrc = File.new(config[:stackrc], "r")
-    stackrc.each_line do |line|
-      case
-      when line.match("OS_USERNAME")
-        @auth_user = line[/.+OS_USERNAME=(.*)/, 1]
-      when line.match("OS_PASSWORD")
-        @auth_password = line[/.+OS_PASSWORD=(.*)/, 1]
-      when line.match("OS_AUTH_URL")
-        @auth_host = line[/.+OS_AUTH_URL=http.:\/\/(.*)\:.*/, 1]
-        @auth_path = "/" + line[/.+OS_AUTH_URL=http.:\/\/.*\:\d+\/(.*)/, 1] + "/tokens"
-        @auth_port = line[/.+OS_AUTH_URL=http.:\/\/.*\:(\d+)\//, 1]
-      when line.match("OS_TENANT_NAME")
-        @tenant_name = line[/.+OS_TENANT_NAME=(.*)/, 1]
-      end
-    end
-    stackrc.close
-
-    get_auth_token
-    check_api_path
-  end
-
-  def check_api_path
-    http = Net::HTTP.new(config[:host], config[:port])
-    req = Net::HTTP::Get.new(config[:path])
-    req["X-Auth-Token"] = @auth_token
-    res = http.request(req)
-
-    if res.body.empty? || JSON.parse(res.body)[config[:match_str]].nil?
-      critical "no results from API at: #{config[:host]}, #{config[:port]} #{config[:path]}"
-    else
+    if $?.exitstatus == 0
       ok
+    else
+      critical
     end
-  end
-
-  # obtain auth-token from Keystone API
-  def get_auth_token
-    payload = {
-      "auth" => {
-        "passwordCredentials" => {
-          "username" => @auth_user,
-          "password" => @auth_password
-        },
-        "tenantName" => @tenant_name
-       }
-    }.to_json
-
-    # Throw Timeout::Error exception if HTTP req/res
-    # runs longer than @http_timeout.
-    begin
-      timeout(@http_timeout) do
-        http = Net::HTTP.new(@auth_host, @auth_port)
-        if config[:use_ssl] && config[:use_ssl].match(/true/i)
-          http.use_ssl = true
-        end
-        req = Net::HTTP::Post.new(@auth_path)
-        req.body = payload
-        req["Content-type"] = "application/json"
-        res = http.request(req)
-        @auth_token = JSON.parse(res.body)["access"]["token"]["id"]
-        if @auth_token.empty?
-          abort "could not retrieve token from keystone"
-        end
-      end
-    rescue Timeout::Error
-      puts "Connection timed out"
-    rescue => e
-      puts "Connection error: #{e.message}"
-    end
-
-    return @auth_token
   end
 end

--- a/playbooks/monitoring/tasks/controller.yml
+++ b/playbooks/monitoring/tasks/controller.yml
@@ -12,7 +12,7 @@
   notify: restart sensu-client
 - sensu_process_check: service=glance-registry
   notify: restart sensu-client
-- sensu_check: name=check-glance-api plugin=check-os-api.rb use_sudo=true args="--stackrc /root/stackrc --host {{ fqdn }} --port 9292 --path /v1/images --match-str images --use-ssl true"
+- sensu_check: name=check-glance-api plugin=check-os-api.rb use_sudo=true args="--service glance"
   notify: restart sensu-client
 
 # horizon
@@ -24,7 +24,8 @@
 
 - sensu_process_check: service=keystone-all
   notify: restart sensu-client
-- sensu_check: name=check-keystone-api plugin=check-http.rb args='-u https://localhost:5001/v2.0 -k true --password {{ secrets.admin_password }} --username admin'
+- sensu_check: name=check-keystone-api plugin=check-os-api.rb use_sudo=true args="--service keystone"
+  notify: restart sensu-client
   notify: restart sensu-client
 
 # neutron
@@ -48,5 +49,5 @@
     - nova-scheduler
   notify: restart sensu-client
 
-- sensu_check: name=check-nova-api plugin=check-os-api.rb use_sudo=true args="--stackrc /root/stackrc --host {{ fqdn }} --port 8774 --path /v2/{{ admin_tenant_id.stdout }}/servers --match-str servers --use-ssl true"
+- sensu_check: name=check-nova-api plugin=check-os-api.rb use_sudo=true args="--service nova"
   notify: restart sensu-client


### PR DESCRIPTION
We should use the CLIs to perform API checking, much simpler, and
easier to debug when problems occur.
