### PR TITLE
Fix config ordering which haproxy complained about

### DIFF
--- a/roles/controller/templates/etc/haproxy/haproxy.cfg
+++ b/roles/controller/templates/etc/haproxy/haproxy.cfg
@@ -41,14 +41,15 @@ defaults
 
 {% for name, clear_port, enc_port, prefer_primary_backend in haproxy_services -%}
 frontend {{ name }}
-  {% if name == "horizon" -%}
-  bind :::80
-  redirect scheme https if !{ ssl_fc }
-  {% endif -%}
   # Require TLS with AES
   bind :::{{ enc_port }} ssl crt /etc/haproxy/openstack.pem no-sslv3 ciphers AES128-SHA:AES256-SHA
   default_backend {{ name }}
   reqadd X-Forwarded-Proto:\ https
+
+  {% if name == "horizon" -%}
+  bind :::80
+  redirect scheme https if !{ ssl_fc }
+  {% endif -%}
 
 backend {{ name }}
   option httpchk /


### PR DESCRIPTION
As pointed out by @dlundquist

```
parsing [/etc/haproxy/haproxy.cfg:34] : a 'reqadd' rule placed after a 'redirect' rule will still be processed before.
```
