### PR TITLE
Set notification_driver to noop

### DIFF
--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -33,7 +33,7 @@ api_paste_config = api-paste.ini
 
 control_exchange = neutron
 
-notification_driver = neutron.openstack.common.notifier.rpc_notifier
+notification_driver = neutron.openstack.common.notifier.no_op_notifier
 
 notification_topics = notifications
 


### PR DESCRIPTION
Rabbit's notification.info queue fills up with neutron notifications
and no consumers.  The notifications can be stopped by setting to no_op.
The best I can tell this does not impact anything else (by looking through
code, and testing in POC).
