### PR TITLE
Disable Neutron LBaaS until ready

### DIFF
--- a/roles/horizon/templates/opt/stack/horizon/openstack_dashboard/local/local_settings.py
+++ b/roles/horizon/templates/opt/stack/horizon/openstack_dashboard/local/local_settings.py
@@ -157,9 +157,9 @@ OPENSTACK_HYPERVISOR_FEATURES = {
 # The OPENSTACK_QUANTUM_NETWORK settings can be used to enable optional
 # services provided by quantum.  Currently only the load balancer service
 # is available.
-OPENSTACK_QUANTUM_NETWORK = {
-    'enable_lb': True
-}
+#OPENSTACK_QUANTUM_NETWORK = {
+#    'enable_lb': True
+#}
 
 # OPENSTACK_ENDPOINT_TYPE specifies the endpoint type to use for the endpoints
 # in the Keystone service catalog. Use this setting when Horizon is running


### PR DESCRIPTION
Neutron LBaaS is not really ready, so don't expose it in Horizon.
Waiting on a legitimate LB with LBaaS v2/Octavia.
