### PR TITLE
Monitor ucarp processes.

### DIFF
--- a/playbooks/monitoring.yml
+++ b/playbooks/monitoring.yml
@@ -43,3 +43,10 @@
   - include: monitoring/tasks/swift.yml
   handlers:
   - include: ../handlers/main.yml
+
+- name: Install ucarp checks
+  hosts: network:swiftnode
+  tasks:
+  - include: monitoring/tasks/ucarp.yml
+  handlers:
+  - include: ../handlers/main.yml

--- a/playbooks/monitoring/files/sensu_plugins/check-ucarp-procs.sh
+++ b/playbooks/monitoring/files/sensu_plugins/check-ucarp-procs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+grep ucarp-vip /etc/network/interfaces | awk '{print $2}' | while read ip; do
+  if ! ps -ef | grep '/usr/sbin/ucarp' | grep $ip >/dev/null; then
+    echo "no ucarp process is running for ip $ip"
+    exit 2
+  fi
+done

--- a/playbooks/monitoring/tasks/controller.yml
+++ b/playbooks/monitoring/tasks/controller.yml
@@ -76,8 +76,3 @@
 - sensu_check: name=memcached-graphite plugin=memcached-graphite.rb args='--host {{ primary_ip }} --scheme stats.{{ inventory_hostname  }}'
   notify: restart sensu-client
 
-# ucarp
-
-- name: ucarp failover alert
-  sensu_check: name=check-ucarp-failover plugin=check-log.rb use_sudo=true auto_resolve=false interval=20 args="-f /var/log/syslog -q 'ucarp.+[Ss]witching to state' --silent --occurences=1"  
-  notify: restart sensu-client

--- a/playbooks/monitoring/tasks/ucarp.yml
+++ b/playbooks/monitoring/tasks/ucarp.yml
@@ -1,0 +1,8 @@
+# ucarp
+
+- name: ucarp failover alert
+  sensu_check: name=check-ucarp-failover plugin=check-log.rb use_sudo=true auto_resolve=false interval=20 args="-f /var/log/syslog -q 'ucarp.+[Ss]witching to state' --silent --occurences=1"
+  notify: restart sensu-client
+
+- sensu_check: name=check-ucarp-procs plugin=check-ucarp-procs.sh
+  notify: restart sensu-client


### PR DESCRIPTION
On network and swift nodes, install a check which ensures
a ucarp process is running for each ucarp-vip present
in /etc/network/interfaces.

If no ucarp-vips are present, the check should never fail.
