### PR TITLE
Jinja fails me again

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -7,4 +7,4 @@ nova:
   metadata_api_workers: 5
   cpu_allocation_ratio: 1.0
   ram_allocation_ratio: 1.0
-  libvirt_cpu_model: None
+  libvirt_cpu_model: null


### PR DESCRIPTION
Jinja doesnt support standard truthiness. Therefore, unset the default
and add an "is defined" to the conditional. Argh, Jiiiiiiinja!
