### PR TITLE
Update sensu_process_check to accept parameters

### DIFF
--- a/library/sensu_process_check
+++ b/library/sensu_process_check
@@ -5,7 +5,8 @@ require 'antsy'
 args = Antsy.args
 service = args[:service]
 short_service_name = File.basename(service)
-
+warn_over=args[:warn_over] || 15
+crit_over=args[:crit_over] || 30
 
 Antsy.fail! "argument 'service' is required" unless service and not service.empty?
 
@@ -14,7 +15,7 @@ check_fname = "/etc/sensu/conf.d/checks/#{short_service_name}-service.json"
 check = {
   'checks' => {
     short_service_name => {
-      'command' => "/etc/sensu/plugins/check-procs.rb -p #{service} -w 15 -c 30 -W 1 -C 1",
+      'command' => "/etc/sensu/plugins/check-procs.rb -p #{service} -w #{warn_over} -c #{crit_over} -W 1 -C 1",
       'standalone' => true,
       'handlers' => [ 'pagerduty' ],
       'interval' => 30,

--- a/playbooks/monitoring/tasks/swift.yml
+++ b/playbooks/monitoring/tasks/swift.yml
@@ -6,7 +6,7 @@
 - sensu_check: name=swift-dispersion plugin=check-swift-dispersion.sh interval=600 occurrences=1 use_sudo=true
 
 - name: sensu account process checks
-  sensu_process_check: service={{ item }}
+  sensu_process_check: service={{ item }} warn_over=30 crit_over=35
   with_items:
     - swift-account-auditor
     - swift-account-replicator
@@ -14,7 +14,7 @@
     - swift-account-server
 
 - name: sensu container process checks
-  sensu_process_check: service={{ item }}
+  sensu_process_check: service={{ item }} warn_over=30 crit_over=35
   with_items:
     - swift-container-replicator
     - swift-container-updater
@@ -23,7 +23,7 @@
     - swift-container-server
 
 - name: sensu object process checks
-  sensu_process_check: service={{ item }}
+  sensu_process_check: service={{ item }} warn_over=30 crit_over=35
   with_items:
     - swift-object-replicator
     - swift-object-updater


### PR DESCRIPTION
Right now, sensu_process_check is hardcoded at 15 and 30 for the number
of processes it finds running, for warn and crit respectively.  Let's
make this configurable.
