### PR TITLE
correctly implemented dashboard check

### DIFF
--- a/playbooks/monitoring/tasks/controller.yml
+++ b/playbooks/monitoring/tasks/controller.yml
@@ -19,9 +19,7 @@
 
 - sensu_process_check: service=apache2
   notify: restart sensu-client
-- sensu_check: name=check-dashboard-clear-port-redirects plugin=check-http.rb args='-P 80 -r'
-  notify: restart sensu-client
-- sensu_check: name=check-dashboard-ssl-port plugin=check-http.rb args='-P 443'
+- sensu_check: name=check-dashboard-clear-port-redirects plugin=check-http.rb args='-u http://localhost/ -r'
   notify: restart sensu-client
 
 # keystone


### PR DESCRIPTION
Sensu requires the url and path.  Can determine
the connection string based on the URL.  Did not implement
SSL check, since this is running on haproxy.  Hopefully the
HTTP redirect check can detect a hung apache.
