### PR TITLE
openstack-setup: fix setup with public CA signed cert

### DIFF
--- a/roles/openstack-setup/tasks/images.yml
+++ b/roles/openstack-setup/tasks/images.yml
@@ -9,5 +9,4 @@
     login_tenant_name=admin
     login_password={{ secrets.admin_password }}
     timeout=12000
-    cacert=/opt/stack/ssl/openstack.crt
   with_items: glance.images

--- a/roles/openstack-setup/tasks/networks.yml
+++ b/roles/openstack-setup/tasks/networks.yml
@@ -11,7 +11,6 @@
     auth_url=https://{{ endpoints.main }}:5001/v2.0/
     login_tenant_name=admin
     login_password={{ secrets.admin_password }}
-    cacert=/opt/stack/ssl/openstack.crt
   with_items: neutron.networks
 
 - name: neutron subnets
@@ -26,7 +25,6 @@
     auth_url=https://{{ endpoints.main }}:5001/v2.0/
     login_tenant_name=admin
     login_password={{ secrets.admin_password }}
-    cacert=/opt/stack/ssl/openstack.crt
   with_items: neutron.subnets
 
 - name: neutron routers
@@ -38,7 +36,6 @@
     auth_url=https://{{ endpoints.main }}:5001/v2.0/
     login_tenant_name=admin
     login_password={{ secrets.admin_password }}
-    cacert=/opt/stack/ssl/openstack.crt
   with_items: neutron.routers
 
 - name: neutron routers gateways
@@ -49,7 +46,6 @@
     auth_url=https://{{ endpoints.main }}:5001/v2.0/
     login_tenant_name=admin
     login_password={{ secrets.admin_password }}
-    cacert=/opt/stack/ssl/openstack.crt
   with_items: neutron.routers
 
 - name: neutron router interfaces
@@ -61,5 +57,4 @@
     auth_url=https://{{ endpoints.main }}:5001/v2.0/
     login_tenant_name=admin
     login_password={{ secrets.admin_password }}
-    cacert=/opt/stack/ssl/openstack.crt
   with_items: neutron.router_interfaces


### PR DESCRIPTION
New Ansible doesn't support use of Jinja here, but since we install the
stack's certificate in to the CA local CA chain and we are running setup
commands from the controller we don't need to specify the cacert.
