### PR TITLE
Add rabbit_hosts macro

### DIFF
--- a/roles/heat/templates/etc/heat/heat.conf
+++ b/roles/heat/templates/etc/heat/heat.conf
@@ -2,6 +2,16 @@
 
 debug = False
 
+{% macro rabbitmq_hosts() -%}
+{% for host in groups['controller'] -%}
+   {% if loop.last -%}
+{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }}
+   {%- else -%}
+{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }},
+   {%- endif -%}
+{% endfor -%}
+{% endmacro -%}
+
 {% if rabbitmq.cluster -%}
 rabbit_hosts = {{ rabbitmq_hosts() }}
 {% else -%}


### PR DESCRIPTION
Missing rabbit_hosts macro for heat.conf template
