### PR TITLE
Allow for setting cinder volume_clear_size

### DIFF
--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -36,3 +36,7 @@ rabbit_port = 5672
 {% endif -%}
 rabbit_userid = {{ rabbitmq.user }}
 rabbit_password = {{ secrets.rabbit_password }}
+
+{% if cinder.volume_clear_size is defined %}
+volume_clear_size = {{ cinder.volume_clear_size }}
+{% endif %}


### PR DESCRIPTION
As it turns out, when cinder is deleting volumes, this operation can be
somewhat demanding. An alternate approach for _single-tenant_
situtations _onylY_ could be to allow the filesystem to get trashed
without taking on an intensive dd operations.
