### PR TITLE
ansible-lint: use egg_info PR, delays imports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ python-cinderclient
 oslo.utils
 tox
 pep8
- -e git+git://github.com/willthames/ansible-lint.git@1e73fac322fdd3992470969c038de45f515ae2fe#egg=ansible-lint
+-e git://github.com/masteinhauser/ansible-lint.git@egg_info#egg=ansible-lint


### PR DESCRIPTION
Fix for `pip install -r requirements.txt` failure on an environment missing `ansible` already installed.
