### PR TITLE
Fix iptables-firewall syntax for filter table

### DIFF
--- a/roles/controller/templates/etc/network/iptables-firewall
+++ b/roles/controller/templates/etc/network/iptables-firewall
@@ -25,6 +25,22 @@
 
 -A INPUT -i {{ ansible_default_ipv4['interface'] }} -j DROP
 
--A POSTROUTING -t mangle -p udp --dport bootpc -j CHECKSUM --checksum-fill
+COMMIT
+*mangle
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+
+-A POSTROUTING -p udp --dport bootpc -j CHECKSUM --checksum-fill
+
+COMMIT
+*nat
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+
 
 COMMIT


### PR DESCRIPTION
iptables-save/restore files do not use `-t <table_name>`
