### PR TITLE
Set default cpu model to Opteron_G3

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -7,4 +7,4 @@ nova:
   metadata_api_workers: 5
   cpu_allocation_ratio: 1.0
   ram_allocation_ratio: 1.0
-  libvirt_cpu_model: Opteron_G3
+  libvirt_cpu_model: None

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -120,8 +120,10 @@ libvirt_type={{ nova.libvirt_type }}
 compute_driver={{ nova.compute_driver }}
 libvirt_use_virtio_for_bridges=true
 resume_guests_state_on_host_boot=true
+{% nova.libvirt_cpu_model -%}
 libvirt_cpu_mode = custom
 libvirt_cpu_model = {{ nova.libvirt_cpu_model }}
+{% endif -%}
 
 # Reserved Resources
 {% if inventory_hostname in groups['controller'] -%}


### PR DESCRIPTION
Out of the gate, libvirt provides cpu's as core2duo. This cpu feature
mapping is not very feature rich. For instance, it does not support
nested KVM. Update nova to default to Opteron_G3 for some better cpu
flag support.
