### PR TITLE
Add support for configurable cinder backends

### DIFF
--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 cinder:
   rev: eedc8eda9bbb
+  enabled_backends: None
+  default_backend: None

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -11,7 +11,6 @@ api_paste_config = /etc/cinder/api-paste.ini
 
 iscsi_helper=tgtadm
 iscsi_ip_address = {{ primary_ip }}
-
 volume_name_template = volume-%s
 volume_group = cinder-volumes
 auth_strategy = keystone
@@ -38,6 +37,28 @@ rabbit_port = 5672
 rabbit_userid = {{ rabbitmq.user }}
 rabbit_password = {{ secrets.rabbit_password }}
 
-{% if cinder.volume_clear_size is defined %}
+{% if cinder.volume_clear_size is defined -%}
 volume_clear_size = {{ cinder.volume_clear_size }}
+{% endif -%}
+
+{% if cinder.enabled_backends is defined -%}
+enabled_backends = {{ cinder.enabled_backends }}
 {% endif %}
+{% if cinder.default_backend is defined -%}
+default_backend = {{ cinder.default_backend }}
+{% endif %}
+
+{% for backend in cinder.backends %}
+[{{ backend.name }}]
+volume_driver = {{ backend.volume_driver }}
+volume_backend_name = {{ backend.name }}
+{% if backend.volume_group is defined %}
+volume_group = {{ backend.volume_group }}
+{% endif -%}
+{% if backend.san_ip is defined -%}
+san_ip = {{ backend.san_ip }}
+san_login = {{ backend.san_login }}
+san_password = {{ backend.san_password }}
+{% endif %}
+
+{% endfor -%}

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -7,3 +7,4 @@ common:
       - megacli
   ipmi:
     enabled: True
+  python_extra_packages: []

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -42,6 +42,7 @@
 - name: /opt/stack
   file: dest=/opt/stack state=directory
 
+- include: python.yml
 - include: ssl.yml
 - include: ssh.yml
 - include: networking.yml

--- a/roles/common/tasks/python.yml
+++ b/roles/common/tasks/python.yml
@@ -1,0 +1,12 @@
+---
+- name: install additional python packages
+  git: |
+    repo={{ item.repo }}
+    dest=/opt/stack/{{ item.name }}
+    version={{ item.rev }}
+    accept_hostkey=True
+  with_items: common.python_extra_packages
+
+- name: install drivers
+  command: python setup.py install chdir=/opt/stack/{{ item.name }}
+  with_items: common.python_extra_packages


### PR DESCRIPTION
Adding support to cinder.conf for configuring alternate backends. This
will allow us to back cinder with something like a SAN. Additionally,
as some SAN's may not have native cinder support, add the ability to
install alternate python packages.
