### PR TITLE
Restart appropriate heat services on change

### DIFF
--- a/roles/heat/handlers/main.yml
+++ b/roles/heat/handlers/main.yml
@@ -1,3 +1,12 @@
 ---
 - name: pip install heat
   shell: pip install -i {{ openstack.pypi_mirror }} /opt/stack/heat
+
+- name: restart heat-api
+  service: name=heat-api state=restarted
+
+- name: restart heat-api-cfn
+  service: name=heat-api state=restarted
+
+- name: restart heat-engine
+  service: name=heat-engine state=restarted

--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -21,12 +21,17 @@
 
 - name: heat config
   template: src=etc/heat/heat.conf dest=/etc/heat/heat.conf mode=0644
+  notify:
+    - restart heat-api
+    - restart heat-api-cfn
+    - restart heat-engine
 
 - name: heat policy config
   template: src=etc/heat/policy.json dest=/etc/heat/policy.json mode=0644
 
 - name: heat paste config
   template: src=etc/heat/api-paste.ini dest=/etc/heat/api-paste.ini mode=0644
+  notify: restart heat-api
 
 - name: install heat services
   upstart_service: name={{ item }}
@@ -36,6 +41,8 @@
     - heat-api
     - heat-api-cfn
     - heat-engine
+
+- meta: flush_handlers
 
 - name: start heat services
   service: name={{ item }} state=started


### PR DESCRIPTION
From dev IRC,  heat.conf should cause all to restart, api-paste should
cause api to restart, and policy.json is re-read automatically on
change.

fixes #599
