### PR TITLE
A better way to handle haproxy services template

### DIFF
--- a/roles/controller/templates/etc/haproxy/haproxy.cfg
+++ b/roles/controller/templates/etc/haproxy/haproxy.cfg
@@ -1,8 +1,22 @@
+{% set haproxy_services = [
+    [ 'horizon', 8080, 443, false ],
+    [ 'keystone', 5000, 5001, false ],
+    [ 'keystone-admin', 35357, 35358, false ],
+    [ 'nova', 8774, 8777, false ],
+    [ 'glance', 9292, 9393, true ],
+    [ 'neutron', 9696, 9797, false ],
+    [ 'cinder', 8776, 8778, false ],
+  ]
+-%}
+{% if heat.enabled -%}
+    {% set _ = haproxy_services.append(['heat', 8004, 8005, false]) %}
+    {% set _ = haproxy_services.append(['heat-cfn', 8000, 8001, false]) %}
+{% endif -%}
 global
   log 127.0.0.1 local0
   maxconn 256
   user nobody
-   group nogroup
+  group nogroup
   daemon
   pidfile /var/run/haproxy.pid
 
@@ -25,22 +39,8 @@ defaults
   stats uri /haproxy_stats
   stats auth admin:{{ secrets.admin_password }}
 
-{% for name, clear_port, enc_port, prefer_primary_backend in
-  [
-   [ 'horizon', 8080, 443, false ],
-    [ 'keystone', 5000, 5001, false ],
-    [ 'keystone-admin', 35357, 35358, false ],
-    [ 'nova', 8774, 8777, false ],
-    [ 'glance', 9292, 9393, true ],
-    [ 'neutron', 9696, 9797, false ],
-    [ 'cinder', 8776, 8778, false ],
-    [ 'heat', 8004, 8005, false ],
-    [ 'heat-cfn', 8000, 8001, false ]
-  ]
-%}
-
+{% for name, clear_port, enc_port, prefer_primary_backend in haproxy_services -%}
 frontend {{ name }}
-  {% if "heat" not in name or heat.enabled -%}
   {% if name == "horizon" -%}
   bind :::80
   redirect scheme https if !{ ssl_fc }
@@ -55,12 +55,11 @@ backend {{ name }}
   balance source
   {% for host in groups['controller'] -%}
 
-  {% if not prefer_primary_backend or hostvars[host][primary_interface]['ipv4']['address'] == primary_ip %}
+  {% if not prefer_primary_backend or hostvars[host][primary_interface]['ipv4']['address'] == primary_ip -%}
     server {{ host }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ clear_port }} check maxconn 40
   {% else -%}
-      server {{ host }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ clear_port }} backup check maxconn 40
-  {% endif %}
-  {% endfor -%}
-
+    server {{ host }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ clear_port }} backup check maxconn 40
   {% endif -%}
+  {% endfor %}
+
 {% endfor %}


### PR DESCRIPTION
Prevsiously we had interspersed Jinja code and variables to get a
desired haproxy config. It is much cleaner to set a baseline variable up
front, and then for the conditional services, add them as they are
enabled or disabled.

This fix also addresses some of the whitespace weirdness with the
templatized config.
