### PR TITLE
testenv: use nested KVM rather than QEMU

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -82,7 +82,7 @@ client:
   self_signed_cert: true
 
 nova:
-  libvirt_type: qemu
+  libvirt_type: kvm
   api_workers: 1
   metadata_api_workers: 1
 


### PR DESCRIPTION
This brings our CI environment closer inline with production.
