### PR TITLE
Consolidate common libraries in common role

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -14,7 +14,7 @@
     - python-lxml
     - python-greenlet
     - python-openssl
-    - python-dev
+    - python2.7-dev
     - python-httplib2
     - python-software-properties
     - python-virtualenv
@@ -26,6 +26,10 @@
     - ipmitool
     - ntp
     - vlan
+    - libffi-dev
+    - libssl-dev
+    - libxml2-dev
+    - libxslt1-dev
 
 - name: set UTC timezone
   template: src=etc/timezone dest=/etc/timezone owner=root group=root mode=0644

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -3,11 +3,6 @@
   with_items:
     - apache2
     - libapache2-mod-wsgi
-    - libffi-dev
-    - libssl-dev
-    - libxml2-dev
-    - libxslt1-dev
-    - python-dev
 
 - name: lesscpy must be in apache PATH
   pip: name=lesscpy version=0.9j

--- a/roles/swift-common/tasks/main.yml
+++ b/roles/swift-common/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- apt: pkg={{ item }}
-  with_items:
-    - python2.7-dev
-    - libffi-dev
-
 - name: create swift user
   user: name=swift comment=swift shell=/bin/false system=yes home=/nonexistent
 


### PR DESCRIPTION
Turns out that we have a number of roles that call for the same sorts
of system dependencies. Consolidate them into the common role so that
we don't repeat ourselves.

Also move python-dev to python2.7-dev as python-dev could be a moving
target.
