### PR TITLE
New version of vagrant tries to guess which provider to use.

### DIFF
--- a/bin/run_vagrant
+++ b/bin/run_vagrant
@@ -31,7 +31,7 @@ else
     exit -1
 fi
 
-vagrant up ${BOXES}
+vagrant up --provider=virtualbox ${BOXES}
 
 # Write the Vagrant SSH config to be used by ansible
 TEMPFILE=`mktemp 2>/dev/null || mktemp -t 'ursula-fifo'`


### PR DESCRIPTION
This explicitly tells it to use virtualbox via run_vagrant
