### PR TITLE
Increase neutron agent_down_time timeout.

### DIFF
--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -2,6 +2,7 @@
 neutron:
   rev: b5c4152ac9958e
   api_workers: 3
+  agent_down_time: 20
   dhcp_dns_servers:
     - 8.8.8.8
     - 8.8.4.4

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -1,5 +1,6 @@
 [DEFAULT]
 debug = False
+agent_down_time = {{ neutron.agent_down_time }}
 
 api_workers = {{ neutron.api_workers }}
 


### PR DESCRIPTION
In one production environment, neutron was intermittently considering
dhcp-agents to be unavailable, leading to instance dhcp failures.

In this environment, dhcp-agents were checking every ~ 5-15 seconds.
The default heartbeat interval is 4 seconds, and the default agent_down_time
is 9 seconds.

It is so far known why heartbeats were not coming in as frequently as expected
in this environment, so bump agent_down_time to 20 seconds, so that
services are not incorrectly considered unavailable.
