### PR TITLE
Increase the haproxy http timeout

### DIFF
--- a/roles/controller/templates/etc/haproxy/haproxy.cfg
+++ b/roles/controller/templates/etc/haproxy/haproxy.cfg
@@ -32,7 +32,7 @@ defaults
   timeout server 30s
   timeout connect 1s
   timeout http-keep-alive 60s
-  timeout http-request 5s
+  timeout http-request 30s
 
   stats enable
   stats refresh 10s


### PR DESCRIPTION
Based on the fact that we were seeing Horizon 408's, we are updating
this timeout from 5 to 30 seconds.

PLEASE DO NOT MERGE UNTIL WE KNOW THIS IS HELPING
