### PR TITLE
haproxy: Run as haproxy user, not nobody

### DIFF
--- a/roles/controller/handlers/main.yml
+++ b/roles/controller/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
-- name: restart haproxy
-  service: name=haproxy state=restarted
+- name: reload haproxy
+  service: name=haproxy state=reloaded
 
 - name: reload iptables
   shell: iptables-restore --noflush < /etc/network/iptables-firewall

--- a/roles/controller/tasks/haproxy.yml
+++ b/roles/controller/tasks/haproxy.yml
@@ -1,3 +1,3 @@
 ---
 - template: src=etc/haproxy/haproxy.cfg dest=/etc/haproxy/haproxy.cfg mode=0644
-  notify: restart haproxy
+  notify: reload haproxy

--- a/roles/controller/templates/etc/haproxy/haproxy.cfg
+++ b/roles/controller/templates/etc/haproxy/haproxy.cfg
@@ -17,10 +17,10 @@
 global
   log 127.0.0.1 local0
   maxconn 256
-  user nobody
-  group nogroup
+  user haproxy
+  group haproxy
   daemon
-  pidfile /var/run/haproxy.pid
+  pidfile /var/run/haproxy/haproxy.pid
 
 defaults
   log global

--- a/roles/haproxy/handlers/main.yml
+++ b/roles/haproxy/handlers/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: reload haproxy
   service: name=haproxy state=reloaded enabled=yes
+
+- name: restart haproxy
+  service: name=haproxy state=restarted enabled=yes

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -7,15 +7,24 @@
   apt_repository: repo='ppa:blueboxgroup/openstack' update_cache=yes
   when: ansible_distribution_version != "12.04"
 
-- apt: pkg=haproxy
+- name: install haproxy
+  apt: pkg=haproxy
 
-- name: create haproxy directory
+- name: create haproxy config directory
   file: dest=/etc/haproxy state=directory mode=0755
 
+- name: HAProxy defaults
+  template: src=etc/default/haproxy dest=/etc/default/haproxy
+  notify: restart haproxy
+
 - name: install ssl cert+key
-  template: src=etc/haproxy/openstack.pem dest=/etc/haproxy/openstack.pem
+  template: >
+    src=etc/haproxy/openstack.pem
+    dest=/etc/haproxy/openstack.pem
+    owner=haproxy
+    group=haproxy
+    mode=0600
   notify: reload haproxy
   tags:
     - ssl
 
-- lineinfile: dest=/etc/default/haproxy regexp=^ENABLED= line=ENABLED=1

--- a/roles/haproxy/templates/etc/default/haproxy
+++ b/roles/haproxy/templates/etc/default/haproxy
@@ -1,0 +1,13 @@
+# Defaults file for HAProxy
+#
+# This is sourced by both, the initscript and the systemd unit file, so do not
+# treat it as a shell script fragment.
+ENABLED=1
+
+PIDFILE=/var/run/haproxy/haproxy.pid
+
+# Change the config file location if needed
+CONFIG="/etc/haproxy/haproxy.cfg"
+
+# Add extra flags here, see haproxy(1) for a few options
+#EXTRAOPTS="-de -m 16"


### PR DESCRIPTION
Fix permissions on the TLS certificate and run the HAProxy service as
the haproxy user and group. This is a limited account created via the
haproxy package.

Explicitly define the PIDFILE to be used to override and default which
may change between the service script and haproxy.cfg.
