### PR TITLE
Update the neutronclient revision

### DIFF
--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -3,6 +3,6 @@ client:
   self_signed_cert: false
   novaclient_rev: 516586a6b8
   keystoneclient_rev: 876c2d6c2a
-  neutronclient_rev: 9fc2ac9e2f
+  neutronclient_rev: 8aacb125df
   glanceclient_rev: cd11833cff
   cinderclient_rev: d21ed05b4e


### PR DESCRIPTION
We are currently using an older version of the neutronclient. In that
version there is no explicit version for the cliff pip module. However,
cliff has since moved on and is no longer compatible with
neutronclient. This has been fixed upstream and as the clients do not
have version tags, pull the latest master sha.
