### PR TITLE
Skip apt-get dist-upgrade in pre-deploy

### DIFF
--- a/playbooks/testenv/tasks/pre-deploy.yml
+++ b/playbooks/testenv/tasks/pre-deploy.yml
@@ -23,7 +23,7 @@
 - hosts: all
   tasks:
   - name: add an apt proxy
-    template: src=../../../roles/common/etc/apt/apt.conf.d/01proxy dest=/etc/apt/apt.conf.d/01proxy owner=root group=root mode=0644
+    template: src=../../../roles/common/templates/etc/apt/apt.conf.d/01proxy dest=/etc/apt/apt.conf.d/01proxy owner=root group=root mode=0644
     when: common.apt_cache is defined
   - name: Run a full dist-upgrade (we don't want to preform this each run on existing clusters)
     apt: update_cache=yes upgrade=dist


### PR DESCRIPTION
We will run a dist-upgrade after configuring an apt-proxy in roles/common, so avoid time consuming apt-get dist-upgrade here.
