### PR TITLE
sensu_check: ensure occurences and interval are integers

### DIFF
--- a/library/sensu_check
+++ b/library/sensu_check
@@ -31,9 +31,9 @@ check = {
       'command' => command,
       'standalone' => true,
       'handlers' => [ 'pagerduty' ],
-      'interval' => interval,
+      'interval' => interval.to_i,
       'notification' => "#{name} check failed",
-      'occurrences' => occurrences,
+      'occurrences' => occurrences.to_i,
       'auto_resolve' => auto_resolve
     }
   }


### PR DESCRIPTION
check-raid was not being processed
by pagerduty handler b/c the Sensu::Handler
doesn't like Strings for occurrences
