### PR TITLE
bootstrap: fix locale command

### DIFF
--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -5,7 +5,6 @@
 - hosts: compute
   serial: 10
   vars:
-    locale: en_US
     timezone: Etc/UTC
   tasks:
   # Bail if run against existing compute nodes
@@ -41,9 +40,9 @@
 
   # Set Locale
   - name: Generate locales
-    command: /usr/sbin/locale-gen {{ locale }}
-  - name: set locale to {{ locale }}
-    command: /usr/sbin/update-locale LANG={{ locale }}.UTF-8 LC_ALL={{ locale }}.UTF-8
+    command: /usr/sbin/locale-gen en_US
+  - name: set locale to en_US.UTF-8
+    command: /usr/sbin/update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 
   # Set Time zone
   - name: set /etc/localtime to {{ timezone }}

--- a/playbooks/testenv/tasks/pre-deploy.yml
+++ b/playbooks/testenv/tasks/pre-deploy.yml
@@ -27,7 +27,7 @@
   - name: Generate en_US locale
     command: /usr/sbin/locale-gen en_US
   - name: set locale to en_US
-    command: /usr/sbin/update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8  
+    command: /usr/sbin/update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
   - name: add an apt proxy
     template: src=../../../roles/common/templates/etc/apt/apt.conf.d/01proxy dest=/etc/apt/apt.conf.d/01proxy owner=root group=root mode=0644
     when: common.apt_cache is defined


### PR DESCRIPTION
also added the locale to the testenv pre-deploy.yml,
machines spun up by test was giving locale errors in
shell.

there's a few items in the two that should
be DRYed up a little.
