### PR TITLE
Cleanup testenv security group

### DIFF
--- a/playbooks/testenv/tasks/create.yml
+++ b/playbooks/testenv/tasks/create.yml
@@ -7,8 +7,7 @@
   tasks:
     - include: keypair.yml
     - name: create the security group and rules
-      local_action:
-        module: nova_group
+      nova_group:
         name: "{{ testenv_security_groups }}"
         description: "{{ testenv_security_groups_description }}"
         rules:
@@ -19,11 +18,16 @@
             state: "{{ item.state }}"
       with_items: testenv_security_group_rules
       register: testenv_security_group
+    - command: neutron security-group-rule-create --ethertype={{ item }} --remote-group-id={{ testenv_security_group.results[0].group_id }} {{ testenv_security_group.results[0].group_id }}
+      register: security_group_rule_create_result
+      failed_when: "security_group_rule_create_result.rc != 0 and 'Security group rule already exists.' not in security_group_rule_create_result.stderr"
+      changed_when: security_group_rule_create_result.rc == 0
+      with_items:
+      - IPv4
+      - IPv6
     - name: create {{ item }}
-      local_action:
-        module: nova_compute
+      nova_compute:
         name: "{{ item }}"
-        state: present
         image_id: "{{ testenv_image_id }}"
         key_name: "{{ testenv_keypair_name }}"
         security_groups: "{{ testenv_security_group.results[0].group_id }}"

--- a/playbooks/testenv/vars/main.yml
+++ b/playbooks/testenv/vars/main.yml
@@ -11,31 +11,15 @@ testenv_security_groups_description: Rules for testing
 testenv_net_id: ba0fdd03-72b5-41eb-bb67-fef437fd6cb4
 testenv_security_groups: ursula
 testenv_security_group_rules:
-  - { proto: 'tcp', port: 22, state: 'present' }
-  - { proto: 'tcp', port: 80, state: 'present' }
-  - { proto: 'tcp', port: 443, state: 'present' }
-  - { proto: 'tcp', port: 3306, state: 'present' }   # mysql
-  - { proto: 'udp', port: 4789, state: 'present' }   # OVS VXLAN
-  # TODO(retr0h): We set port to 65535 (can likely remove this rule).
-  - { proto: 'tcp', port: 4369, state: 'present' }   # erlang portmapper (epmd)
-  - { proto: 'tcp', port: 4444, state: 'present' }   # percona cluster
-  - { proto: 'tcp', port: 4567, state: 'present' }   # percona cluster
-  - { proto: 'tcp', port: 4568, state: 'present' }   # percona cluster
-  - { proto: 'tcp', port: 5000, state: 'present' }   # keystone
-  - { proto: 'tcp', port: 5001, state: 'present' }   # keystone LB SSL
-  - { proto: 'tcp', port: 5672, state: 'present' }   # rabbit
-  - { proto: 'tcp', port: 8080, state: 'present' }   # dashboard
-  - { proto: 'tcp', port: 8774, state: 'present' }   # nova
-  - { proto: 'tcp', port: 8776, state: 'present' }   # cinder
-  - { proto: 'tcp', port: 8777, state: 'present' }   # nova LB SSL
-  - { proto: 'tcp', port: 8778, state: 'present' }   # cinder LB SSL
-  - { proto: 'tcp', port: 9292, state: 'present' }   # glance
-  - { proto: 'tcp', port: 9393, state: 'present' }   # glance LB SSL
-  - { proto: 'tcp', port: 9696, state: 'present' }   # neutron
-  - { proto: 'tcp', port: 9797, state: 'present' }   # neutron LB SSL
-  - { proto: 'tcp', port: 11211, state: 'present' }  # memcached
-  - { proto: 'tcp', port: 25307, state: 'present' }  # btsync (glance images)
-  - { proto: 'tcp', port: 35357, state: 'present' }  # keystone admin
-  - { proto: 'tcp', port: 35358, state: 'present' }  # keystone admin LB SSL
-  - { proto: 'tcp', port: 65535, state: 'present' }  # erlang portmapper (epmd)
+  - { proto: 'tcp', port: 22, state: 'present' }     # SSH (Ansible)
+  - { proto: 'tcp', port: 80, state: 'present' }     # HTTPS redirect
+  - { proto: 'tcp', port: 443, state: 'present' }    # Horizon SSL
+  - { proto: 'tcp', port: 5001, state: 'present' }   # Keystone SSL
+  - { proto: 'tcp', port: 6080, state: 'present' }   # NoVNC proxy
+  - { proto: 'tcp', port: 8777, state: 'present' }   # Nova SSL
+  - { proto: 'tcp', port: 8778, state: 'present' }   # Cinder SSL
+  - { proto: 'tcp', port: 9292, state: 'present' }   # Glance
+  - { proto: 'tcp', port: 9393, state: 'present' }   # Glance SSL
+  - { proto: 'tcp', port: 9797, state: 'present' }   # Neutron SSL
+  - { proto: 'tcp', port: 9798, state: 'present' }   # Cinder SSL
   - { proto: 'icmp', port: -1, state: 'present' }


### PR DESCRIPTION
Only permit external services from the internet and permit all traffic between members of the security group.

Remove unnecessary local_action directives from testenv playbook, we are already defining `connection: local, hosts: local`.
