### PR TITLE
removing .sh from backup script so cron will execute

### DIFF
--- a/roles/percona-backup/tasks/main.yml
+++ b/roles/percona-backup/tasks/main.yml
@@ -3,4 +3,4 @@
   apt: pkg=mailutils
 
 - name: add percona-xtrabackup.sh to cron.daily
-  template: src=percona-xtrabackup.sh dest=/etc/cron.daily/percona-xtrabackup.sh owner=root group=root mode=0755
+  template: src=percona-xtrabackup.sh dest=/etc/cron.daily/percona-xtrabackup owner=root group=root mode=0755


### PR DESCRIPTION
This change removes the .sh extension of the percona-xtrabackup script that is copied to disk so that cron will execute the backup script as intended. 
