### PR TITLE
mysql: timeout locks every 30 minutes rather than 1 year

### DIFF
--- a/roles/percona-server/templates/etc/mysql/conf.d/tuning.cnf
+++ b/roles/percona-server/templates/etc/mysql/conf.d/tuning.cnf
@@ -2,3 +2,4 @@
 
 max_connections = 512
 innodb_log_file_size=50331648
+lock_wait_timeout = 1800


### PR DESCRIPTION
Applying this to master too.
