### PR TITLE
Tweak ansible default vars plugin to work with our usage.

### DIFF
--- a/bin/ursula
+++ b/bin/ursula
@@ -14,6 +14,10 @@ POSTDEPLOY_PLAYBOOK=${ENV}/playbooks/postdeploy.yml
 HOSTS=${ENV}/hosts
 SSH_CONFIG=${ENV}/ssh_config
 
+if [ -e "${ENV}/../defaults.yml" ]; then
+  export ANSIBLE_VAR_DEFAULTS_FILE="${ENV}/../defaults.yml"
+fi
+
 if [ -e ${SSH_CONFIG} ]; then
   export ANSIBLE_SSH_ARGS="${ANSIBLE_SSH_ARGS} -F ${SSH_CONFIG}"
 fi


### PR DESCRIPTION
In ansible, the `hash_behaviour = merge` setting does
not apply to vars which come from plugins.

This change adds a monkey-patch to cause this setting to be
honored.

The monkey patch should be removed if this change can
me merged into upstream ansible.
