### PR TITLE
Add httpclose option to default haproxy config

### DIFF
--- a/roles/controller/templates/etc/haproxy/haproxy.cfg
+++ b/roles/controller/templates/etc/haproxy/haproxy.cfg
@@ -13,6 +13,7 @@ defaults
   option dontlognull
   option redispatch
   option forwardfor
+  option httpclose # needed for empty reponse body 204's
   timeout client 30s
   timeout server 30s
   timeout connect 1s


### PR DESCRIPTION
API DELETE calls were hanging as they return a 204. Without option
httpclose, these connections remain open and from a client's
perspective, the call returned no data. It sees this as a failure.
These failures have all kinds of rippling effects on things like
Horizon.
