### PR TITLE
Move Nova patching out of a handler

### DIFF
--- a/roles/nova-common/handlers/main.yml
+++ b/roles/nova-common/handlers/main.yml
@@ -15,7 +15,3 @@
     - nova-consoleauth
     - nova-novncproxy
     - nova-scheduler
-
-- name: patch nova
-  patch: basedir=/opt/stack/nova patchfile=/opt/stack/patches/nova/{{ item }} strip=1
-  with_items: nova_common_patchfiles.stdout_lines

--- a/roles/nova-common/tasks/main.yml
+++ b/roles/nova-common/tasks/main.yml
@@ -26,6 +26,14 @@
     - restart nova services
 - meta: flush_handlers
 
+- name: patch nova
+  patch: basedir=/opt/stack/nova patchfile=/opt/stack/patches/nova/{{ item }} strip=0
+  with_items: nova_common_patchfiles.stdout_lines
+  notify:
+    - pip install nova
+    - restart nova services
+- meta: flush_handlers
+
 - file: dest=/etc/nova state=directory
 - file: dest=/var/lib/nova state=directory owner=nova
 - file: dest=/var/cache/nova state=directory mode=0700 owner=nova group=nova


### PR DESCRIPTION
nova patching should be taking place in the normal task flow. Doing
otherwise would mean that patches are only applied when the git
repo module reports a change.  We want patches to be applied when
available.
