### PR TITLE
Nova talks to neutron with https.

### DIFF
--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -67,7 +67,7 @@ memcached_servers={{ memcached_hosts() }}
 
 # Networking #
 network_api_class=nova.network.quantumv2.api.API
-quantum_url=http://{{ endpoints.neutron }}:9696
+quantum_url=https://{{ endpoints.neutron }}:9797
 quantum_auth_strategy=keystone
 quantum_admin_tenant_name=service
 quantum_admin_username=neutron


### PR DESCRIPTION
Nova was failing to talk to neutron after locking down the plaintext
neutron port.
