### PR TITLE
Cause test environment to use private IP of instances.

### DIFF
--- a/test/common
+++ b/test/common
@@ -24,3 +24,7 @@ die() {
 public_ip() {
   nova list | grep "$1" | awk '{print $13}'
 }
+
+private_ip() {
+  nova list | grep "$1" | awk '{print $12}' | awk -F= '{print $2}' | awk -F, '{print $1}'
+}

--- a/test/setup
+++ b/test/setup
@@ -21,7 +21,7 @@ $(ansible_command \
   ${ROOT}/playbooks/testenv/tasks/create.yml)
 
 echo "building config"
-CONTROLLER_IP=$(public_ip test-controller-0)
+CONTROLLER_IP=$(private_ip test-controller-0)
 rm -rf ${ROOT}/envs/test/group_vars/
 rm -f ${ROOT}/envs/test/hosts
 mkdir -p ${ROOT}/envs/test/


### PR DESCRIPTION
Tests were failing because the database is not accessible
on the public IP (it is blocked by iptables).
