### PR TITLE
Better support for ssh forwarding agents

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,7 @@ BOX_URL = ENV['URSULA_BOX_URL'] || 'http://files.vagrantup.com/precise64.box'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
+  config.ssh.forward_agent = true
   (1..NUM_CONTROLLERS).each do |i|
     config.vm.define "controller#{i}" do |controller_config|
       controller_config.vm.box = "precise64"

--- a/roles/common/tasks/ssh.yml
+++ b/roles/common/tasks/ssh.yml
@@ -1,4 +1,7 @@
 ---
+- name: ssh agent for sudoers operations
+  lineinfile: dest=/etc/sudoers insertafter="^Defaults.*$" line="Defaults        env_keep+=SSH_AUTH_SOCK" state=present
+
 - lineinfile: dest=/etc/ssh/sshd_config regexp=^PasswordAuthentication line="PasswordAuthentication no"
   notify:
     - reload-sshd


### PR DESCRIPTION
Add forward_agent to Vagrantfile as well as pass SSH_AUTH_SOCK on to
any sudoers elevations. This would be required for pulling any private
git repos via ssh.
