### PR TITLE
Update all the apt caches updates with a timeout

### DIFF
--- a/playbooks/testenv/tasks/pre-deploy.yml
+++ b/playbooks/testenv/tasks/pre-deploy.yml
@@ -26,7 +26,7 @@
     template: src=../../../roles/common/templates/etc/apt/apt.conf.d/01proxy dest=/etc/apt/apt.conf.d/01proxy owner=root group=root mode=0644
     when: common.apt_cache is defined
   - name: Run a full dist-upgrade (we don't want to preform this each run on existing clusters)
-    apt: update_cache=yes cache_valid_time=3600 upgrade=dist cache_valid_time=3600
+    apt: update_cache=yes cache_valid_time=3600 upgrade=dist
   - name: Ubuntu 14.04 style /etc/network/interfaces.d/ directory
     file: dest=/etc/network/interfaces.d state=directory owner=root group=root mode=0755
   - name: /etc/network/interfaces to support interfaces.d/

--- a/roles/openvswitch/tasks/main.yml
+++ b/roles/openvswitch/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - apt_key: id=49DE63CB url='http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xC37BA5F849DE63CB'
-- apt_repository: repo='ppa:blueboxgroup/openstack' update_cache=yes cache_valid_time=3600
+- apt_repository: repo='ppa:blueboxgroup/openstack' update_cache=yes
 
 # FIXME(cmt): for whatever reason the PPA doesnt like the signature on openvswitch-datapath-dkms
 - apt: pkg=openvswitch-datapath-dkms force=yes

--- a/roles/rabbitmq/tasks/cluster.yml
+++ b/roles/rabbitmq/tasks/cluster.yml
@@ -16,7 +16,6 @@
   apt_repository: >
     repo='deb http://packages.erlang-solutions.com/debian precise contrib'
     update_cache=yes
-    cache_valid_time=3600
 
 - name: install erlang-solutions erlang
   apt: pkg=esl-erlang
@@ -28,7 +27,6 @@
   apt_repository: >
     repo='deb http://www.rabbitmq.com/debian/ testing main'
     update_cache=yes
-    cache_valid_time=3600
 
 - name: install rabbitmq
   apt: pkg=rabbitmq-server


### PR DESCRIPTION
One of the longest processes in an ursula run is the cache update. So,
dont do it if we dont really need to.
