### PR TITLE
Correct upstart syntax in neutron-openvswitch-agent

### DIFF
--- a/roles/openvswitch/templates/etc/init/neutron-openvswitch-agent.conf
+++ b/roles/openvswitch/templates/etc/init/neutron-openvswitch-agent.conf
@@ -3,7 +3,9 @@ stop on stopping openvswitch-switch
 
 respawn
 
-pre-start /usr/local/bin/neutron-ovs-cleanup
+pre-start script
+    /usr/local/bin/neutron-ovs-cleanup
+end script
 
 exec start-stop-daemon --start \
                        --chuid neutron \


### PR DESCRIPTION
the pre-start syntax was incorrect and led to this job remaining
Unknown and unstartable.  Fix this so that it can run.
