### PR TITLE
Lock down public-facing interfaces with iptables.

### DIFF
--- a/playbooks/tests/tasks/controller.yml
+++ b/playbooks/tests/tasks/controller.yml
@@ -37,6 +37,10 @@
     shell: rabbitmq-plugins list | grep '\[E\] rabbitmq_management'
   - name: rabbitmq has the rabbitmqadmin script installed
     shell: test -f /usr/local/bin/rabbitmqadmin
+  - name: iptables defaults to dropping connections from the internet
+    shell: iptables-save | grep "-A INPUT -i br-ex -j DROP"
+  - name: iptables lets ssh in from outside
+    shell: iptables-save | grep "-A INPUT -i br-ex -m tcp -p tcp --dport=22 -j ACCEPT"
 
 - hosts: controller[0]
   tasks:

--- a/roles/client/templates/root/stackrc
+++ b/roles/client/templates/root/stackrc
@@ -1,6 +1,6 @@
 export NOVA_VERSION=1.1
 export OS_PASSWORD={{ secrets.provider_admin_password }}
-export OS_AUTH_URL=https://{{ endpoints.keystone }}:5001/v2.0
+export OS_AUTH_URL=https://{{ endpoints.main }}:5001/v2.0
 export OS_USERNAME=provider_admin
 export OS_TENANT_NAME=admin
 export COMPUTE_API_VERSION=1.1

--- a/roles/controller/handlers/main.yml
+++ b/roles/controller/handlers/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: restart haproxy
   service: name=haproxy state=restarted
+
+- name: reload iptables
+  shell: iptables-restore < /etc/network/iptables-firewall

--- a/roles/controller/tasks/iptables.yml
+++ b/roles/controller/tasks/iptables.yml
@@ -1,0 +1,10 @@
+---
+
+# firewall for public-facing controller nodes
+
+- name: iptables rules
+  template: src=etc/network/iptables-firewall dest=/etc/network/iptables-firewall owner=root group=root mode=0644
+  notify: reload iptables
+
+- name: iptables load on boot
+  template: src=etc/network/if-up.d/iptables dest=/etc/network/if-up.d/iptables owner=root group=root mode=0755

--- a/roles/controller/tasks/main.yml
+++ b/roles/controller/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+- include: iptables.yml
 - include: haproxy.yml
 - include: keystone.yml
 - include: nova.yml

--- a/roles/controller/templates/etc/network/if-up.d/iptables
+++ b/roles/controller/templates/etc/network/if-up.d/iptables
@@ -1,0 +1,2 @@
+#!/bin/bash
+iptables-restore < /etc/network/iptables-firewall

--- a/roles/controller/templates/etc/network/iptables-firewall
+++ b/roles/controller/templates/etc/network/iptables-firewall
@@ -1,0 +1,28 @@
+*filter
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+
+-A INPUT -i br-ex -m tcp -p tcp --dport=22 -j ACCEPT
+-A INPUT -i br-ex -p udp --dport 32768:61000 -j ACCEPT
+-A INPUT -i br-ex -p tcp --dport 32768:61000 -j ACCEPT
+-A INPUT -i br-ex -p icmp -j ACCEPT
+
+{% for tcp_port in [
+    80,
+    443,
+    5001,
+    6080,
+    8777,
+    8778,
+    9393,
+    9797
+  ]
+%}
+-A INPUT -i br-ex -m tcp -p tcp --dport={{ tcp_port }} -j ACCEPT
+{% endfor %}
+
+-A INPUT -i br-ex -j DROP
+
+
+COMMIT


### PR DESCRIPTION
Add a default DROP policy to br-ex interface, and open ports
only for web/api services.
