### PR TITLE
cinder-volume goes on compute for test

### DIFF
--- a/test/setup
+++ b/test/setup
@@ -74,6 +74,9 @@ $(public_ip "test-controller-1")
 [network]
 $(public_ip "test-controller-0")
 $(public_ip "test-controller-1")
+
+[cinder_volume]
+$(public_ip "test-compute-0")
 eof
 
 echo "copying files"


### PR DESCRIPTION
We're going to be offering this as a demo on compute, we should test it
in CI as well. This makes the group show up for role application.
