### PR TITLE
Adding default rabbit port to defaults.yml

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -24,6 +24,7 @@ etc_hosts:
     ip: "{{ floating_ip }}"
 
 rabbitmq:
+  port: 5672
   user: openstack
   cluster: true
 


### PR DESCRIPTION
As the rabbitmq information is used beyond the scope of just the rabbit
role, we do not pickup all of the rabbit role's defaults. So redefine
that here.
