### PR TITLE
Update default-vars monkeypatch to work with latest ansible.

### DIFF
--- a/plugins/vars/default_vars.py
+++ b/plugins/vars/default_vars.py
@@ -56,7 +56,7 @@ class VarsModule(GroupVarsModule):
         return group_vars
 
 
-def monkeypatch_get_variables(self, hostname):
+def monkeypatch_get_variables(self, hostname, vault_password=None):
     host = self.get_host(hostname)
     if host is None:
         raise errors.AnsibleError("host not found: %s" % hostname)


### PR DESCRIPTION
Upstream ansible changed the signature of a method we are
monkeypatching, breaking the plugin.  This change matches the
new signature, and the plugin remains backward-compatible with
older versions of ansible.
