### PR TITLE
Set auth_uri for swift proxy server

### DIFF
--- a/roles/swift-proxy/templates/etc/swift/proxy-server.conf
+++ b/roles/swift-proxy/templates/etc/swift/proxy-server.conf
@@ -52,6 +52,7 @@ use = egg:swift#proxy_logging
 
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+auth_uri = https://{{ endpoints.keystone }}:5001/
 auth_host = {{ endpoints.keystone }}
 auth_port = 5001
 admin_password = {{ secrets.service_password }}


### PR DESCRIPTION
Not only does the service complain that this should be set, but under
certain scenarios and keystone middleware versions, this is flat out
broken.
