### PR TITLE
Remove checksum verification from rabbitmqadmin

### DIFF
--- a/roles/rabbitmq/defaults/main.yml
+++ b/roles/rabbitmq/defaults/main.yml
@@ -7,4 +7,3 @@ rabbitmq:
   port: 5672
   management_port: 15672
   admin_cli_url: 'http://localhost:15672/cli/rabbitmqadmin'
-  admin_cli_sha: 1d58218258edcb5502cb2781cbd186abeb253dca9519e545ba42a544b1121f3e

--- a/roles/rabbitmq/tasks/cluster.yml
+++ b/roles/rabbitmq/tasks/cluster.yml
@@ -88,7 +88,7 @@
 - meta: flush_handlers
 
 - name: install rabbitmqadmin
-  get_url: dest=/usr/local/bin/ url={{ rabbitmq.admin_cli_url }} sha256sum={{ rabbitmq.admin_cli_sha }}
+  get_url: dest=/usr/local/bin/ url={{ rabbitmq.admin_cli_url }}
 
 - name: correct rabbitmqadmin modes
   file: group=root owner=root mode=0755 path=/usr/local/bin/rabbitmqadmin


### PR DESCRIPTION
This checksum recently changed with the upstream package changes, and we
are fetching from localhost so the risk of corruption is small. Remove
sha256 checksum rather than maintaining it in this repo.
