### PR TITLE
Use neutron-lbaas conditionally.

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -96,6 +96,7 @@ cinder:
       control_location: front-end
 
 neutron:
+  enable_lbaas: true
   physical_bridge: br-ex
   physical_network: br-ex
   tenant_network_type: vxlan

--- a/roles/controller/templates/etc/init/neutron-server.conf
+++ b/roles/controller/templates/etc/init/neutron-server.conf
@@ -9,4 +9,6 @@ exec start-stop-daemon --start \
                        -- --config-dir /etc/neutron \
                           --config-file /etc/neutron/neutron.conf \
                           --config-file /etc/neutron/plugins/openvswitch/ovs_neutron_plugin.ini \
+{% if neutron.enable_lbaas %}
                           --config-file /etc/neutron/services/loadbalancer/haproxy/lbaas_agent.ini
+{% endif %}

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -18,7 +18,6 @@
 - template: src=etc/init/{{ item }}.conf dest=/etc/init/{{ item }}.conf
   with_items:
     - neutron-l3-agent
-    - neutron-lbaas-agent
     - neutron-dhcp-agent
     - neutron-metadata-agent
 
@@ -28,3 +27,8 @@
     - neutron-lbaas-agent
     - neutron-dhcp-agent
     - neutron-metadata-agent
+
+- template: src=etc/init/neutron-lbaas-agent.conf dest=/etc/init/neutron-lbaas-agent.conf
+  when: neutron.enable_lbaas
+- service: name=neutron-lbaas-agent state=started
+  when: neutron.enable_lbaas

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -6,5 +6,3 @@ neutron:
   dhcp_dns_servers:
     - 8.8.8.8
     - 8.8.4.4
-  service_plugins:
-    - neutron.services.loadbalancer.plugin.LoadBalancerPlugin

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -4,10 +4,13 @@ agent_down_time = {{ neutron.agent_down_time }}
 
 api_workers = {{ neutron.api_workers }}
 
+{% if neutron.enable_lbaas %}
+service_plugins = neutron.services.loadbalancer.plugin.LoadBalancerPlugin
+{% endif %}
+
 auth_strategy = keystone
 allow_overlapping_ips = False
 verbose = True
-service_plugins = {{ neutron.service_plugins|join(',') }}
 core_plugin = neutron.plugins.openvswitch.ovs_neutron_plugin.OVSNeutronPluginV2
 
 {% macro rabbitmq_hosts() -%}


### PR DESCRIPTION
Since lbaas is currently a moving target, it is desirable
to release it only where required, to avoid painful
upgrades/migrations later.

This change causes neutron-lbaas agent to be configured and
started only if `neutron.enable_lbaas` var is true.
