### PR TITLE
make nova ssh keypairs optional

### DIFF
--- a/roles/compute/defaults/main.yml
+++ b/roles/compute/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+compute:
+  enable_ssh: False

--- a/roles/compute/tasks/main.yml
+++ b/roles/compute/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - include: ssh.yml
+  when: compute.enable_ssh == True
 
 # Ensure this file is written before kvm_intel or kvm_amd module is loaded
 - name: enable nested kvm


### PR DESCRIPTION
It is not always the case where a nova keypairs are avaialble. So,
make their inclusion contingent on a role default.
