### PR TITLE
swift: backport logging fixes for 1.0.x upgrade

### DIFF
--- a/roles/swift-common/files/etc/logrotate.d/swift
+++ b/roles/swift-common/files/etc/logrotate.d/swift
@@ -1,0 +1,11 @@
+/var/log/swift/*.log {
+	daily
+	missingok
+	rotate 7
+	compress
+	notifempty
+	nocreate
+	postrotate
+		reload rsyslog >/dev/null 2>&1 || true
+	endscript
+}

--- a/roles/swift-common/files/etc/rsyslog.d/49-swift.conf
+++ b/roles/swift-common/files/etc/rsyslog.d/49-swift.conf
@@ -1,0 +1,28 @@
+if $programname == 'proxy-server' then /var/log/swift/proxy-server.log
+& stop
+if $programname == 'account-server' then /var/log/swift/account-server.log
+& stop
+if $programname == 'account-replicator' then /var/log/swift/account-replicator.log
+& stop
+if $programname == 'account-auditor' then /var/log/swift/account-auditor.log
+& stop
+if $programname == 'account-reaper' then /var/log/swift/account-reaper.log
+& stop
+if $programname == 'container-server' then /var/log/swift/container-server.log
+& stop
+if $programname == 'container-replicator' then /var/log/swift/container-replicator.log
+& stop
+if $programname == 'container-updater' then /var/log/swift/container-updater.log
+& stop
+if $programname == 'container-auditor' then /var/log/swift/container-auditor.log
+& stop
+if $programname == 'container-sync' then /var/log/swift/container-sync.log
+& stop
+if $programname == 'object-server' then /var/log/swift/object-server.log
+& stop
+if $programname == 'object-replicator' then /var/log/swift/object-replicator.log
+& stop
+if $programname == 'object-updater' then /var/log/swift/object-updater.log
+& stop
+if $programname == 'object-auditor' then /var/log/swift/object-auditor.log
+& stop

--- a/roles/swift-common/handlers/main.yml
+++ b/roles/swift-common/handlers/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: restart rsync
   service: name=rsync state=restarted
+
+- name: restart rsyslog
+  service: name=rsyslog state=restarted

--- a/roles/swift-common/tasks/main.yml
+++ b/roles/swift-common/tasks/main.yml
@@ -21,6 +21,16 @@
 - name: setup swiftops sudoers
   template: src=etc/sudoers.d/swiftops dest=/etc/sudoers.d/swiftops owner=root group=root mode=0440
 
+- name: create swift log files directory
+  file: dest=/var/log/swift state=directory owner=syslog group=adm mode=0755
+
+- name: send swift logs to local files
+  copy: src=etc/rsyslog.d/49-swift.conf dest=/etc/rsyslog.d/49-swift.conf mode=0644
+  notify: restart rsyslog
+
+- name: log rotate swift log files
+  copy: src=etc/logrotate.d/swift dest=/etc/logrotate.d/swift mode=0644
+
 - name: get swifttool repo
   git: |
     repo=https://github.com/blueboxgroup/swifttool.git


### PR DESCRIPTION
This is further Swift logging cleanup task which @craigtracey implemented on during the 1.0.x upgrade. It can be backported, but might be considered a feature too and could simply be used for future releases.

/cc @dlundquist