### PR TITLE
Update config files and libraries for insecure

### DIFF
--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -328,3 +328,6 @@ ssl:
 common:
   ipmi:
     enabled: false
+
+ironic:
+  enabled: false

--- a/library/glance_image
+++ b/library/glance_image
@@ -135,7 +135,8 @@ def _get_ksclient(module, kwargs):
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
                                  auth_url=kwargs.get('auth_url'),
-                                 cacert=kwargs.get('cacert'))
+                                 cacert=kwargs.get('cacert'),
+                                 insecure=kwargs.get('insecure'))
     except Exception as e:
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
     return client
@@ -231,10 +232,12 @@ def main():
             copy_from         = dict(default= None),
             timeout           = dict(default=180),
             file              = dict(default=None),
-            state            = dict(default='present', choices=['absent', 'present'])
+            state             = dict(default='present', choices=['absent', 'present']),
+            insecure          = dict(required=False, default=False, choices=BOOLEANS),
         ),
         mutually_exclusive = [['file','copy_from']],
     )
+    module.params['insecure'] = module.boolean(module.params['insecure'])
     if module.params['state'] == 'present':
         if not module.params['file'] and not module.params['copy_from']:
             module.fail_json(msg = "Either file or copy_from variable should be set to create the image")

--- a/library/neutron_network
+++ b/library/neutron_network
@@ -124,7 +124,8 @@ def _get_ksclient(module, kwargs):
         kclient = ksclient.Client(username=kwargs.get('login_username'),
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
-                                 auth_url=kwargs.get('auth_url'))
+                                 auth_url=kwargs.get('auth_url'),
+                                 insecure=kwargs.get('insecure'))
     except Exception as e:
         module.fail_json(msg = "Error authenticating to the keystone: %s" %e.message)
     global _os_keystone
@@ -246,9 +247,12 @@ def main():
             router_external = dict(default=False, type='bool'),
             shared = dict(default=False, type='bool'),
             admin_state_up = dict(default=True, type='bool'),
-            state = dict(default='present', choices=['absent', 'present'])
+            state = dict(default='present', choices=['absent', 'present']),
+            insecure = dict(required=False, default=False, choices=BOOLEANS),
         ),
     )
+
+    module.params['insecure'] = module.boolean(module.params['insecure'])
 
     if module.params['provider_network_type'] in ['vlan' , 'flat']:
             if not module.params['provider_physical_network']:

--- a/library/neutron_router
+++ b/library/neutron_router
@@ -91,7 +91,8 @@ def _get_ksclient(module, kwargs):
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
                                  auth_url=kwargs.get('auth_url'),
-                                 cacert=kwargs.get('cacert'))
+                                 cacert=kwargs.get('cacert'),
+                                 insecure=kwargs.get('insecure'))
     except Exception as e:
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
     global _os_keystone
@@ -180,8 +181,11 @@ def main():
         tenant_name                     = dict(default=None),
         state                           = dict(default='present', choices=['absent', 'present']),
         admin_state_up                  = dict(type='bool', default=True),
+        insecure                        = dict(required=False, default=False, choices=BOOLEANS),
         ),
     )
+
+    module.params['insecure'] = module.boolean(module.params['insecure'])
 
     neutron = _get_neutron_client(module, module.params)
     _set_tenant_id(module)

--- a/library/neutron_router_gateway
+++ b/library/neutron_router_gateway
@@ -85,7 +85,8 @@ def _get_ksclient(module, kwargs):
         kclient = ksclient.Client(username=kwargs.get('login_username'),
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
-                                 auth_url=kwargs.get('auth_url'))
+                                 auth_url=kwargs.get('auth_url'),
+                                 insecure=kwargs.get('insecure'))
     except Exception as e:
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
     global _os_keystone
@@ -182,8 +183,11 @@ def main():
             router_name = dict(required=True),
             network_name = dict(required=True),
             state = dict(default='present', choices=['absent', 'present']),
+            insecure = dict(required=False, default=False, choices=BOOLEANS),
         ),
     )
+
+    module.params['insecure'] = module.boolean(module.params['insecure'])
 
     neutron = _get_neutron_client(module, module.params)
     router_id = _get_router_id(module, neutron)

--- a/library/neutron_router_interface
+++ b/library/neutron_router_interface
@@ -89,7 +89,8 @@ def _get_ksclient(module, kwargs):
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
                                  auth_url=kwargs.get('auth_url'),
-                                 cacert=kwargs.get('cacert'))
+                                 cacert=kwargs.get('cacert'),
+                                 insecure=kwargs.get('insecure'))
     except Exception as e:
         module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
     global _os_keystone
@@ -210,8 +211,11 @@ def main():
             subnet_name                     = dict(required=True),
             tenant_name                     = dict(default=None),
             state                           = dict(default='present', choices=['absent', 'present']),
+            insecure                        = dict(required=False, default=False, choices=BOOLEANS),
         ),
     )
+
+    module.params['insecure'] = module.boolean(module.params['insecure'])
 
     neutron = _get_neutron_client(module, module.params)
     _set_tenant_id(module)

--- a/library/neutron_subnet
+++ b/library/neutron_subnet
@@ -117,7 +117,8 @@ def _get_ksclient(module, kwargs):
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
                                  auth_url=kwargs.get('auth_url'),
-                                 cacert=kwargs.get('cacert'))
+                                 cacert=kwargs.get('cacert'),
+                                 insecure=kwargs.get('insecure'))
     except Exception as e:
         module.fail_json(msg = "Error authenticating to the keystone: %s" %e.message)
     global _os_keystone
@@ -250,8 +251,11 @@ def main():
             gateway_ip              = dict(default=None),
             allocation_pool_start   = dict(default=None),
             allocation_pool_end     = dict(default=None),
