### PR TITLE
Disable ipmi in CI and Vagrant envs

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -328,6 +328,8 @@ percona:
 
 common:
   apt_cache: "http://ursula-cache.openstack.blueboxgrid.com:3142"
+  ipmi:
+    enabled: false
 
 heat:
   enabled: True

--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -275,3 +275,5 @@ ssl:
 
 common:
   apt_cache: "http://ursula-cache.openstack.blueboxgrid.com:3142"
+  ipmi:
+    enabled: false


### PR DESCRIPTION
We dont need these and they would never work there anyway, so remove.
