### PR TITLE
Set localhost properly

### DIFF
--- a/roles/common/tasks/networking.yml
+++ b/roles/common/tasks/networking.yml
@@ -2,6 +2,8 @@
 - template: src=etc/network/interfaces dest=/etc/network/interfaces owner=root group=root mode=0644
   when: network_interfaces is defined
 
+- lineinfile: dest=/etc/hosts regexp=^127.0.0.1 line="{{ ansible_hostname }} {{ ansible_fqdn }} localhost.localdomain localhost"
+
 - lineinfile: dest=/etc/hosts regexp=^{{ item.ip }} line="{{ item.ip }} {{ item.name }}"
   with_items: etc_hosts
 


### PR DESCRIPTION
We need a proper resolution of localhost in order to be able to run
things like ntp offset checks.
