### PR TITLE
testenv: allow specifiying instance network

### DIFF
--- a/playbooks/testenv/vars/main.yml
+++ b/playbooks/testenv/vars/main.yml
@@ -6,9 +6,8 @@ testenv_instance_names:
 testenv_keypair_name: int-test
 testenv_keypair_path: "{{ ansible_env.ROOT }}/envs/test/{{ testenv_keypair_name }}.pem"
 testenv_image_id: "{{ ansible_env.IMAGE_ID }}"
-testenv_security_groups: ursula
+testenv_net_id: "{{ ansible_env.NET_ID }}"
 testenv_security_groups_description: Rules for testing
-testenv_net_id: ba0fdd03-72b5-41eb-bb67-fef437fd6cb4
 testenv_security_groups: ursula
 testenv_security_group_rules:
   - { proto: 'tcp', port: 22, state: 'present' }     # SSH (Ansible)

--- a/test/common
+++ b/test/common
@@ -18,6 +18,7 @@ SSH_ARGS=\
 export ANSIBLE_SSH_ARGS="${SSH_ARGS}"
 export ANSIBLE_VAR_DEFAULTS_FILE="${ROOT}/envs/test/defaults.yml"
 export IMAGE_ID=${IMAGE_ID:=014f8214-37b0-4920-b7ce-ec05edc253fb}
+export NET_ID=${NET_ID:=ba0fdd03-72b5-41eb-bb67-fef437fd6cb4}
 
 die() {
   echo "[ERROR] $*"; exit 1


### PR DESCRIPTION
We are including the UUID of the internal tenant network of our CI environment in the testenv defaults. Making this overrideable with an environmental variable like IMAGE_ID.
