### PR TITLE
rabbitmq-plugins exists in the new rabbit packages

### DIFF
--- a/roles/rabbitmq/tasks/cluster.yml
+++ b/roles/rabbitmq/tasks/cluster.yml
@@ -81,3 +81,14 @@
                    node={{ rabbitmq_nodename }}
                    pattern='.*'
                    tags=ha-mode=all
+
+- name: install management plugin
+  rabbitmq_plugin: names=rabbitmq_management
+  notify: restart rabbitmq
+- meta: flush_handlers
+
+- name: install rabbitmqadmin
+  get_url: dest=/usr/local/bin/ url={{ rabbitmq_admin_cli_url }} sha256sum={{ rabbitmq_admin_cli_sha }}
+
+- name: correct rabbitmqadmin modes
+  file: group=root owner=root mode=0755 path=/usr/local/bin/rabbitmqadmin

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -27,14 +27,3 @@
                  read_priv=.*
                  write_priv=.*
                  state=present
-
-- name: install management plugin
-  rabbitmq_plugin: names=rabbitmq_management
-  notify: restart rabbitmq
-- meta: flush_handlers
-
-- name: install rabbitmqadmin
-  get_url: dest=/usr/local/bin/ url={{ rabbitmq_admin_cli_url }} sha256sum={{ rabbitmq_admin_cli_sha }}
-
-- name: correct rabbitmqadmin modes
-  file: group=root owner=root mode=0755 path=/usr/local/bin/rabbitmqadmin


### PR DESCRIPTION
Clustering installs the new rabbit 3.x which has `rabbitmq-plugins`.
Move tasks which setup and rely on the management plugin into the
clustering tasks.
