### PR TITLE
Purge nodejs

### DIFF
--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -6,6 +6,9 @@
     - libxml2-dev
     - libxslt1-dev
 
+- name: purge nodejs and can be removed once purged everywhere
+  apt: pkg=nodejs purge=yes state=absent
+
 - name: lesscpy must be in apache PATH
   pip: name=lesscpy version=0.9j
 


### PR DESCRIPTION
Would like to make sure nodejs is purged.  If we don't need the package
lets remove it.  Want to make sure POC doesn't function due to a package
existing, and new sites fail due to it somehow being required.
