### PR TITLE
add Horizon API versioning

### DIFF
--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -3,3 +3,4 @@ horizon:
   rev: 19634d62f5a9b2c1aa9f867c247f46ed7f19ac07
   logo_url: https://s3.amazonaws.com/horizon-branding/bluebox.png
   favicon_url: https://s3.amazonaws.com/horizon-branding/bluebox.ico
+  keystone_api_version: 2.0

--- a/roles/horizon/templates/opt/stack/horizon/openstack_dashboard/local/local_settings.py
+++ b/roles/horizon/templates/opt/stack/horizon/openstack_dashboard/local/local_settings.py
@@ -120,9 +120,14 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 #     ('http://cluster1.example.com:5000/v2.0', 'cluster1'),
 #     ('http://cluster2.example.com:5000/v2.0', 'cluster2'),
 # ]
+{% if horizon.keystone_api_version == 3 -%}
+AVAILABLE_REGIONS = [
+     ('https://{{ endpoints.main }}:5001/v3', 'RegionOne'),
+]
+{% endif -%}
 
 OPENSTACK_HOST = "{{ endpoints.main }}"
-OPENSTACK_KEYSTONE_URL = "https://%s:5001/v2.0" % OPENSTACK_HOST
+OPENSTACK_KEYSTONE_URL = "https://%s:5001/v{{horizon.keystone_api_version}}" % OPENSTACK_HOST
 OPENSTACK_KEYSTONE_DEFAULT_ROLE = "service"
 
 # Disable SSL certificate checks (useful for self-signed certificates):


### PR DESCRIPTION
Added api versioning with a default of 2.0, and ability to use 3(for BFG)
