### PR TITLE
Provide URL for a precise Vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,12 +7,14 @@ VAGRANTFILE_API_VERSION = "2"
 NUM_CONTROLLERS = ENV['URSULA_NUM_CONTROLLERS'] || 2
 NUM_COMPUTES = ENV['URSULA_NUM_COMPUTES'] || 1
 NUM_SWIFT_NODES = ENV['URSULA_NUM_SWIFT_NODES'] || 3
+BOX_URL = ENV['URSULA_BOX_URL'] || 'http://files.vagrantup.com/precise64.box'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   (1..NUM_CONTROLLERS).each do |i|
     config.vm.define "controller#{i}" do |controller_config|
       controller_config.vm.box = "precise64"
+      controller_config.vm.box_url = BOX_URL
       controller_config.vm.network :private_network, ip: "10.1.1.10#{i}", :netmask => "255.255.0.0"
     end
   end
@@ -20,6 +22,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   (1..NUM_COMPUTES).each do |i|
     config.vm.define "compute#{i}" do |compute_config|
       compute_config.vm.box = "precise64"
+      compute_config.vm.box_url = BOX_URL
       compute_config.vm.network :private_network, ip: "10.1.1.11#{i}", :netmask => "255.255.0.0"
     end
   end
@@ -32,6 +35,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         v.customize ['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium', file_to_disk]
       end
       swiftnode_config.vm.box = "precise64"
+      swiftnode_config.vm.box_url = BOX_URL
       swiftnode_config.vm.network :private_network, ip: "10.1.1.13#{i}", :netmask => "255.255.0.0"
     end
   end


### PR DESCRIPTION
Previously, the box was only specified by 'precise64'. Also provide a
URL to pull the box if this is a new setup.
