### PR TITLE
Add new crypttab module

### DIFF
--- a/library/crypttab
+++ b/library/crypttab
@@ -1,0 +1,198 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2013, Blue Box Group, Inc.
+# Copyright (c) 2013, Craig Tracey <craigtracey@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+DOCUMENTATION = '''
+---
+module: crypttab
+short_description: Add, delete and modify entries in /etc/crypttab
+description:
+     - This module controls /etc/crypttab and its mappings.
+options:
+  state:
+    description:
+        - if present, entry will be added/updated to crypttab. if absent, entry
+        will be removed from cypttab. if mapped, entry will be added/updated to
+        crypttab and target will be mapped. if unmapped, entry will be removed
+        from crypttab and unampped.
+    required: True
+    choices: [ "present", "absent", "mapped", "unmaped" ]
+    default: None
+  target:
+    description:
+      - the target name of the dev mapper mapping (ie. /dev/mapper/<name>)
+    required: True
+    default: None
+  source:
+    description:
+      - encrypted device or image to be mapped (ie. /de/hda2)
+    required: False
+    default: None
+  keyfile:
+    description:
+      - keyfile used to map encrypted volume/image.
+    required: False
+    default: 'none'
+  opts:
+    description:
+      - mapping options (see man crypttab)
+    required: False
+    default: 'default'
+
+author: Craig Tracey
+'''
+
+import re
+
+CRYPTTAB_FILE = '/etc/crypttab'
+
+
+def _write_crypttab(entries):
+    crypttab = open(CRYPTTAB_FILE, 'w')
+    for entry in entries:
+        crypttab.write("%s\n" % entry)
+    crypttab.flush()
+    crypttab.close()
+
+
+def update_crypttab(module, state, target, source=None, keyfile='none',
+                    opts='default'):
+    if not state in ('absent', 'present'):
+        module.fail_json(msg="crypttab 'state' must be one of 'absent' \
+                             or 'present'")
+
+    changed = False
+    new_crypttab = []
+    new_entry = {
+        'target': target,
+        'source': source,
+        'keyfile': keyfile,
+        'opts': opts
+    }
+
+    for line in open(CRYPTTAB_FILE, 'r').readlines():
+        line = line.strip()
+        if not line:
+            new_crypptab.append(line)
+            continue
+        if line.startswith('#'):
+            new_crypttab.append(line)
+            continue
+        if len(re.split('\s+', line)) != 4:
+            new_crypttab.append(line)
+            continue
+
+        # otherwise check to see if we want to update this line
+        entry = {}
+        (entry['target'], entry['source'], entry['keyfile'], entry['opts']) = \
+            re.split('\s+', line)
+
+        if state == 'absent' and entry['target'] == target:
+            changed = True
+            continue
+        elif state == 'present':
+            if entry == new_entry:
+                return
+            elif entry['target'] == new_entry['target']:
+                new_crypttab.append("%s\t%s\t%s\t%s" % (new_entry['target'],
+                                                        new_entry['source'],
+                                                        new_entry['keyfile'],
+                                                        new_entry['opts']))
+                changed = True
+                continue
+        new_crypttab.append(line)
+
+    if state == 'present' and not changed:
+        new_crypttab.append("%s\t%s\t%s\t%s" % (new_entry['target'],
+                                                new_entry['source'],
+                                                new_entry['keyfile'],
+                                                new_entry['opts']))
+        changed = True
+
+    if changed:
+        _write_crypttab(new_crypttab)
+
+    return changed
+
+
+def target_in_crypttab(module, target):
+    grep = module.get_bin_path('grep')
+    rc, _, _ = module.run_command([grep, target, CRYPTTAB_FILE])
+    return not rc
+
+
+def cryptdisks_command(module, action, target):
+    if not action in ('start', 'stop'):
+        return -1, "Logic problem: cryptdisks_start requires 'start' or 'stop'"
+
+    cmd = None
+    if action == 'start':
+        cmd = module.get_bin_path('cryptdisks_start')
+    else:
+        cmd = module.get_bin_path('cryptdisks_stop')
+
+    rc, out, err = module.run_command([cmd, target])
+    if rc == 0:
+        return 0, None
+    else:
+        return rc, out + err
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            state=dict(required=True,
+                       choices=['present', 'absent', 'mapped',
+                                'unmapped']),
+            target=dict(required=True),
+            source=dict(default=None),
+            keyfile=dict(default='none'),
+            opts=dict(default='defaults'),
+        )
+    )
+
+    changed = False
+    params = module.params
+    if params['state'] in ('present', 'mapped'):
+        changed = update_crypttab(module, 'present', params['target'],
+                                  params['source'], params['keyfile'],
+                                  params['opts'])
+        if params['state'] == 'mapped':
+            if params['keyfile'] == 'none':
+                msg = """Mapping does not have a keyfile. This module only supports non-interactive mapping."""
+                module.fail_json(msg=msg)
+            rc, error = cryptdisks_command(module, 'start', params['target'])
+            if rc:
+                module.fail_json(msg=error)
+
+    elif params['state'] in ('absent', 'unmapped'):
+        if (params['state'] == 'unmapped' and
+            target_in_crypttab(module, params['target'])):
+            rc, error = cryptdisks_command(module, 'stop', params['target'])
+            if rc:
+                module.fail_json(msg=error)
+
+        changed = update_crypttab(module, 'absent', params['target'])
+
+    module.exit_json(changed=changed)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()


### PR DESCRIPTION
This change adds a new crypttab module. The purpose of this module is
to support the modification of /etc/crypttab as well as provide a
mechanism to start and stop the mappings found within.

The available states are:
present - entry is found in /etc/crypttab
absent - entry is not found in /etc/crypttab
mapped - entry is found in /etc/crypttab and is actively mapped (except
  in the case where it would be impossible for us to do so - ie. no
  keyfile parameter)
unmapped - entry is removed from /etc/crypttab and mapping is unmapped
  if currently mapped.
