### PR TITLE
Add ufw firewall to swift proxy nodes.

### DIFF
--- a/library/ufw_allow
+++ b/library/ufw_allow
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+require 'rubygems'
+require 'antsy'
+
+args = Antsy.args
+to = args[:to] || 'Anywhere'
+from = args[:from] || 'Anywhere'
+
+Antsy.fail! "ufw is not present" unless system 'which ufw'
+
+if system "ufw status  | egrep '^#{to}\\s+ALLOW\\s+#{from}$'"
+  Antsy.no_change!
+else
+  add_cmd = "ufw allow"
+  add_cmd += " #{to}" unless to == 'Anywhere'
+  add_cmd += " from #{from}" unless from == 'Anywhere'
+  if system add_cmd
+    Antsy.changed!
+  else
+    Antsy.fail! "failed to add ufw rule with command: #{add_cmd}"
+  end
+end

--- a/roles/swift-proxy/handlers/main.yml
+++ b/roles/swift-proxy/handlers/main.yml
@@ -4,3 +4,6 @@
 
 - name: restart haproxy
   service: name=haproxy state=restarted
+
+- name: enable ufw
+  command: ufw --force enable

--- a/roles/swift-proxy/tasks/main.yml
+++ b/roles/swift-proxy/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- include: ufw.yml
+
 - name: install memcached
   apt: pkg=memcached
 
@@ -17,3 +19,5 @@
 - name: configure haproxy
   template: src=etc/haproxy/haproxy.cfg dest=/etc/haproxy/haproxy.cfg mode=0644
   notify: restart haproxy
+
+

--- a/roles/swift-proxy/tasks/ufw.yml
+++ b/roles/swift-proxy/tasks/ufw.yml
@@ -1,0 +1,14 @@
+---
+- apt: pkg=ufw
+
+- name: permit ssh from anywhere
+  ufw_allow: to=22/tcp
+  notify: enable ufw
+
+- name: permit swift proxy from anywhere
+  ufw_allow: to=8090/tcp
+  notify: enable ufw
+
+- name: permit internal access to anywhere
+  ufw_allow: from={{ undercloud_cidr }}
+  notify: enable ufw


### PR DESCRIPTION
This prevents unwanted access to internal services such
as memcached.

Publically accessible ports are SSH and swift-proxy.
All other ports are accessible only from `undercloud_cidr`.
