### PR TITLE
Use service dependencies when starting Neutron

### DIFF
--- a/roles/network/templates/etc/init/neutron-dhcp-agent.conf
+++ b/roles/network/templates/etc/init/neutron-dhcp-agent.conf
@@ -1,5 +1,5 @@
-start on runlevel [2345]
-stop on runlevel [016]
+start on started neutron-openvswitch-agent
+stop on stopping neutron-openvswitch-agent
 
 respawn
 

--- a/roles/network/templates/etc/init/neutron-l3-agent.conf
+++ b/roles/network/templates/etc/init/neutron-l3-agent.conf
@@ -1,5 +1,5 @@
-start on runlevel [2345]
-stop on runlevel [016]
+start on started neutron-openvswitch-agent
+stop on stopping neutron-openvswitch-agent
 
 respawn
 

--- a/roles/network/templates/etc/init/neutron-lbaas-agent.conf
+++ b/roles/network/templates/etc/init/neutron-lbaas-agent.conf
@@ -1,5 +1,5 @@
-start on runlevel [2345]
-stop on runlevel [016]
+start on started neutron-openvswitch-agent
+stop on stopping neutron-openvswitch-agent
 
 respawn
 

--- a/roles/network/templates/etc/init/neutron-metadata-agent.conf
+++ b/roles/network/templates/etc/init/neutron-metadata-agent.conf
@@ -1,5 +1,5 @@
-start on runlevel [2345]
-stop on runlevel [016]
+start on started neutron-openvswitch-agent
+stop on stopping neutron-openvswitch-agent
 
 respawn
 

--- a/roles/openvswitch/tasks/main.yml
+++ b/roles/openvswitch/tasks/main.yml
@@ -3,7 +3,9 @@
 - apt_repository: repo='ppa:blueboxgroup/openstack' update_cache=yes
 
 # FIXME(cmt): for whatever reason the PPA doesnt like the signature on openvswitch-datapath-dkms
+# Linux 3.13 and later include the OVS datapath
 - apt: pkg=openvswitch-datapath-dkms force=yes
+  when: ansible_distribution_version == "12.04"
 
 - apt: pkg={{ item }}
   with_items:

--- a/roles/openvswitch/templates/etc/init/neutron-openvswitch-agent.conf
+++ b/roles/openvswitch/templates/etc/init/neutron-openvswitch-agent.conf
@@ -1,7 +1,9 @@
-start on runlevel [2345]
-stop on runlevel [016]
+start on started openvswitch-switch
+stop on stopping openvswitch-switch
 
 respawn
+
+pre-start /usr/local/bin/neutron-ovs-cleanup
 
 exec start-stop-daemon --start \
                        --chuid neutron \


### PR DESCRIPTION
Do not include openvswitch-datapath-dkms on Trusty since the 3.13 kernel
includes the Open vSwitch datapath
