### PR TITLE
Move neutron-l3-agent pid file to /var/run

### DIFF
--- a/roles/network/templates/etc/init/neutron-l3-agent.conf
+++ b/roles/network/templates/etc/init/neutron-l3-agent.conf
@@ -5,7 +5,7 @@ respawn
 
 exec start-stop-daemon --start \
                        --chuid neutron \
-                       --make-pidfile --pidfile /var/run/resource-agents/neutron-l3-agent.pid \
+                       --make-pidfile --pidfile /var/run/neutron-l3-agent.pid \
                        --exec /usr/local/bin/neutron-l3-agent \
                        -- --config-dir /etc/neutron \
                           --config-file /etc/neutron/neutron.conf \


### PR DESCRIPTION
/var/run/resource-agents/ didn't exist and was preventing l3-agent from
starting.
