### PR TITLE
Dont check lbaas agent if we are not using it

### DIFF
--- a/playbooks/monitoring/tasks/network.yml
+++ b/playbooks/monitoring/tasks/network.yml
@@ -4,5 +4,8 @@
     - neutron-l3-agent
     - neutron-dhcp-agent
     - neutron-metadata-agent
-    - neutron-lbaas-agent
   notify: restart sensu-client
+
+- sensu_process_check: service=neutron-lbaas-agent
+  notify: restart sensu-client
+  when: neutron.enable_lbaas


### PR DESCRIPTION
Need to break the lbaas sensu checks out as we may not alway need them.
