### PR TITLE
Collapse swift-dispersion checks into one

### DIFF
--- a/playbooks/monitoring/tasks/swift.yml
+++ b/playbooks/monitoring/tasks/swift.yml
@@ -1,6 +1,5 @@
 ---
-- sensu_check: name=swift-dispersion-containers plugin=check-swift-dispersion.py args="-c 90 -d 95"
-- sensu_check: name=swift-dispersion-objects plugin=check-swift-dispersion.py args="-o 90 -n 95"
+- sensu_check: name=swift-dispersion-containers plugin=check-swift-dispersion.py args="-c 98 -d 99 -o 98 -n 99"
 
 - name: sensu account process checks
   sensu_process_check: service={{ item }}


### PR DESCRIPTION
As it turns out, running more than one swift-dispersion-report at the
same time was causing issues. However, there should be no reason we
cannot combine these two checks into one and still have the same result.
