### PR TITLE
Added syncing of glance image directories

### DIFF
--- a/envs/example/group_vars/all.yml
+++ b/envs/example/group_vars/all.yml
@@ -12,6 +12,7 @@ secrets:
   provider_admin_password:   &provider_admin_password ghij
   metadata_proxy_shared_secret: asdf
   horizon_secret_key:           asdf
+  glance_sync:      ADQ64XUQLUWH75M634RVBLP55RKPGGOWG
 
 fqdn: &fqdn openstack.example.com
 floating_ip: &floating_ip 173.247.112.252

--- a/playbooks/testenv/vars/main.yml
+++ b/playbooks/testenv/vars/main.yml
@@ -33,6 +33,7 @@ testenv_security_group_rules:
   - { proto: 'tcp', port: 9696, state: 'present' }   # neutron
   - { proto: 'tcp', port: 9797, state: 'present' }   # neutron LB SSL
   - { proto: 'tcp', port: 11211, state: 'present' }  # memcached
+  - { proto: 'tcp', port: 25307, state: 'present' }  # btsync (glance images)
   - { proto: 'tcp', port: 35357, state: 'present' }  # keystone admin
   - { proto: 'tcp', port: 35358, state: 'present' }  # keystone admin LB SSL
   - { proto: 'tcp', port: 65535, state: 'present' }  # erlang portmapper (epmd)

--- a/playbooks/tests/tasks/controller.yml
+++ b/playbooks/tests/tasks/controller.yml
@@ -11,6 +11,8 @@
     shell: date | grep UTC
   - name: glance api has proper workers
     shell: grep 'workers = 1' /etc/glance/glance-api.conf
+  - name: glance replicated images
+    shell: test -f /var/lib/glance/images/[a-b0-9]*
   - name: keystone config has memcached servers
     shell: egrep "servers = [0-9.]+:11211,[0-9.]+" /etc/keystone/keystone.conf
   - name: neutron dnsmasq has 8.8.8.8 upstream resolver

--- a/roles/glance-common/defaults/main.yml
+++ b/roles/glance-common/defaults/main.yml
@@ -2,3 +2,12 @@
 glance:
   rev: 252fe8572400c25c35
   api_workers: 5
+  sync:
+    enabled: true
+    listening_port: 25307
+    download_limit: 0
+    upload_limit: 0
+    folder_rescan_interval: 600
+    storage_path: /var/lib/btsync
+    device_name: image-cache
+    dir: /var/lib/glance/images

--- a/roles/glance-common/handlers/main.yml
+++ b/roles/glance-common/handlers/main.yml
@@ -7,3 +7,6 @@
   with_items:
     - glance-api
     - glance-registry
+
+- name: restart btsync
+  action: service name=btsync state=restarted enabled=yes

--- a/roles/glance-common/tasks/image-sync.yml
+++ b/roles/glance-common/tasks/image-sync.yml
@@ -1,0 +1,20 @@
+- name: add btsync ppa repository
+  apt_repository: repo='ppa:tuxpoldo/btsync' update_cache=yes
+
+- name: install btsync
+  apt: pkg=btsync
+
+- name: remove default config
+  file: dest=/etc/btsync/debconf-default.conf state=absent
+  notify:
+    - restart btsync
+
+- name: btsync config
+  template: >
+    src=etc/btsync/glance-cache.conf
+    dest=/etc/btsync/
+    owner=root
+    group=root
+    mode=0600
+  notify:
+    - restart btsync

--- a/roles/glance-common/tasks/main.yml
+++ b/roles/glance-common/tasks/main.yml
@@ -22,3 +22,7 @@
   with_fileglob: ../templates/etc/glance/*
   notify:
     - restart glance services
+
+- name: setup glance image replication
+  include: image-sync.yml
+  when: glance.sync.enabled

--- a/roles/glance-common/templates/etc/btsync/glance-cache.conf
+++ b/roles/glance-common/templates/etc/btsync/glance-cache.conf
@@ -1,0 +1,25 @@
+{
+  "device_name": "{{ glance.sync.device_name }}",
+  "storage_path": "{{ glance.sync.storage_path }}",
+  "listening_port": {{ glance.sync.listening_port }},
+  "check_for_updates": false,
+  "use_upnp": false,
+  "download_limit": {{ glance.sync.download_limit }},
+  "upload_limit": {{ glance.sync.upload_limit }},
+  "disk_low_priority": true,
+  "lan_encrypt_data": false,
+  "lan_use_tcp": true,
+  "rate_limit_local_peers": false,
+  "folder_rescan_interval": {{ glance.sync.folder_rescan_interval }},
+  "webui" : {},
+  "shared_folders": [
+    {
+      "secret": "{{ secrets.glance_sync }}",
+      "dir": "{{ glance.sync.dir }}",
+      "use_relay_server": false,
+      "use_dht": false,
+      "search_lan": true,
+      "use_sync_trash": false
+    }
+  ]
+}


### PR DESCRIPTION
This allows for a true HA glance, without all the complexities
of the existing sync tools.  BT is locked down with a secret,
and we are further locking down our controllers with iptables.
This should be a fairly safe rollout.
