### PR TITLE
Define glance's database sync syntax

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -116,6 +116,7 @@
       tags: ['openstack', 'glance', 'control']
     - role: openstack-database
       database_name: glance
+      db_sync: 'db sync'
       tags: ['openstack', 'glance', 'control']
 
 - name: nova control plane


### PR DESCRIPTION
Not sure why this wasn't defined previously, but glance uses "db sync"
instead of our default of "db_sync".
