### PR TITLE
Standardized our varable usage in shell scripts

### DIFF
--- a/bin/install-osx
+++ b/bin/install-osx
@@ -10,7 +10,7 @@ install_pip() {
 
 pip_pkgs() {
   for pkg in $*; do
-    pip freeze | grep $pkg || pip install $pkg
+    pip freeze | grep ${pkg} || pip install ${pkg}
   done
 }
 

--- a/bin/ursula
+++ b/bin/ursula
@@ -15,24 +15,23 @@ HOSTS=${ENV}/hosts
 SSH_CONFIG=${ENV}/ssh_config
 
 if [ -e ${SSH_CONFIG} ]; then
-  export ANSIBLE_SSH_ARGS="$ANSIBLE_SSH_ARGS -F ${SSH_CONFIG}"
+  export ANSIBLE_SSH_ARGS="${ANSIBLE_SSH_ARGS} -F ${SSH_CONFIG}"
 fi
 
-if [ -z $ENV ] || [ -z $PLAYBOOK ]; then
+if [ -z ${ENV} ] || [ -z ${PLAYBOOK} ]; then
   usage
 fi
 
-for PBOOK in $PREDEPLOY_PLAYBOOK $PLAYBOOK $POSTDEPLOY_PLAYBOOK; do
-  if [ -f $PBOOK ]; then
+for pbook in ${PREDEPLOY_PLAYBOOK} ${PLAYBOOK} ${POSTDEPLOY_PLAYBOOK}; do
+  if [ -f ${pbook} ]; then
     $(ansible_command \
       ${HOSTS} \
       "root" \
-      ${PBOOK})
+      ${pbook})
 
     if [ "$?" != "0" ]; then
-      echo "Run failed on playbook $PBOOK"
+      echo "Run failed on playbook ${pbook}"
       exit -1
     fi
   fi
-
 done

--- a/share/common
+++ b/share/common
@@ -19,13 +19,13 @@ ansible_command() {
 }
 
 # Safely create a controlmasters directory
-if [ ! -d $HOME/.ssh/controlmasters ]; then
-    if [ -e $HOME/.ssh/controlmasters ]; then
-        echo "$HOME/.ssh/controlmasters exists and is not a directory"
-    else
-        mkdir $HOME/.ssh/controlmasters && \
-        chmod 700 $HOME/.ssh/controlmasters
-    fi
+if [ ! -d ~/.ssh/controlmasters ]; then
+  if [ -e ~/.ssh/controlmasters ]; then
+    echo "~/.ssh/controlmasters exists and is not a directory"
+  else
+    mkdir ~/.ssh/controlmasters && \
+    chmod 700 ~/.ssh/controlmasters
+  fi
 fi
 
 export ANSIBLE_SSH_ARGS=\

--- a/test/cleanup
+++ b/test/cleanup
@@ -5,4 +5,4 @@ source $(dirname $0)/common
 $(ansible_command \
   "envs/test/hosts" \
   "root" \
-  $root/playbooks/testenv/tasks/delete.yml)
+  ${ROOT}/playbooks/testenv/tasks/delete.yml)

--- a/test/common
+++ b/test/common
@@ -3,23 +3,24 @@ set -eu
 [[ -f ~/.stackrc ]] && source ~/.stackrc
 source $(dirname $0)/../share/common
 
-export root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
-vms="test-controller-0 test-controller-1 test-compute-0"
-key_name=int-test
-key_path=$root/envs/test/${key_name}.pem
-login_user=ubuntu
-ssh_args=\
-" $ANSIBLE_SSH_ARGS"\
+export ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
+VMS="test-controller-0 test-controller-1 test-compute-0"
+KEY_NAME=int-test
+KEY_PATH=${ROOT}/envs/test/${KEY_NAME}.pem
+LOGIN_USER=ubuntu
+SSH_ARGS=\
+" ${ANSIBLE_SSH_ARGS}"\
 ' -o LogLevel=quiet'\
 ' -o StrictHostKeyChecking=no'\
 ' -o UserKnownHostsFile=/dev/null'\
-" -i $key_path"
+" -i ${KEY_PATH}"
+export ANSIBLE_SSH_ARGS="${SSH_ARGS}"
 
 die() {
   echo "[ERROR] $*"; exit 1
 }
 
