### PR TITLE
rabbitmq: Cluster default to false, not undefined

### DIFF
--- a/roles/rabbitmq/defaults/main.yml
+++ b/roles/rabbitmq/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 rabbitmq:
+  cluster: False
   erlang_cookie: 6IMgelGs3Ygu
   user: openstack
   nodename: 'openstack@{{ ansible_hostname }}'


### PR DESCRIPTION
This has popped up for me a few times when working in the test environment. This is congruent with what we are defining in our defaults.yml normally.
