### PR TITLE
Add port to the ssh control path

### DIFF
--- a/share/common
+++ b/share/common
@@ -34,5 +34,5 @@ export ANSIBLE_FORCE_COLOR=yes
 export ANSIBLE_SSH_ARGS=\
 "${ANSIBLE_SSH_ARGS}"\
 ' -o ControlMaster=auto'\
-' -o ControlPath=~/.ssh/controlmasters/u-%r@%h'\
+' -o ControlPath=~/.ssh/controlmasters/u-%r@%h:%p'\
 ' -o ControlPersist=300'


### PR DESCRIPTION
Vagrant uses 127.0.0.1:<port> so this ControlPath is insufficient.
Add port to the control path to further qualify a host.
