### PR TITLE
Dont check for unbound variables

### DIFF
--- a/share/common
+++ b/share/common
@@ -1,4 +1,4 @@
-set -eu
+set -e
 
 ansible_command() {
   local inventory=$1
@@ -31,7 +31,7 @@ fi
 export ANSIBLE_FORCE_COLOR=yes
 
 export ANSIBLE_SSH_ARGS=\
-"$ANSIBLE_SSH_ARGS"\
+"${ANSIBLE_SSH_ARGS}"\
 ' -o ControlMaster=auto'\
 ' -o ControlPath=~/.ssh/controlmasters/ursula-%l-%r@%h:%p'\
 ' -o ControlPersist=300'


### PR DESCRIPTION
It is quite possible that ANSIBLE_SSH_ARGS is not already set, so
remove this bound check
