### PR TITLE
Update custom vars plugin for Ansible 1.7+

### DIFF
--- a/bin/ursula
+++ b/bin/ursula
@@ -108,7 +108,6 @@ main() {
   done
 }
 
-check_common_deps
 process_opts "$@"
 set_vars
 main

--- a/share/common
+++ b/share/common
@@ -1,10 +1,6 @@
 set -e
 
 # Shared amongst test suite and ursula binaries
-check_common_deps() {
-  ansible --version | grep "ansible 1.[456]" >/dev/null || die "[Error] Ansible 1.4 - 1.6 is required."
-}
-
 ansible_command() {
   local inventory=$1
   local user=$2

--- a/test/check-deps
+++ b/test/check-deps
@@ -6,6 +6,4 @@ which nova >/dev/null || die "nova client must be present"
 
 which ansible-playbook >/dev/null || die "ansible-playbook must be present"
 
-check_common_deps
-
 [ -e ${STACK_RC} ] || die "${STACK_RC} must be present"


### PR DESCRIPTION
With the introduction of Ansbile 1.7, our var plugin broke due to
incompatible changes upstream. Update the plugin so that we can make
use of the new Ansible releases.

!version-patch
