### PR TITLE
logging: haproxy to /var/log/haproxy.log

### DIFF
--- a/roles/haproxy/templates/etc/haproxy/haproxy.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy.cfg
@@ -15,7 +15,7 @@
     {% set _ = haproxy_services.append(['heat-cfn', 8000, 8001, false]) %}
 {% endif -%}
 global
-  log 127.0.0.1 local0
+  log /dev/log local0  # Log via local socket to use $programname
   maxconn 256
   user haproxy
   group haproxy

--- a/roles/logging/files/etc/rsyslog.d/49-haproxy.conf
+++ b/roles/logging/files/etc/rsyslog.d/49-haproxy.conf
@@ -1,0 +1,7 @@
+# Create an additional socket in haproxy's chroot in order to allow logging via
+# /dev/log to chroot'ed HAProxy processes
+$AddUnixListenSocket /var/lib/haproxy/dev/log
+
+# Write HAProxy messages to async dedicated logfile
+if $programname startswith 'haproxy' then -/var/log/haproxy.log
+& stop

--- a/roles/logging/tasks/main.yml
+++ b/roles/logging/tasks/main.yml
@@ -22,6 +22,10 @@
   template: src=etc/rsyslog.d/udp.conf dest=/etc/rsyslog.d/udp.conf mode=0644
   notify: restart rsyslog
 
+- name: send haproxy logs to local file
+  copy: src=etc/rsyslog.d/49-haproxy.conf dest=/etc/rsyslog.d/49-haproxy.conf mode=0644
+  notify: restart rsyslog
+
 - name: send swift logs to local file
   copy: src=etc/rsyslog.d/49-swift.conf dest=/etc/rsyslog.d/49-swift.conf mode=0644
   notify: restart rsyslog


### PR DESCRIPTION
This fixes the HAProxy logging issue we were running into. I previously changed `haproxy.cfg` to log over `udp/localhost:514` but that loses the ability for rsyslog to test based on the `$programname` field. We also now explicitly lay down and override the `49-haproxy.conf` that comes from the PPA.

@dlundquist @paulczar @craigtracey 
