### PR TITLE
Replace the git mirror used by vagrant

### DIFF
--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -71,7 +71,7 @@ monitoring:
 
 openstack:
   pypi_mirror: http://pypi.openstack.org/openstack
-  git_mirror:  http://git-mirror.openstack.blueboxgrid.com
+  git_mirror:  https://github.com/openstack
   git_update: yes
 
 nova:


### PR DESCRIPTION
This mirror is an old mirror that we had used when we had upstream
reliability issues. Point this back to github and soon to be replaced
by giftwrap.
