### PR TITLE
GRUB boot options

### DIFF
--- a/roles/common/tasks/kernel-tuning.yml
+++ b/roles/common/tasks/kernel-tuning.yml
@@ -5,3 +5,11 @@
             mode=0644
   notify:
     - apply-sysctl
+
+- name: "Kernel boot parameters: disable console screen blanking, enabled serial console on IPMI serial over LAN"
+  lineinfile: dest=/etc/default/grub
+              regexp="^GRUB_CMDLINE_LINUX_DEFAULT="
+              line='GRUB_CMDLINE_LINUX_DEFAULT="console=tty0 console=ttyS2,115200n8 consoleblank=0"'
+
+- name: Update GRUB configuration
+  command: /usr/sbin/update-grub


### PR DESCRIPTION
1. Disable console blanking
2. Disable boot splash screen
3. Enable kernel console on ttyS2 (IPMI serial over LAN)

We can test console blanking by writing to
/sys/module/kernel/parameters/panic
