### PR TITLE
Clean up glance role

### DIFF
--- a/roles/glance/tasks/image-sync.yml
+++ b/roles/glance/tasks/image-sync.yml
@@ -3,7 +3,7 @@
 
 - name: stop btsync
   service: name=btsync state=stopped enabled=false
-  ignore_errors: yes
+  failed_when: False
 
 - name: remove btsync
   apt: pkg=btsync state=absent
@@ -11,24 +11,35 @@
 - name: btsync config
   file: dest=/etc/btsync/glance-cache.conf state=absent
 
-- apt: pkg=rsync
+- name: install rsync
+  apt: pkg=rsync
 
-- lineinfile: dest=/etc/default/rsync regexp=^RSYNC_ENABLE line=RSYNC_ENABLE=true
+- name: rsync defaults
+  lineinfile: dest=/etc/default/rsync regexp={{ item.value.regexp }}
+              line={{ item.value.line }}
+  with_dict:
+    enable:
+      regexp: ^RSYNC_ENABLE
+      line: RSYNC_ENABLE=true
+    nice:
+      regexp: ^RSYNC_NICE
+      line: RSYNC_NICE=10
+    ionice:
+      regexp: ^RSYNC_IONICE
+      line: "RSYNC_IONICE='-c3'"
   notify:
     - restart rsync
 
-- lineinfile: dest=/etc/default/rsync regexp=^RSYNC_NICE line=RSYNC_NICE=10
+- name: configure rsync
+  template: src=etc/rsyncd.conf dest=/etc/rsyncd.conf mode=0644
   notify:
     - restart rsync
 
-- lineinfile: dest=/etc/default/rsync regexp=^RSYNC_IONICE line=RSYNC_IONICE='-c3'
-  notify:
-    - restart rsync
+- meta: flush_handlers
 
-- template: src=etc/rsyncd.conf dest=/etc/rsyncd.conf mode=0644
-  notify:
-    - restart rsync
+- name: start rsync
+  service: name=rsync state=started enabled=yes
 
-- service: name=rsync state=started enabled=yes
-
-- template: src=etc/cron.d/glance-image-sync dest=/etc/cron.d/glance-image-sync mode=0640
+- name: glance image sync cron
+  template: src=etc/cron.d/glance-image-sync dest=/etc/cron.d/glance-image-sync
+            mode=0640

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -2,23 +2,22 @@
 - name: Check if glance user exists
   action: shell getent passwd glance
   register: glance_user
-  ignore_errors: True
+  failed_when: False
   changed_when: False
 
 - name: glance user
   user: name=glance shell=/bin/false createhome=no
-  when: glance_user.rc == 0
+  when: glance_user|success
 
 - name: glance user
   user: name=glance comment=glance shell=/bin/false system=yes home=/nonexistent createhome=no
-  when: glance_user.rc != 0
+  when: glance_user|failed
 
 - name: get glance source repo
-  git: |
-    repo={{ openstack.git_mirror }}/glance.git
-    dest=/opt/stack/glance
-    version={{ glance.rev }}
-    update={{ openstack.git_update }}
+  git: repo={{ openstack.git_mirror }}/glance.git
+       dest=/opt/stack/glance
+       version={{ glance.rev }}
+       update={{ openstack.git_update }}
   register: result
   until: result|success
   retries: 3
@@ -26,21 +25,26 @@
   notify:
     - pip install glance
     - restart glance services
+
 - meta: flush_handlers
 
 - name: /etc/glance
   file: dest=/etc/glance state=directory
 
-- file: dest=/var/lib/glance state=directory owner=glance group=glance
-- file: dest=/var/lib/glance/images state=directory owner=glance group=glance
-- file: dest=/var/cache/glance state=directory mode=0700 owner=glance group=glance
-- file: dest=/var/log/glance state=directory mode=0755 owner=glance group=glance
+- name: glance images dir
+  file: dest=/var/lib/glance/images state=directory owner=glance group=glance
+
+- name: glance cache dir
+  file: dest=/var/cache/glance state=directory mode=0700 owner=glance
+        group=glance
+
+- name: glance log dir
+  file: dest=/var/log/glance state=directory mode=0755 owner=glance group=glance
 
 - name: install glance services
-  upstart_service: |
-    name={{ item }}
-    user=glance
-    cmd=/usr/local/bin/{{ item }}
+  upstart_service: name={{ item }}
+                   user=glance
+                   cmd=/usr/local/bin/{{ item }}
   with_items:
     - glance-api
     - glance-registry
@@ -52,7 +56,7 @@
     - glance-registry
 
 - name: glance config
-  action: template src={{ item }} dest=/etc/glance mode=0644
+  template: src={{ item }} dest=/etc/glance mode=0644
   with_fileglob: ../templates/etc/glance/*
   notify:
     - restart glance services
@@ -63,6 +67,5 @@
     - 9292
     - 9293
 
-- name: setup glance image replication
-  include: image-sync.yml
+- include: image-sync.yml
   when: glance.sync.enabled


### PR DESCRIPTION
Add names to tasks, use failed_when, add a handler flush to avoid
restarting glance twice, loop over lineinfile, remove name on include,
whitespace.
