### PR TITLE
Allow for swift backed glance

### DIFF
--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -12,6 +12,7 @@ glance:
     storage_path: /var/lib/btsync
     device_name: image-cache
     dir: /var/lib/glance/images
+  store_swift: False
 
   logs:
     - paths:

--- a/roles/glance/templates/etc/glance/glance-api.conf
+++ b/roles/glance/templates/etc/glance/glance-api.conf
@@ -2,10 +2,11 @@
 verbose = False
 debug = False
 
+{% if glance.store_swift %}
+default_store = swift
+{% else %}
 default_store = file
-
-known_stores = glance.store.filesystem.Store,
-               glance.store.http.Store
+{% endif %}
 
 bind_host = 0.0.0.0
 bind_port = 9292
@@ -27,7 +28,22 @@ registry_client_protocol = http
 
 notifier_strategy = noop
 
+[glance_store]
+{% if glance.store_swift %}
+stores = glance.store.swift.Store,
+         glance.store.http.Store
+
+swift_store_auth_address = https://{{ endpoints.main }}:35358/v2.0
+swift_store_user = service:glance
+swift_store_key {{ secrets.service_password }}
+swift_store_create_container_on_put = True
+
+{% else %}
+stores = glance.store.filesystem,
+         glance.store.http.Store.Store
+
 filesystem_store_datadir = /var/lib/glance/images/
+{% endif %}
 
 [keystone_authtoken]
 identity_uri = {{ endpoints.identity_uri }}


### PR DESCRIPTION
This introduces a new bool, glance.store_swift. If this is true,
settings will be made to have glance store images in swift, under the
"glance" container. The container will be created upon first use so no
other setup is necessary.
