### PR TITLE
Install pip 1.4 everywhere.

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -6,6 +6,9 @@
 - name: update apt index
   apt: update_cache=yes
 
+# the pip ansible library doesn't support `>=`, sho shell out instead
+- shell: pip install pip>=1.4.1
+
 - name: python dependencies
   apt: pkg={{ item }}
   with_items:


### PR DESCRIPTION
Previously, pip 1.0, installed via apt, was used.

Due to some upstream change, keystone now fails to pip install,
claiming to require pip >= 1.4.
