### PR TITLE
Check dmesg for anomalous service failures

### DIFF
--- a/playbooks/tests/tasks/all.yml
+++ b/playbooks/tests/tasks/all.yml
@@ -7,3 +7,5 @@
     shell: grep 'PasswordAuthentication no' /etc/ssh/sshd_config
   - name: /nonexistant should not exist
     shell: test ! -e /nonexistent
+  - name: Upstart should not report any failed services
+    shell: 'if dmesg | egrep "init: \w+ main process \([0-9]+\) terminated with status [0-9]+"; then false; else true; fi'


### PR DESCRIPTION
This should catch things like our starting keystone before memcached,
and neutron-l3-agent without a pidfile directory issues.
