### PR TITLE
Bind memcache and rabbitmq to IPANY

### DIFF
--- a/roles/memcached/templates/memcached.conf
+++ b/roles/memcached/templates/memcached.conf
@@ -32,7 +32,7 @@ logfile /var/log/memcached.log
 # Specify which IP address to listen on. The default is to listen on all IP addresses
 # This parameter is one of the only security measures that memcached has, so make sure
 # it's listening on a firewalled interface.
--l {{ ansible_eth0["ipv4"]["address"] }}
+-l 0.0.0.0
 
 # Limit the number of simultaneous incoming connections. The daemon default is 1024
 -c {{ memcached.max_connections }}

--- a/roles/rabbitmq/defaults/main.yml
+++ b/roles/rabbitmq/defaults/main.yml
@@ -3,7 +3,7 @@ rabbitmq:
   erlang_cookie: 6IMgelGs3Ygu
   user: openstack
   nodename: 'openstack@{{ ansible_hostname }}'
-  ip: '{{ ansible_eth0["ipv4"]["address"] }}'
+  ip: '0.0.0.0'
   port: 5672
   management_port: 15672
   admin_cli_url: 'http://localhost:15672/cli/rabbitmqadmin'


### PR DESCRIPTION
Bringing RabbitMQ and Memcached in line with our service standard: bound to IPANY and enforce access restrictions using IPTables.
