### PR TITLE
fix nbd mispelling in /etc/modules

### DIFF
--- a/roles/nova-data/tasks/main.yml
+++ b/roles/nova-data/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - file: dest=/var/lib/nova/instances state=directory owner=nova
 
-- lineinfile: dest=/etc/modules line="ndb"
+- lineinfile: dest=/etc/modules line="nbd"
 
 - modprobe: name=nbd state=present
 


### PR DESCRIPTION
/etc/modules had nbd spelled incorrectly
