### PR TITLE
Configure nova-scheduler to use CoreFilter.

### DIFF
--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -10,7 +10,7 @@ send_arp_for_ha=true
 
 enabled_apis = ec2,osapi_compute,metadata,openstack_compute_api_v2
 
-scheduler_default_filters=AvailabilityZoneFilter,RamFilter,ComputeFilter
+scheduler_default_filters=AvailabilityZoneFilter,RamFilter,ComputeFilter,CoreFilter
 cpu_allocation_ratio={{ nova.cpu_allocation_ratio }}
 ram_allocation_ratio={{ nova.ram_allocation_ratio }}
 


### PR DESCRIPTION
Without this setting, `cpu_allocation_ratio` has no effect,
allowing compute nodes to be over-subscribed.
