### PR TITLE
Fix recent change to install sensu plugins with fileglob.

### DIFF
--- a/playbooks/monitoring/tasks/common.yml
+++ b/playbooks/monitoring/tasks/common.yml
@@ -2,7 +2,7 @@
 - file: dest=/etc/sensu/conf.d/checks state=directory owner=root mode=0755
 
 - file: dest=/etc/sensu/plugins state=directory owner=root
-- copy: src={{ item }} dest=/etc/sensu/plugins/{{ item }} mode=0755
+- copy: src={{ item }} dest=/etc/sensu/plugins mode=0755
   with_fileglob: ../files/sensu_plugins/*
 
 - sensu_check: name=cpu  plugin=check-cpu.rb args='-w 80 -c 90'


### PR DESCRIPTION
Apparently the trailing `/` in the destination path was
causing the incorrect path to be used.
