### PR TITLE
Enlarge root disk for m1.tiny flavor.

### DIFF
--- a/playbooks/tests/tasks/controller.yml
+++ b/playbooks/tests/tasks/controller.yml
@@ -52,3 +52,5 @@
     shell: . /root/stackrc; glance index | grep cirros
   - name: nova has a working api
     shell: . /root/stackrc; nova list | grep ID
+  - name: m1.tiny flavor has been embiggened
+    shell: mysql -e "select root_gb from nova.instance_types where name='m1.tiny';" | grep 10

--- a/roles/openstack-setup/tasks/flavors.yml
+++ b/roles/openstack-setup/tasks/flavors.yml
@@ -1,0 +1,10 @@
+---
+- name: is m1.tiny undersized?
+  shell: mysql -e "select root_gb from nova.instance_types where name='m1.tiny';" | grep 10
+  ignore_errors: True
+  changed_when: False
+  register: resize_tiny_flavor
+
+- name: bump root disk size on m1.tiny
+  shell: mysql -e "update nova.instance_types set root_gb=10 where name='m1.tiny';"
+  when: resize_tiny_flavor.rc != 0

--- a/roles/openstack-setup/tasks/main.yml
+++ b/roles/openstack-setup/tasks/main.yml
@@ -5,3 +5,4 @@
   when: openstack_setup.add_images == True or openstack_setup.add_images is undefined
 - include: networks.yml
   when: openstack_setup.add_networks == True or openstack_setup.add_networks is undefined
+- include: flavors.yml


### PR DESCRIPTION
The default root disk of m1.tiny is 1GB, which is too
small for common images, which causes opaque-to-the-user
boot errors.

Make the root disk of m1.tiny 10GB instead, which is large
enough for most common images.
