### PR TITLE
Use failed_when instead of ignore_errors

### DIFF
--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -69,4 +69,4 @@
   - shell: ovs-vsctl --may-exist add-port br-eth0 eth0 < /dev/null > /dev/null && reboot
     async: 0
     poll: 0
-    ignore_errors: true
+    failed_when: False

--- a/playbooks/bootstrap_ml2.yml
+++ b/playbooks/bootstrap_ml2.yml
@@ -66,6 +66,6 @@
   - command: shutdown -r now
     async: 0
     poll: 0
-    ignore_errors: true
+    failed_when: False
 
 

--- a/playbooks/fix-nova-user.yml
+++ b/playbooks/fix-nova-user.yml
@@ -9,7 +9,7 @@
 
     - name: stop nova services
       shell: ls /etc/init/{{ item }}.conf && service {{ item }} stop
-      ignore_errors: True
+      failed_when: False
       with_items:
         - nova-api
         - nova-consoleauth

--- a/playbooks/testenv/tasks/keypair.yml
+++ b/playbooks/testenv/tasks/keypair.yml
@@ -2,7 +2,7 @@
 - name: test for presence of local keypair
   command: cat {{ testenv_keypair_path }}
   register: testenv_keypair_local
-  ignore_errors: True
+  failed_when: False
   changed_when: False
 
 - name: delete remote keypair

--- a/playbooks/testenv/tasks/pre-deploy.yml
+++ b/playbooks/testenv/tasks/pre-deploy.yml
@@ -66,5 +66,5 @@
     command: shutdown -r now
     async: 0
     poll: 0
-    ignore_errors: true
+    failed_when: False
 

--- a/playbooks/tests/tasks/cleanup.yml
+++ b/playbooks/tests/tasks/cleanup.yml
@@ -3,10 +3,10 @@
   tasks:
   - name: cleanup test instance, key-pair and security group
     shell: . /root/stackrc; nova delete turtle-stack && sleep 30
-    ignore_errors: True
+    failed_when: False
   - name: cleanup test instance, key-pair and security group
     shell: . /root/stackrc; nova secgroup-delete turtle-sec
-    ignore_errors: True
+    failed_when: False
   - name: cleanup test instance, key-pair and security group
     shell: . /root/stackrc; nova keypair-delete turtle-key
-    ignore_errors: True
+    failed_when: False

--- a/roles/neutron-data-network/handlers/main.yml
+++ b/roles/neutron-data-network/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: ifup br-ex
   command: ifup br-ex
-  ignore_errors: True
+  failed_when: False
 
 - name: restart xorp
   service: name=xorp state=restarted sleep=10


### PR DESCRIPTION
ignore_errors still displays red on the screen and it looks like a
failed task. Makes it difficult to grep logs and visually inspect
output. failed_when does not do this, instead it just looks as if it
were a success, which is what we're after. The return json still marks
the task as failed so we can use that data elsewhere if desired.

This is a pet-peeve style fix applied across the files without looking at anything else in those files.
