### PR TITLE
Fix broken memcached sensu checks.

### DIFF
--- a/playbooks/monitoring/tasks/controller.yml
+++ b/playbooks/monitoring/tasks/controller.yml
@@ -65,8 +65,8 @@
 
 # memcached
 
-- sensu_check: name=memcached-stats plugin=check-memcached-stats.rb args='--host={{ primary_ip }}'
+- sensu_check: name=memcached-stats plugin=check-memcached-stats.rb args='--host {{ primary_ip }}'
   notify: restart sensu-client
 
-- sensu_check: name=memcached-graphite plugin=memcached-graphite.rb args='--host={{ primary_ip }} --scheme=stats.{{ inventory_hostname  }}'
+- sensu_check: name=memcached-graphite plugin=memcached-graphite.rb args='--host {{ primary_ip }} --scheme stats.{{ inventory_hostname  }}'
   notify: restart sensu-client


### PR DESCRIPTION
The equals sign in `args='--host=xxx'` was confusing
ansible/yaml/jinja, and causing the check arguments to not
be rendered.

Replacing the equals sign with whitespace results in the
desired output.
