### PR TITLE
Update 3ware check to not alert on VERIFYING disks

### DIFF
--- a/playbooks/monitoring/files/sensu_plugins/check_3ware_raid.py
+++ b/playbooks/monitoring/files/sensu_plugins/check_3ware_raid.py
@@ -262,7 +262,8 @@ def test_drives(verbosity, warn_true=False, no_summary=False):
             state = drive_line[1]
             if state == "OK" or state == "NOT-PRESENT":
                 continue
-            if not warn_true and state == "VERIFYING":
+            if not warn_true and \
+                state in ('VERIFYING', 'REBUILDING', 'INITIALIZING'):
                 continue
             else:
                 drives_not_ok += 1


### PR DESCRIPTION
Right now this 3ware check has the ability to allow for VERIFYING to be
treated as an acceptable state for arrays.  However, this state is not
acceptable for individual drives. Plumb this logic through to the
test_drives routine.
