### PR TITLE
Store keystone tokens in mysql.

### DIFF
--- a/roles/db/tasks/keystone.yml
+++ b/roles/db/tasks/keystone.yml
@@ -1,0 +1,3 @@
+---
+- name: add cron job to clean up expired tokens
+  template: src=drop-expired-keystone-tokens.sh dest=/etc/cron.hourly/drop-expired-keystone-tokens.sh owner=root group=root mode=0755

--- a/roles/db/tasks/main.yml
+++ b/roles/db/tasks/main.yml
@@ -37,3 +37,4 @@
     - cinder
 
 - include: sync.yml
+- include: keystone.yml

--- a/roles/db/templates/drop-expired-keystone-tokens.sh
+++ b/roles/db/templates/drop-expired-keystone-tokens.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# This script drops all expired entries from the keystone.token table.
+# This is necessary, because otherwise the number of tokens would grow without bound.
+# Intended to be run periodically by cron.
+
+/usr/bin/mysql -e "delete from keystone.token where expires < now();"

--- a/roles/keystone-common/templates/etc/keystone/keystone.conf
+++ b/roles/keystone-common/templates/etc/keystone/keystone.conf
@@ -13,7 +13,7 @@ driver = keystone.identity.backends.sql.Identity
 driver = keystone.catalog.backends.sql.Catalog
 
 [token]
-driver = keystone.token.backends.memcache.Token
+driver = keystone.token.backends.sql.Token
 
 # Amount of time a token should remain valid (in seconds)
 expiration = 3600


### PR DESCRIPTION
Keystone would commonly become unresponsive when using
the memcached token backend.  This is suspected to be due
to known issues with how keystone handles token expiration
from memcached, which causes the keystone process to peg
cpu usage iterating through memcached for every request.

This change
- switches keystone to use the mysql token backend
- adds an hourly cron job to remove stale tokens from the
  keystone.token table, so that the table does not grow without
  bound.
