### PR TITLE
Set X-Forwarded-Proto for haproxy ssl frontends.

### DIFF
--- a/roles/controller/templates/etc/haproxy/haproxy.cfg
+++ b/roles/controller/templates/etc/haproxy/haproxy.cfg
@@ -46,6 +46,7 @@ frontend {{ name }}
   # Require TLS with AES
   bind :{{ enc_port }} ssl crt /etc/haproxy/openstack.pem no-sslv3 ciphers AES128-SHA:AES256-SHA
   default_backend {{ name }}
+  reqadd X-Forwarded-Proto:\ https
 
 backend {{ name }}
   option httpchk /


### PR DESCRIPTION
Required to prevent heat from issuing redirects back to non-ssl.
