### PR TITLE
Convert ovs-bridge module to python

### DIFF
--- a/library/ovs_bridge
+++ b/library/ovs_bridge
@@ -1,22 +1,64 @@
-#!/usr/bin/env ruby
-require 'rubygems'
-require 'antsy'
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
-args = Antsy.args
-name = args[:name]
-state = args[:state]
+# Copyright 2014, Blue Box Group, Inc.
+# Copyright 2014, Craig Tracey <craigtracey@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-Antsy.fail! "bad bridge name: '#{name}'" unless name  and name  =~ /\w+/
-Antsy.fail! "bad state: '#{state}'"      unless state and state == 'present'
-Antsy.fail! 'ovs-vsctl is not present'   unless system 'which ovs-vsctl'
+import re
+import subprocess
 
-if system "ovs-vsctl list-br | grep #{args[:name]}"
-  Antsy.no_change!
-else
-  add_cmd = "ovs-vsctl add-br #{args[:name]}"
-  if system add_cmd
-    Antsy.changed!
-  else
-    Antsy.fail! "failed to add bridge with command: #{add_cmd}"
-  end
-end
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(default=None, required=True),
+            state=dict(default='present'),
+        )
+    )
+
+    try:
+        if not re.match('\w+', module.params['name']):
+            module.fail_json(msg="invalid bridge name: %s" %
+                             (module.params['name']))
+
+        cmd = ["which", "ovs-vsctl"]
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        ovs_cmd = p.stdout.readlines()
+        if len(ovs_cmd) == 0:
+            module.fail_json(msg="ovs-vsctl could not be found")
+
+        ovs_cmd = ovs_cmd[0].strip()
+        cmd = [ovs_cmd, "list-br"]
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        bridges = p.stdout.readlines()
+        for bridge in bridges:
+            if bridge.strip() == module.params['name']:
+                module.exit_json(changed=False, result="ok")
+
+        cmd = [ovs_cmd, "add-br", module.params['name']]
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        out, err = p.communicate()
+        if p.returncode != 0:
+            module.fail_json(msg="failed to create bridge. out: %s; err: %s" %
+                             (out, err))
+        module.exit_json(changed=True, result="changed")
+    except Exception as e:
+        module.fail_json(msg="ovs_bridge error: %s" % (str(e)))
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()


### PR DESCRIPTION
Vagrant runs were failing on 'ovs br-int'. On the surface it looked like
this call was hanging in ruby. Therefore, I moved this module to python.
Turns out that this was not the root cause, but the work was already
done.

!version-minor
