### PR TITLE
rsyncd: Fix misspelled config options

### DIFF
--- a/roles/glance-common/templates/etc/rsyncd.conf
+++ b/roles/glance-common/templates/etc/rsyncd.conf
@@ -1,7 +1,7 @@
 [glance]
-    command = "Glance Images"
+    comment = "Glance Images"
     path = /var/lib/glance/images
-    user chroot = yes
+    use chroot = yes
     read only = yes
     list = yes
     uid = glance


### PR DESCRIPTION
When refactoring the logging code, I spotted numerous references in the syslog file to invalid config options in the `rsyncd.conf` file. Based on the options, I modified them to what I assumed they were meant to be based on the [man page for rsyncd.conf](http://linux.die.net/man/5/rsyncd.conf).

These can be seen in the following example logs:

```
Oct  2 15:20:01 test-controller-0 rsyncd[32766]: Unknown Parameter encountered: "command"
Oct  2 15:20:01 test-controller-0 rsyncd[32766]: IGNORING unknown parameter "command"
Oct  2 15:20:01 test-controller-0 rsyncd[32766]: Unknown Parameter encountered: "user chroot"
Oct  2 15:20:01 test-controller-0 rsyncd[32766]: IGNORING unknown parameter "user chroot"
```

/cc @dlundquist 
