### PR TITLE
Add empty swiftnode stanza for now

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -53,7 +53,7 @@
     - swift-common
 
 - name: swift bootstrap rings
-  hosts: swiftnode[0]
+  hosts: swiftnode_primary
   roles:
     - swift-ring
 

--- a/test/setup
+++ b/test/setup
@@ -67,8 +67,6 @@ $(public_ip "test-controller-1")
 [network]
 $(public_ip "test-controller-0")
 $(public_ip "test-controller-1")
-
-[swiftnode]
 eof
 
 echo "copying files"


### PR DESCRIPTION
Adding an empty swiftnode stanza so that CI will work again. Will
eventually get the CI building out swift cluster as well. Blocker
at the moment is getting haproxy role more modular.
