### PR TITLE
Mechanism for making setup conditional

### DIFF
--- a/envs/example/group_vars/all.yml
+++ b/envs/example/group_vars/all.yml
@@ -250,3 +250,9 @@ ssl:
     Ol08q4TScRU4qf1//74yJwlo/+W1CtuiTwysibjgs4BQ8fWJUzgbKvXE3lxJ6D+h
     QxSg02mn6ve0/jY/zcdCAY1gVOU6Z2MNtUYHBAEbbw+G/vXSVtY=
     -----END RSA PRIVATE KEY-----
+
+openstack_setup:
+  add_users: True
+  add_images: True
+  add_networks: True
+  add_cinder: True

--- a/roles/openstack-setup/tasks/main.yml
+++ b/roles/openstack-setup/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
 - include: users.yml
+  when: openstack_setup.add_users == True or openstack_setup.add_users is undefined
 - include: images.yml
+  when: openstack_setup.add_images == True or openstack_setup.add_images is undefined
 - include: networks.yml
+  when: openstack_setup.add_networks == True or openstack_setup.add_networks is undefined


### PR DESCRIPTION
There are a number of times when, during testing, it may be preferrable
to not configure your newly provisioned OpenStack services. This change
provides a mechanism to make setup conditional.
