### PR TITLE
swift-dispersion-report auth against keystone standard port

### DIFF
--- a/roles/swift-common/templates/etc/swift/dispersion.conf
+++ b/roles/swift-common/templates/etc/swift/dispersion.conf
@@ -1,5 +1,5 @@
 [dispersion]
-auth_url = https://{{ endpoints.keystone }}:35358/v2.0
+auth_url = https://{{ endpoints.keystone }}:5001/v2.0
 auth_user = service:swift
 auth_key = {{ secrets.service_password }}
 auth_version = 2.0


### PR DESCRIPTION
Craig made a change to have the swift-proxy auth w/ 5001 so I think it needs to change here too.
Switching this value made the swift-dispersion-report run with much less errors (though I'm not sure how it was working at all).
