### PR TITLE
Unable to setup percona cluster

### DIFF
--- a/playbooks/percona/tasks/main.yml
+++ b/playbooks/percona/tasks/main.yml
@@ -4,6 +4,9 @@
   register: my_cnf_exists
   changed_when: False
 
+- name: python-mysqldb package brings in mysql-common
+  apt: pkg=mysql-common purge=yes state=absent
+
 - name: install percona xtradb packages
   register: pkg_installed
   apt: pkg={{ item }} state=installed

--- a/site.yml
+++ b/site.yml
@@ -1,13 +1,13 @@
 ---
+- hosts: all
+  roles:
+    - common
+
 - name: rabbitmq used by openstack
   hosts: controller
   serial: 1
   roles:
     - rabbitmq
-
-- hosts: all
-  roles:
-    - common
 
 - name: replicated db setup
   include: playbooks/percona.yml


### PR DESCRIPTION
The python-mysqldb package brings in mysql-common, this creates
a /etc/mysql/my.cnf, and as a result causes our problem.  Opted
to purge the package vs installing after percona to avoid excessive
dep order in our site.yml.
