### PR TITLE
Increase ansible `forks` config option.

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,3 +6,4 @@ transport = ssh
 vars_plugins = plugins/vars
 connection_plugins = plugins/connection
 transport = monkeypatched_ssh
+forks = 25


### PR DESCRIPTION
Ansible's documentation says that by default, it will
fork at most 5 processes for communicating with remote hosts.

This can multiply running times for environments with >5 hosts.
