### PR TITLE
Remove apt_cache for now

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -329,7 +329,6 @@ percona:
   replication: True
 
 common:
-  apt_cache: "http://ursula-cache.openstack.blueboxgrid.com:3142"
   ipmi:
     enabled: false
 


### PR DESCRIPTION
apt_cache is somehow breaking the CI runs when attempting to install
the sensu packages.
