### PR TITLE
Explicit list of btsync peers

### DIFF
--- a/roles/glance-common/templates/etc/btsync/glance-cache.conf
+++ b/roles/glance-common/templates/etc/btsync/glance-cache.conf
@@ -18,8 +18,18 @@
       "dir": "{{ glance.sync.dir }}",
       "use_relay_server": false,
       "use_dht": false,
-      "search_lan": true,
-      "use_sync_trash": false
+      "search_lan": false,
+      "use_sync_trash": false,
+      "known_hosts" :
+      [
+        {% for host in groups['controller'] -%}
+            {% if loop.last -%}
+        "{{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}:{{ glance.sync.listening_port }}"
+            {%- else -%}
+        "{{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}:{{ glance.sync.listening_port }}",
+            {%- endif -%}
+        {% endfor -%}
+      ]
     }
   ]
 }


### PR DESCRIPTION
Avoids multicast peer discovery which was being blocked by iptables.
