### PR TITLE
Bring Heat up to 2014.1.b2

### DIFF
--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 heat:
-  rev: 28e2287314a4f2f98a4ea4db2384e701af28410e
+  rev: 371bbdea47dce1c7ccea9b55dc769d48c38a4167

--- a/roles/heat/templates/etc/heat/api-paste.ini
+++ b/roles/heat/templates/etc/heat/api-paste.ini
@@ -1,6 +1,6 @@
 # heat-api pipeline
 [pipeline:heat-api]
-pipeline = faultwrap versionnegotiation authtoken context apiv1app
+pipeline = faultwrap ssl versionnegotiation authtoken context apiv1app
 
 # heat-api pipeline for standalone heat
 # ie. uses alternative auth backend that authenticates users against keystone
@@ -11,7 +11,7 @@ pipeline = faultwrap versionnegotiation authtoken context apiv1app
 #   flavor = standalone
 #
 [pipeline:heat-api-standalone]
-pipeline = faultwrap versionnegotiation authpassword context apiv1app
+pipeline = faultwrap ssl versionnegotiation authpassword context apiv1app
 
 # heat-api pipeline for custom cloud backends
 # i.e. in heat.conf:
@@ -72,6 +72,10 @@ paste.filter_factory = heat.common.context:ContextMiddleware_filter_factory
 
 [filter:ec2authtoken]
 paste.filter_factory = heat.api.aws.ec2token:EC2Token_filter_factory
+
+[filter:ssl]
+paste.filter_factory = heat.common.wsgi:filter_factory
+heat.filter_factory = heat.api.openstack:sslmiddleware_filter
 
 # Auth middleware that validates token against keystone
 [filter:authtoken]

--- a/roles/heat/templates/etc/heat/policy.json
+++ b/roles/heat/templates/etc/heat/policy.json
@@ -1,5 +1,7 @@
 {
+    "context_is_admin":  "role:admin",
     "deny_stack_user": "not role:heat_stack_user",
+
     "cloudformation:ListStacks": "rule:deny_stack_user",
     "cloudformation:CreateStack": "rule:deny_stack_user",
     "cloudformation:DescribeStacks": "rule:deny_stack_user",
@@ -23,5 +25,26 @@
     "cloudwatch:ListMetrics": "rule:deny_stack_user",
     "cloudwatch:PutMetricAlarm": "rule:deny_stack_user",
     "cloudwatch:PutMetricData": "",
-    "cloudwatch:SetAlarmState": "rule:deny_stack_user"
+    "cloudwatch:SetAlarmState": "rule:deny_stack_user",
+
+    "actions:action": "rule:deny_stack_user",
+    "build_info:build_info": "rule:deny_stack_user",
+    "events:index": "rule:deny_stack_user",
+    "events:show": "rule:deny_stack_user",
+    "resource:index": "rule:deny_stack_user",
+    "resource:metadata": "",
+    "resource:show": "rule:deny_stack_user",
+    "stacks:abandon": "rule:deny_stack_user",
+    "stacks:create": "rule:deny_stack_user",
+    "stacks:delete": "rule:deny_stack_user",
+    "stacks:detail": "rule:deny_stack_user",
+    "stacks:generate_template": "rule:deny_stack_user",
+    "stacks:index": "rule:deny_stack_user",
+    "stacks:list_resource_types": "rule:deny_stack_user",
+    "stacks:lookup": "rule:deny_stack_user",
+    "stacks:resource_schema": "rule:deny_stack_user",
+    "stacks:show": "rule:deny_stack_user",
+    "stacks:template": "rule:deny_stack_user",
+    "stacks:update": "rule:deny_stack_user",
+    "stacks:validate_template": "rule:deny_stack_user"
 }


### PR DESCRIPTION
Turns out that Heat in havana does not work behind an ssl terminating
proxy. Icehouse does, so lets move there.
