### PR TITLE
be more lenient about token expiration

### DIFF
--- a/roles/db/templates/drop-expired-keystone-tokens
+++ b/roles/db/templates/drop-expired-keystone-tokens
@@ -3,4 +3,4 @@
 # This is necessary, because otherwise the number of tokens would grow without bound.
 # Intended to be run periodically by cron.
 
-/usr/bin/mysql -e "delete from keystone.token where expires < now();"
+/usr/bin/mysql -e "delete from keystone.token where expires < date_sub(now(), interval 24 hours);"


### PR DESCRIPTION
we were killing tokens that may have been in use. while that logic is
certainly correct, there may be transactions in flight. and, to be
super safe, give a very long reprieve interval of 1 day. this keeps the
token database clean and gives us some runway.
