### PR TITLE
Lock down haproxy stats interface

### DIFF
--- a/roles/controller/templates/etc/haproxy/haproxy.cfg
+++ b/roles/controller/templates/etc/haproxy/haproxy.cfg
@@ -20,7 +20,8 @@ defaults
 
   stats enable
   stats refresh 10s
-  stats uri /stats
+  stats uri /haproxy_stats
+  stats auth admin:{{ secrets.admin_password }}
 
 {% for name, clear_port, enc_port in
   [
@@ -47,7 +48,7 @@ backend {{ name }}
   option httpchk /
   balance source
   {% for host in groups['controller'] -%}
-  server {{ loop.index }} {{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}:{{ clear_port }} check maxconn 40
+  server {{ host }} {{ hostvars[host]['ansible_eth0']['ipv4']['address'] }}:{{ clear_port }} check maxconn 40
   {% endfor -%}
 
 {% endfor %}


### PR DESCRIPTION
Small HAProxy changes:
1. Enable basic auth for stats interface
2. Move stats URL to /haproxy_stats so to reduce risk of collision with horizon
3. Include hostnames in stats output
