### PR TITLE
Perform iptables checksum filling on dhcp packets.

### DIFF
--- a/roles/controller/templates/etc/network/iptables-firewall
+++ b/roles/controller/templates/etc/network/iptables-firewall
@@ -25,5 +25,6 @@
 
 -A INPUT -i {{ ansible_default_ipv4['interface'] }} -j DROP
 
+-A POSTROUTING -t mangle -p udp --dport bootpc -j CHECKSUM --checksum-fill
 
 COMMIT


### PR DESCRIPTION
When running nova-compute on the same server as neutron-dhcp-agent,
DHCPACK packets were being dropped due to a bad UDP checksums, causing
networking to fail for VMs resident on that server.

This change configures iptables to perform UDP checksum filling on
DHCP packets, which causes the above symptom to disappear.
