### PR TITLE
Fix /etc/hosts file

### DIFF
--- a/roles/common/tasks/networking.yml
+++ b/roles/common/tasks/networking.yml
@@ -16,7 +16,8 @@
 
 - template: src=etc/modprobe.d/conntrack.conf dest=/etc/modprobe.d/conntrack.conf owner=root group=root mode=0644
 
-- lineinfile: dest=/etc/hosts regexp=^127.0.0.1 line="127.0.0.1 {{ ansible_fqdn }} {{ ansible_hostname }} localhost.localdomain localhost"
+- lineinfile: dest=/etc/hosts regexp='^127\.0\.0\.1\s' line="127.0.0.1 localhost.localdomain localhost" insertbefore=BOF
+- lineinfile: dest=/etc/hosts regexp='^127\.0\.1\.1\s' line="127.0.1.1 {{ ansible_fqdn }} {{ ansible_hostname }}" insertafter='^127\.0\.0\.1\s'
 
 - lineinfile: dest=/etc/hosts regexp=^{{ item.ip }} line="{{ item.ip }} {{ item.name }}"
   with_items: etc_hosts


### PR DESCRIPTION
We were already updating /etc/hosts with the hostname and FQDN, so I split localhost from the machine's FQDN following the Debian/Ubuntu standard: https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution
