### PR TITLE
Only set tunnel_types when explictly called out

### DIFF
--- a/roles/neutron-common/templates/etc/neutron/plugins/openvswitch/ovs_neutron_plugin.ini
+++ b/roles/neutron-common/templates/etc/neutron/plugins/openvswitch/ovs_neutron_plugin.ini
@@ -17,7 +17,7 @@ local_ip = {{ primary_ip }}
 [AGENT]
 root_helper = sudo /usr/local/bin/neutron-rootwrap /etc/neutron/rootwrap.conf
 polling_interval = 2
-{% if neutron.tunnel_types is defined %}
+{% if neutron.enable_tunneling and neutron.tunnel_types is defined %}
 tunnel_types = {{ neutron.tunnel_types|join(' ,') }}
 {% endif %}
 


### PR DESCRIPTION
Neutron does not honor enable_tunneling in all cases, so dont give the
agent an opportunity to create tunnels.
