### PR TITLE
Create a heat.enabled feature flag

### DIFF
--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -34,9 +34,16 @@ endpoints:
 rabbitmq:
   user: openstack
   cluster: false
+
 etc_hosts:
   - name: "{{ fqdn }}"
     ip: "{{ undercloud_floating_ip }}"
+
+memcached:
+  memory: 64
+  port: 11211
+  user: nobody
+  max_connections: 1024
 
 mysql:
   root_password: asdf
@@ -209,6 +216,9 @@ keystone:
       public_url: https://{{ endpoints.main }}:8001/v1
       internal_url: https://{{ endpoints.main }}:8001/v1
       admin_url: https://{{ endpoints.main }}:8001/v1
+
+heat:
+  enabled: False
 
 ssl:
   crt: |

--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 heat:
+  enabled: True
   rev: 0007c2d671c811bf01bdfac60357d8dd855b5cb5

--- a/roles/heat/tasks/heat_main.yml
+++ b/roles/heat/tasks/heat_main.yml
@@ -1,0 +1,25 @@
+---
+- name: create heat user
+  user: name=heat comment=heat shell=/bin/false system=yes home=/nonexistent createhome=no
+
+- name: get heat source repo
+  git: |
+    repo={{ openstack.git_mirror }}/heat.git dest=/opt/stack/heat version={{ heat.rev }}
+  notify:
+    - pip install heat
+- meta: flush_handlers
+
+- name: create heat config directory
+  file: dest=/etc/heat state=directory
+
+- name: create heat environment.d directory
+  file: dest=/etc/heat/environment.d state=directory
+
+- name: heat config
+  template: src=etc/heat/heat.conf dest=/etc/heat/heat.conf mode=0644
+
+- name: heat policy config
+  template: src=etc/heat/policy.json dest=/etc/heat/policy.json mode=0644
+
+- name: heat paste config
+  template: src=etc/heat/api-paste.ini dest=/etc/heat/api-paste.ini mode=0644

--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -1,25 +1,3 @@
 ---
-- name: create heat user
-  user: name=heat comment=heat shell=/bin/false system=yes home=/nonexistent createhome=no
-
-- name: get heat source repo
-  git: |
-    repo={{ openstack.git_mirror }}/heat.git dest=/opt/stack/heat version={{ heat.rev }}
-  notify:
-    - pip install heat
-- meta: flush_handlers
-
-- name: create heat config directory
-  file: dest=/etc/heat state=directory
-
-- name: create heat environment.d directory
-  file: dest=/etc/heat/environment.d state=directory
-
-- name: heat config
-  template: src=etc/heat/heat.conf dest=/etc/heat/heat.conf mode=0644
-
-- name: heat policy config
-  template: src=etc/heat/policy.json dest=/etc/heat/policy.json mode=0644
-
-- name: heat paste config
-  template: src=etc/heat/api-paste.ini dest=/etc/heat/api-paste.ini mode=0644
+- include: heat_main.yml
+  when: heat.enabled


### PR DESCRIPTION
As we are not quite ready to ship heat wholesale, add a heat.enabled
feature flag. This moves heat/tasks/main to heat/tasks/heat_main and
conditionalizes the include. Also update envs to support/not support
heat.

Also sneaking in a defaults.yml change for memcached.
