### PR TITLE
Remove v2.0 public_endpoint and admin_endpoint

### DIFF
--- a/roles/keystone-common/templates/etc/keystone/keystone.conf
+++ b/roles/keystone-common/templates/etc/keystone/keystone.conf
@@ -3,8 +3,8 @@ admin_token = {{ secrets.admin_token }}
 
 debug = False
 
-public_endpoint = https://{{ endpoints.keystone }}:5001/v2.0/
-admin_endpoint = https://{{ endpoints.keystone }}:35358/v2.0/
+public_endpoint = https://{{ endpoints.keystone }}:5001/
+admin_endpoint = https://{{ endpoints.keystone }}:35358/
 
 [sql]
 connection=mysql://keystone:{{ secrets.db_password }}@{{ endpoints.db }}/keystone?charset=utf8


### PR DESCRIPTION
Erroneously added the keystone version to this endpoint declaration. It
should simply be the fqdn and port.
