### PR TITLE
Prevent false positives in haproxy check.

### DIFF
--- a/playbooks/monitoring/tasks/controller.yml
+++ b/playbooks/monitoring/tasks/controller.yml
@@ -36,7 +36,7 @@
 
 # haproxy
 
-- sensu_check: name=haproxy plugin=check-procs.rb args="-p haproxy -w 5 -c 10 -W 1 -C 1"
+- sensu_check: name=haproxy plugin=check-procs.rb args="-p 'haproxy.*-f /etc/haproxy/haproxy.cfg' -w 5 -c 10 -W 1 -C 1"
   notify: restart sensu-client
 
 # nova


### PR DESCRIPTION
Previously, the haproxy process check was looking for the string 'haproxy'
in the process command line.

This results in false positives with the introduction of LBaaS, which contains
'haproxy' in the path to its config file.

Prevent this by looking for a process which contains "haproxy.*-f $haproxy_config_file".
