### PR TITLE
Upgrade neutron to allow multiple api processes.

### DIFF
--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 neutron:
-  rev: 02cd640e4a7ef9b
+  rev: b5c4152ac9958e
+  api_workers: 3
   dhcp_dns_servers:
     - 8.8.8.8
     - 8.8.4.4

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -1,6 +1,8 @@
 [DEFAULT]
 debug = False
 
+api_workers = {{ neutron.api_workers }}
+
 auth_strategy = keystone
 allow_overlapping_ips = False
 verbose = True


### PR DESCRIPTION
Upgrade neutron to pick up a recent backport to havana,
which allows running multiple neutron-server worker
processes.

This is desirable, because clients have been observed
to timeout talking to neutron-server when several requests
are sent in close succession.