+            insecure                = dict(required=False, default=False, choices=BOOLEANS),
         ),
     )
+    module.params['insecure'] = module.boolean(module.params['insecure'])
+
     neutron = _get_neutron_client(module, module.params)
     _set_tenant_id(module)
     if module.params['state'] == 'present':

--- a/roles/glance/templates/etc/glance/glance-api.conf
+++ b/roles/glance/templates/etc/glance/glance-api.conf
@@ -37,6 +37,9 @@ admin_tenant_name = service
 admin_user = glance
 admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/glance/api
+{% if client.self_signed_cert %}
+insecure = True
+{% endif %}
 
 [paste_deploy]
 flavor = keystone

--- a/roles/glance/templates/etc/glance/glance-registry.conf
+++ b/roles/glance/templates/etc/glance/glance-registry.conf
@@ -53,6 +53,9 @@ admin_tenant_name = service
 admin_user = glance
 admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/glance/registry
+{% if client.self_signed_cert %}
+insecure = True
+{% endif %}
 
 [paste_deploy]
 flavor = keystone

--- a/roles/heat/templates/etc/heat/heat.conf
+++ b/roles/heat/templates/etc/heat/heat.conf
@@ -30,3 +30,6 @@ auth_protocol = https
 admin_tenant_name = service
 admin_user = heat
 admin_password = {{ secrets.service_password }}
+{% if client.self_signed_cert %}
+insecure = True
+{% endif %}

--- a/roles/ironic-common/templates/etc/ironic/ironic.conf
+++ b/roles/ironic-common/templates/etc/ironic/ironic.conf
@@ -35,3 +35,6 @@ auth_protocol = https
 admin_tenant_name = service
 admin_user = ironic
 admin_password = {{ secrets.service_password }}
+{% if client.self_signed_cert %}
+insecure = True
+{% endif %}

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -69,6 +69,9 @@ admin_tenant_name = service
 admin_user = neutron
 admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/neutron/api
+{% if client.self_signed_cert %}
+insecure = True
+{% endif %}
 
 [DATABASE]
 sqlalchemy_pool_size = 60

--- a/roles/openstack-setup/tasks/images.yml
+++ b/roles/openstack-setup/tasks/images.yml
@@ -10,5 +10,3 @@
                 timeout=12000
                 insecure={{ client.self_signed_cert|lower }}
   with_items: glance.images
-  tags:
-    - images

--- a/roles/openstack-setup/tasks/images.yml
+++ b/roles/openstack-setup/tasks/images.yml
@@ -8,4 +8,7 @@
                 login_tenant_name=admin
                 login_password={{ secrets.admin_password }}
                 timeout=12000
+                insecure={{ client.self_signed_cert|lower }}
   with_items: glance.images
+  tags:
+    - images

--- a/roles/openstack-setup/tasks/main.yml
+++ b/roles/openstack-setup/tasks/main.yml
@@ -7,5 +7,7 @@
 
 - include: networks.yml
   when: openstack_setup.add_networks|bool or openstack_setup.add_networks is undefined
+  tags:
+    - nets
 
 - include: flavors.yml

--- a/roles/openstack-setup/tasks/main.yml
+++ b/roles/openstack-setup/tasks/main.yml
@@ -7,7 +7,5 @@
 
 - include: networks.yml
   when: openstack_setup.add_networks|bool or openstack_setup.add_networks is undefined
-  tags:
-    - nets
 
 - include: flavors.yml

--- a/roles/openstack-setup/tasks/networks.yml
+++ b/roles/openstack-setup/tasks/networks.yml
@@ -10,6 +10,7 @@
                    auth_url=https://{{ endpoints.main }}:5001/v2.0/
                    login_tenant_name=admin
                    login_password={{ secrets.admin_password }}
+                   insecure={{ client.self_signed_cert|lower }}
   with_items: neutron.networks
 
 - name: neutron subnets
@@ -23,6 +24,7 @@
                   auth_url=https://{{ endpoints.main }}:5001/v2.0/
                   login_tenant_name=admin
                   login_password={{ secrets.admin_password }}
+                  insecure={{ client.self_signed_cert|lower }}
   with_items: neutron.subnets
 
 - name: neutron routers
@@ -33,6 +35,7 @@
                   auth_url=https://{{ endpoints.main }}:5001/v2.0/
                   login_tenant_name=admin
                   login_password={{ secrets.admin_password }}
+                  insecure={{ client.self_signed_cert|lower }}
   with_items: neutron.routers
 
 - name: neutron routers gateways
@@ -42,6 +45,7 @@
                           auth_url=https://{{ endpoints.main }}:5001/v2.0/
                           login_tenant_name=admin
                           login_password={{ secrets.admin_password }}
+                          insecure={{ client.self_signed_cert|lower }}
   with_items: neutron.routers
 
 - name: neutron router interfaces
@@ -52,4 +56,5 @@
                             auth_url=https://{{ endpoints.main }}:5001/v2.0/
                             login_tenant_name=admin
                             login_password={{ secrets.admin_password }}
+                            insecure={{ client.self_signed_cert|lower }}
   with_items: neutron.router_interfaces

--- a/roles/openstack-setup/tasks/users.yml
+++ b/roles/openstack-setup/tasks/users.yml
@@ -11,5 +11,6 @@
                     tenant_name=admin
                     login_user=admin
                     login_password={{ secrets.admin_password }}
+                    insecure={{ client.self_signed_cert|lower }}
   with_items: keystone.services
   when: endpoints[item.name] is defined and endpoints[item.name]


### PR DESCRIPTION
When testing we often use a self-signed CA cert. This leads to problems
with many of the openstack clients as well as the ansible libraries.
Add options to add "insecure = True" for various ursula bits.