### PR TITLE
testenv: cleanup nova secgroup

### DIFF
--- a/library/nova_group
+++ b/library/nova_group
@@ -320,9 +320,8 @@ def main():
     group_id = None
     group = security_group.get()
     if group:
-        group_id = group.id
         if state == 'absent':
-            security_group.delete()
+            group.delete()
             changed = True
     elif state == 'present':
         group = security_group.create()

--- a/playbooks/testenv/tasks/delete.yml
+++ b/playbooks/testenv/tasks/delete.yml
@@ -8,3 +8,9 @@
     - name: delete test instances
       local_action: nova_compute name={{ item }} state=absent
       with_items: testenv_instance_names
+
+    - name: remove security group
+      nova_group:
+        name: "{{ testenv_security_groups }}"
+        description: "{{ testenv_security_groups_description }}"
+        state: absent


### PR DESCRIPTION
During the `test/setup` script a security group is created for the new
environment. Unfortunately, this fails when the security group already
exists from a previous run. Instead of trying to diff the two groups and
update, simply remove the existing security group when the instances are
deleted.
