### PR TITLE
cinder: Define cinder.backends in defaults

### DIFF
--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -3,3 +3,4 @@ cinder:
   rev: eedc8eda9bbb
   enabled_backends: None
   default_backend: None
+  backends: []


### PR DESCRIPTION
Fixes failure in current CI runs.
