### PR TITLE
swift: include default value for swift versioning feature flag

### DIFF
--- a/roles/swift-container/defaults/main.yml
+++ b/roles/swift-container/defaults/main.yml
@@ -3,3 +3,5 @@ swift_container:
   ip: "{{ primary_ip }}"
   port: 6001
   workers: 10
+swift:
+  allow_versions: False


### PR DESCRIPTION
Fixes upgrade path for clusters deployed before this feature was introduced and do not have this variable defined.
