### PR TITLE
Add missing pip install handler for python-client

### DIFF
--- a/roles/client/handlers/main.yml
+++ b/roles/client/handlers/main.yml
@@ -10,3 +10,6 @@
 
 - name: pip install neutronclient
   action: command pip install -i {{ openstack.pypi_mirror }} /opt/stack/python-neutronclient
+
+- name: pip install cinderclient
+  action: command pip install -i {{ openstack.pypi_mirror }} /opt/stack/python-cinderclient


### PR DESCRIPTION
In the previous commit to add the python-cinderclient, this handler
was accidentally omitted. Add it now.
