### PR TITLE
add galera pkg version to avoid version conflicts

### DIFF
--- a/envs/example/group_vars/all.yml
+++ b/envs/example/group_vars/all.yml
@@ -41,6 +41,7 @@ endpoints:
 mysql:
   root_password: asdf
 xtradb:
+  galera_version: 2.x
   client_version: 5.5
   server_version: 5.5
   sst_auth_user: sst_admin

--- a/playbooks/percona/tasks/main.yml
+++ b/playbooks/percona/tasks/main.yml
@@ -8,6 +8,7 @@
   register: pkg_installed
   apt: pkg={{ item }} state=installed
   with_items:
+  - percona-xtradb-cluster-galera-{{ xtradb.galera_version }}
   - percona-xtradb-cluster-client-{{ xtradb.client_version }}
   - percona-xtradb-cluster-server-{{ xtradb.server_version }}
   - percona-xtrabackup


### PR DESCRIPTION
Percona's xtradb 5.5 packages automatically install the latest percona-xtradb-cluster-galera package (currently: percona-xtradb-cluster-galera-3.x). We need to use percona-xtradb-cluster-galera-2.x with percona-xtradb-cluster-server-5.5.

3.x creates the following error when attempting to start percona-xtradb-cluster-server-5.5:

<pre>*** glibc detected *** /usr/sbin/mysqld: double free or corruption (!prev): 0x000000000162aa50 ***</pre>