-# given a vm name, return its public ip
+# Given a vm name, return its public ip
 public_ip() {
   nova list | grep "$1" | awk '{print $13}'
 }

--- a/test/gen-cert
+++ b/test/gen-cert
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Bash shell script for generating self-signed certs. Run this in a folder, as it
 # generates a few files. Large portions of this script were taken from the
@@ -11,7 +11,7 @@
 
 # Script accepts a single argument, the fqdn for the cert
 DOMAIN="$1"
-if [ -z "$DOMAIN" ]; then
+if [ -z "${DOMAIN}" ]; then
   echo "Usage: $(basename $0) <domain>"
   exit 11
 fi
@@ -32,13 +32,13 @@ C=US
 ST=WA
 O=Blue Box Group
 localityName=Seattle
-commonName=$DOMAIN
+commonName=${DOMAIN}
 organizationalUnitName=heh. heh. 'unit'.
 emailAddress=hostmaster@bluebox.net
 "
 
 # Generate the server private key
-openssl genrsa -des3 -out $DOMAIN.key -passout env:PASSPHRASE 2048
+openssl genrsa -des3 -out ${DOMAIN}.key -passout env:PASSPHRASE 2048
 fail_if_error $?
 
 # Generate the CSR
@@ -46,19 +46,19 @@ openssl req \
     -new \
     -batch \
     -subj "$(echo -n "$subj" | tr "\n" "/")" \
-    -key $DOMAIN.key \
-    -out $DOMAIN.csr \
+    -key ${DOMAIN}.key \
+    -out ${DOMAIN}.csr \
     -passin env:PASSPHRASE
 fail_if_error $?
-cp $DOMAIN.key $DOMAIN.key.org
+cp ${DOMAIN}.key ${DOMAIN}.key.org
 fail_if_error $?
 
 # Strip the password so we don't have to type it every time we restart Apache
-openssl rsa -in $DOMAIN.key.org -out $DOMAIN.key -passin env:PASSPHRASE
+openssl rsa -in ${DOMAIN}.key.org -out ${DOMAIN}.key -passin env:PASSPHRASE
 fail_if_error $?
 
 # Generate the cert (good for 10 years)
-openssl x509 -req -days 3650 -in $DOMAIN.csr -signkey $DOMAIN.key -out $DOMAIN.crt
+openssl x509 -req -days 3650 -in ${DOMAIN}.csr -signkey ${DOMAIN}.key -out ${DOMAIN}.crt
 fail_if_error $?
 
 exit 0

--- a/test/run
+++ b/test/run
@@ -5,29 +5,27 @@ if [ $# -gt 0 ]; then
     ACTION=$1
 fi
 
-if [ "$ACTION" != "all" -a "$ACTION" != "test" -a "$ACTION" != "deploy" ]; then
+if [ "${ACTION}" != "all" -a "${ACTION}" != "test" -a "${ACTION}" != "deploy" ]; then
   echo "Usage: run [test | deploy]"
   exit 1
 fi
 
 source $(dirname $0)/common
 
-cd ${root}
-export ANSIBLE_SSH_ARGS="${ssh_args}"
-echo ${ANSIBLE_SSH_ARGS}
+cd ${ROOT}
 
-if [ "$ACTION" == "all" -o "$ACTION" == "deploy" ]; then
+if [ "${ACTION}" == "all" -o "${ACTION}" == "deploy" ]; then
   time $(ansible_command \
     "envs/test/hosts" \
-    ${login_user} \
+    ${LOGIN_USER} \
     "site.yml" \
     "true")
 fi
 
-if [ "$ACTION" == "all" -o "$ACTION" == "test" ]; then
+if [ "${ACTION}" == "all" -o "${ACTION}" == "test" ]; then
   time $(ansible_command \
     "envs/test/hosts" \
-    ${login_user} \
-    ${root}/playbooks/tests/tasks/main.yml \
+    ${LOGIN_USER} \
+    ${ROOT}/playbooks/tests/tasks/main.yml \
     "true")
 fi

--- a/test/setup
+++ b/test/setup
@@ -2,54 +2,51 @@
 
 source $(dirname $0)/common
 
-$root/test/check-deps
-
-export ANSIBLE_SSH_ARGS="${ssh_args}"
-echo ${ANSIBLE_SSH_ARGS}
+${ROOT}/test/check-deps
 
 echo "writing initial inventory file"
-mkdir -p $root/envs/test
-cat > $root/envs/test/hosts <<eof
+mkdir -p ${ROOT}/envs/test
+cat > ${ROOT}/envs/test/hosts <<eof
 [local]
 127.0.0.1
 eof
 
-echo "destroying: $vms"
-$root/test/cleanup
+echo "destroying: ${VMS}"
+${ROOT}/test/cleanup
 
-echo "booting vms"
+echo "booting ${VMS}"
 $(ansible_command \
   "envs/test/hosts" \
   "root" \
-  $root/playbooks/testenv/tasks/create.yml)
+  ${ROOT}/playbooks/testenv/tasks/create.yml)
 
 echo "building config"
