### PR TITLE
Correct broken arping syntax

### DIFF
--- a/roles/network/templates/etc/ipchanged/add_internal_floating_ip
+++ b/roles/network/templates/etc/ipchanged/add_internal_floating_ip
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # Send gratuitous ARP to update other nodes ARP cache
-arping -U -I {{ hostvars[inventory_hostname][primary_interface].device }} -s {{ undercloud_floating_ip }} -c 10
+arping -A -U -I {{ hostvars[inventory_hostname][primary_interface].device }} {{ undercloud_floating_ip }} -c 10


### PR DESCRIPTION
Adding the -A option and removing the -s flag. This is identical to the
mechanism used by the neutron l3 agent.
