### PR TITLE
Fix IPMI console config to work with our HW

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -7,5 +7,6 @@ common:
       - megacli
   ipmi:
     enabled: True
+    serial_console: ttyS1
   python_extra_packages: []
   ssh_private_keys: []

--- a/roles/common/files/sensu_plugins/check-kernel-options.rb
+++ b/roles/common/files/sensu_plugins/check-kernel-options.rb
@@ -19,13 +19,13 @@ require 'socket'
 class CheckKernelOptions < Sensu::Plugin::Check::CLI
 
   def run
-    contents = File::open('/proc/cmdline', 'r'){|io| io.read}
+    kernel_cmd_line = File::open('/proc/cmdline', 'r'){ |io| io.read }
 
     [
-        'console=ttyS2,115200n8',
-        'consoleblank=0'
+        'consoleblank=0',
+        /console=ttyS\d+,115200n8/
     ].each do |option|
-        warning "Kernel not booted without #{option}" unless contents.include?(option)
+        warning "Kernel booted without #{option}" unless kernel_cmd_line.match(option)
     end
 
     ok "Kernel boot options appear good"

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -11,4 +11,7 @@
 - name: apply-sysctl
   shell: "cat /etc/sysctl.conf /etc/sysctl.d/*.conf | sysctl -e -p -"
 
+- name: update grub config
+  command: /usr/sbin/update-grub
+
 - include: ssh.yml

--- a/roles/common/tasks/ipmi.yml
+++ b/roles/common/tasks/ipmi.yml
@@ -10,4 +10,4 @@
     - ipmi_msghandler
 
 - name: IPMI serial over LAN console
-  template: src=etc/init/ttyS2.conf dest=/etc/init/ttyS2.conf
+  template: src=etc/init/tty_ipmi_console.conf dest=/etc/init/{{ common.ipmi.serial_console }}.conf

--- a/roles/common/tasks/kernel-tuning.yml
+++ b/roles/common/tasks/kernel-tuning.yml
@@ -9,7 +9,5 @@
 - name: "Kernel boot parameters: disable console screen blanking, enabled serial console on IPMI serial over LAN"
   lineinfile: dest=/etc/default/grub
               regexp="^GRUB_CMDLINE_LINUX_DEFAULT="
-              line='GRUB_CMDLINE_LINUX_DEFAULT="console=tty0 console=ttyS2,115200n8 consoleblank=0"'
-
-- name: Update GRUB configuration
-  command: /usr/sbin/update-grub
+              line="GRUB_CMDLINE_LINUX_DEFAULT=\"console=tty1 console={{ common.ipmi.serial_console }},115200n8 consoleblank=0\""
+  notify: update grub config

--- a/roles/common/templates/etc/init/tty_ipmi_console.conf
+++ b/roles/common/templates/etc/init/tty_ipmi_console.conf
@@ -1,6 +1,6 @@
-# ttyS2 - getty
+# {{ common.ipmi.serial_console }} - getty
 #
-# This service maintains a getty on ttyS2 from the point the system is
+# This service maintains a getty on {{ common.ipmi.serial_console }} from the point the system is
 # started until it is shut down again.
 
 start on stopped rc RUNLEVEL=[2345] and (
@@ -11,5 +11,5 @@ start on stopped rc RUNLEVEL=[2345] and (
 stop on runlevel [!2345]
 
 respawn
-exec /sbin/getty -L ttyS2 115200 vt100
+exec /sbin/getty -L {{ common.ipmi.serial_console }} 115200 vt100
 


### PR DESCRIPTION
The IPMI console on most of our currently deployed systems is wired to ttyS1,
while on other systems its ttyS2. Move this into a configuration
parameter `common.ipmi.serial_console`.

Update check-kernel-options to accept a console on either port and fix
double negative in warning message.

Configure primary kernel console on virtual tty 1, rather than 0 so
we can switch back to it and login prompt appears after boot as
expected.

Move update-grub into a handler
