### PR TITLE
Remove nodejs, no longer required by Horizon

### DIFF
--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -2,7 +2,6 @@
 - apt: pkg={{ item }}
   with_items:
     - python-dev
-    - nodejs
     - libapache2-mod-wsgi
     - libxml2-dev
     - libxslt1-dev


### PR DESCRIPTION
See https://github.com/openstack/horizon/commit/a0739c94
