### PR TITLE
Use yaml syntax instead of key=value for keypair

### DIFF
--- a/playbooks/testenv/tasks/keypair.yml
+++ b/playbooks/testenv/tasks/keypair.yml
@@ -12,6 +12,8 @@
   register: testenv_keypair
 
 - name: persist the keypair
-  copy: dest={{ testenv_keypair_path }} content={{ testenv_keypair.key }}
-        mode=0600
+  copy:
+    dest: "{{ testenv_keypair_path }}"
+    content: "{{ testenv_keypair.key }}"
+    mode: 0600
   when: testenv_keypair.changed


### PR DESCRIPTION
The key value is multiline and needs to be done with yaml syntax,
otherwise it'll get double white spaces.

See https://github.com/ansible/ansible-modules-core/issues/33
