### PR TITLE
Add Keystone public and admin endpoints

### DIFF
--- a/roles/keystone-common/templates/etc/keystone/keystone.conf
+++ b/roles/keystone-common/templates/etc/keystone/keystone.conf
@@ -3,6 +3,9 @@ admin_token = {{ secrets.admin_token }}
 
 debug = False
 
+public_endpoint = https://{{ endpoints.keystone }}:5001/v2.0/
+admin_endpoint = https://{{ endpoints.keystone }}:35358/v2.0/
+
 [sql]
 connection=mysql://keystone:{{ secrets.db_password }}@{{ endpoints.db }}/keystone?charset=utf8
 


### PR DESCRIPTION
Some of the newer clients have begun to do service version discovery.
With that, they interrogate Keystone for the version that is supported,
and then use that data to pass all further authentication requests on to
the href provided by the query. In our case we were always returning
localhost as the next hop. This is clearly not correct.
