### PR TITLE
Provide mechanism for patching nova

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+nova_common:
+  patches:
+
 nova_common_rev: 6bf7e78a6dc
 
 nova_common_compute_driver: nova.virt.libvirt.LibvirtDriver

--- a/roles/nova-common/handlers/main.yml
+++ b/roles/nova-common/handlers/main.yml
@@ -15,3 +15,7 @@
     - nova-consoleauth
     - nova-novncproxy
     - nova-scheduler
+
+- name: patch nova
+  patch: basedir=/opt/stack/nova patchfile=/opt/stack/patches/nova/{{ item }} strip=1
+  with_items: nova_common_patchfiles.stdout_lines

--- a/roles/nova-common/tasks/main.yml
+++ b/roles/nova-common/tasks/main.yml
@@ -5,10 +5,23 @@
 - apt: pkg=python-mysqldb
 - apt: pkg=python-numpy
 
+- name: create nova patches directory
+  file: path=/opt/stack/patches/nova/ state=directory owner=root group=root mode=0755
+
+- name: download nova patches
+  get_url: url={{ item }} dest=/opt/stack/patches/nova/
+  with_items: nova_common.patches
+  when: nova_common.patches is defined and nova_common.patches is not None
+
+- name: register nova patches
+  command: ls /opt/stack/patches/nova/
+  register: nova_common_patchfiles
+
 - name: get nova source repo
   git: |
     repo={{ openstack.git_mirror }}/nova.git dest=/opt/stack/nova version={{ nova_common_rev }} depth=5
   notify:
+    - patch nova
     - pip install nova
     - nova rootwrap
     - restart nova services


### PR DESCRIPTION
This change provides a mechanism for patching nova on the host. Patch
files are copied onto the host and dropped in /opt/stack/patches/nova.
Once there they are applied in lexical order.

This is intended to be a stopgap measure until we have artifacts that
we can lay down instead.
