### PR TITLE
Configure horizon to not show mount-point option.

### DIFF
--- a/roles/horizon/templates/opt/stack/horizon/openstack_dashboard/local/local_settings.py
+++ b/roles/horizon/templates/opt/stack/horizon/openstack_dashboard/local/local_settings.py
@@ -142,7 +142,7 @@ OPENSTACK_KEYSTONE_BACKEND = {
 }
 
 OPENSTACK_HYPERVISOR_FEATURES = {
-    'can_set_mount_point': True,
+    'can_set_mount_point': False,
 
     # NOTE: as of Grizzly this is not yet supported in Nova so enabling this
     # setting will not do anything useful


### PR DESCRIPTION
KVM does not support setting the mount point when attaching a volume.
This change causes horizon not to show the option, as it is confusing
to show the option when it does not work.