-controller_ip=$(public_ip test-controller-0)
-rm -rf $root/envs/test/group_vars/
-rm -f $root/envs/test/hosts
-mkdir -p $root/envs/test/
-cp -r $root/envs/example/group_vars $root/envs/test
-cp $root/envs/example/hosts $root/envs/test
-sed -i -e "s/^controller_primary: \&controller.*/controller_primary: \&controller $controller_ip/" envs/test/group_vars/all.yml
+CONTROLLER_IP=$(public_ip test-controller-0)
+rm -rf ${ROOT}/envs/test/group_vars/
+rm -f ${ROOT}/envs/test/hosts
+mkdir -p ${ROOT}/envs/test/
+cp -r ${ROOT}/envs/example/group_vars ${ROOT}/envs/test
+cp ${ROOT}/envs/example/hosts ${ROOT}/envs/test
+sed -i -e "s/^controller_primary: \&controller.*/controller_primary: \&controller ${CONTROLLER_IP}/" envs/test/group_vars/all.yml
 
-echo "generating ssl cert for $controller_ip"
-cert_dir=$(mktemp -d 2> /dev/null || mktemp -d -t 'setup')
-pushd $cert_dir
-$root/test/gen-cert $controller_ip
-cat >> $root/envs/test/group_vars/all.yml <<eof
+echo "generating ssl cert for ${CONTROLLER_IP}"
+CERT_DIR=$(mktemp -d 2> /dev/null || mktemp -d -t 'setup')
+pushd ${CERT_DIR}
+${ROOT}/test/gen-cert ${CONTROLLER_IP}
+cat >> ${ROOT}/envs/test/group_vars/all.yml <<eof
 ssl:
   crt: |
 eof
-cat $cert_dir/$controller_ip.crt | sed 's/^/    /' >> $root/envs/test/group_vars/all.yml
-cat >> $root/envs/test/group_vars/all.yml <<eof
+cat ${CERT_DIR}/${CONTROLLER_IP}.crt | sed 's/^/    /' >> ${ROOT}/envs/test/group_vars/all.yml
+cat >> ${ROOT}/envs/test/group_vars/all.yml <<eof
   key: |
 eof
-cat $cert_dir/$controller_ip.key | sed 's/^/    /' >> $root/envs/test/group_vars/all.yml
+cat ${CERT_DIR}/${CONTROLLER_IP}.key | sed 's/^/    /' >> ${ROOT}/envs/test/group_vars/all.yml
 popd
-rm -rf $cert_dir
+rm -rf ${CERT_DIR}
 
 echo "writing inventory file"
-cat > $root/envs/test/hosts <<eof
+cat > ${ROOT}/envs/test/hosts <<eof
 [db]
 $(public_ip "test-controller-0")
 $(public_ip "test-controller-1")
@@ -71,8 +68,8 @@ eof
 echo "copying files"
 $(ansible_command \
   "envs/test/hosts" \
-  ${login_user} \
-  $root/playbooks/testenv/tasks/pre-deploy.yml \
+  ${LOGIN_USER} \
+  ${ROOT}/playbooks/testenv/tasks/pre-deploy.yml \
   "true")
 
-echo "vms are up: $vms !!"
+echo "vms are up: ${VMS} !!"


### PR DESCRIPTION
Hate opening a file with mixed upper and lowercase variables.
Also, wasn't fond of the 2 space vs 4 space with noexpandtab.
I wanted to move us to a standard, we can clean it with whichever
standard we like.  *e.g. 2 vs 4 spaces, ${} vs $ etc...
