### PR TITLE
Configure dnsmasq to send IPv6 RA for other nodes

### DIFF
--- a/roles/ipv6ra/handlers/main.yml
+++ b/roles/ipv6ra/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart-dnsmasq
+  service: name=dnsmasq state=restarted

--- a/roles/ipv6ra/tasks/main.yml
+++ b/roles/ipv6ra/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+# IPv6 RA requires dnsmasq >= 2.64
+- apt_key: id=49DE63CB url='http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xC37BA5F849DE63CB'
+- apt_repository: repo='ppa:blueboxgroup/openstack' update_cache=yes
+
+- apt: pkg=dnsmasq state=latest
+
+- template: src=etc/dnsmasq.d/internal-ipv6-ra.conf dest=/etc/dnsmasq.d/internal-ipv6-ra.conf owner=root group=root mode=0644
+  notify: restart-dnsmasq
+
+- service: name=dnsmasq state=started enabled=yes

--- a/roles/ipv6ra/templates/etc/dnsmasq.d/internal-ipv6-ra.conf
+++ b/roles/ipv6ra/templates/etc/dnsmasq.d/internal-ipv6-ra.conf
@@ -1,0 +1,2 @@
+dhcp-range=::,constructor:{{ hostvars[inventory_hostname][primary_interface].device }},ra-stateless
+

--- a/site.yml
+++ b/site.yml
@@ -3,6 +3,11 @@
   roles:
     - common
 
+- name: Setup IPv6 Router Advertisements
+  hosts: controller
+  roles:
+    - ipv6ra
+
 - name: rabbitmq used by openstack
   hosts: controller
   serial: 1


### PR DESCRIPTION
This configuration is dependent on the controller nodes having IPv6
forwarding enabled and static IPv6 addresses, but will enable using
SLAAC for other compute nodes.

Note: this also includes backporting dnsmasq from Trusty for IPv6 RA support.
