### PR TITLE
pep8: Exclude vendored plugins, known bad files

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,5 @@ commands =
 [pep8]
 show-source = True
 ignore =
-builtins = _
 exclude=.venv,.git,.tox,doc,*lib/python*,*egg,build,check_3ware_raid.py,migrate_to_ml2.py,plugins/,local_settings.py
 


### PR DESCRIPTION
Simply exclude known bad files instead of fixing all vendored content. Was #544.

@craigtracey 
