### PR TITLE
Update ursula to test from our own ansible fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git://github.com/blueboxgroup/ansible@v1.8.2-bbg#egg=ansble
+-e git://github.com/blueboxgroup/ansible@v1.8.2-bbg#egg=ansible
 python-novaclient==2.19.0
 python-neutronclient==2.3.6
 python-keystoneclient

--- a/test/setup
+++ b/test/setup
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
-virtualenv $HOME/.venv
-source $HOME/.venv/bin/activate
-pip install -U -r requirements.txt
+set -e
+
+rm -rf .venv
+virtualenv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
 
 source $(dirname $0)/common
 


### PR DESCRIPTION
We have recently added functionality to support a 'gather_facts: force'
option.  Therefore, ensure that ursula builds from ansible sources
that we are currently curating. In the future, should this change be
accepted, we would then move to an upstream ansible source/version tag.
