### PR TITLE
Flush swift handlers before service start

### DIFF
--- a/roles/swift-account/tasks/main.yml
+++ b/roles/swift-account/tasks/main.yml
@@ -13,6 +13,8 @@
             dest=/etc/swift/account-server.conf owner=root group=root
   notify: restart swift-account service
 
+- meta: flush_handlers
+
 - name: start swift-account services
   service: name={{ item }} state=started
   with_items:

--- a/roles/swift-container/tasks/main.yml
+++ b/roles/swift-container/tasks/main.yml
@@ -14,6 +14,8 @@
             dest=/etc/swift/container-server.conf owner=root group=root
   notify: restart swift-container service
 
+- meta: flush_handlers
+
 - name: start swift-container services
   service: name={{ item }} state=started
   with_items:

--- a/roles/swift-object/tasks/main.yml
+++ b/roles/swift-object/tasks/main.yml
@@ -16,6 +16,8 @@
             owner=root group=root mode=0644
   notify: restart swift-object service
 
+- meta: flush_handlers
+
 - name: start swift-object services
   service: name={{ item }} state=started
   with_items:

--- a/roles/swift-proxy/tasks/main.yml
+++ b/roles/swift-proxy/tasks/main.yml
@@ -16,5 +16,7 @@
             owner=root group=root mode=0644
   notify: restart swift-proxy service
 
+- meta: flush_handlers
+
 - name: start swift-proxy service
   service: name=swift-proxy state=started


### PR DESCRIPTION
Flushing the handlers means non-running services will get started, and
then the task to ensure the service is running will be unchanged.
Without flushing handlers a scenario can happen that will result in a
service being started and then immediately restarted.

fixes #595
