### PR TITLE
Set gather_facts on the plays that need it

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,5 @@
 ---
 - name: common role for all hosts
-  gather_facts: force
   hosts: all
   roles:
     - role: common
@@ -13,12 +12,14 @@
       tags: ['common', 'logging']
 
 - name: setup IPv6 router advertisements
+  gather_facts: force
   hosts: controller
   roles:
     - role: ipv6ra
       tags: ['infra']
 
 - name: rabbitmq used by openstack
+  gather_facts: force
   hosts: controller
   serial: 1 # serial because clustering
   roles:
@@ -26,12 +27,14 @@
       tags: ['infra']
 
 - name: install common percona components and gather facts
+  gather_facts: force
   hosts: db
   roles:
     - role: percona-common
       tags: ['infra', 'percona']
 
 - name: install percona on primary
+  gather_facts: force
   hosts: db[0]
   vars:
     should_bootstrap_as_primary: True
@@ -40,6 +43,7 @@
       tags: ['infra', 'percona']
 
 - name: install percona on secondaries
+  gather_facts: force
   hosts: db:!db[0]
   vars:
     should_bootstrap_as_primary: False
@@ -48,6 +52,7 @@
       tags: ['infra', 'percona']
 
 - name: install percona arbiter
+  gather_facts: force
   hosts: db_arbiter
   roles:
     - role: percona-common
@@ -63,6 +68,7 @@
       tags: ['infra', 'percona']
 
 - name: memcached for keystone and horizon
+  gather_facts: force
   hosts: controller
   roles:
     - role: memcached
@@ -76,6 +82,7 @@
       tags: ['infra', 'data', 'openvswitch']
 
 - name: controller haproxy
+  gather_facts: force
   hosts: controller
   roles:
     - role: haproxy
@@ -83,6 +90,7 @@
       tags: ['haproxy', 'infra']
 
 - name: swift haproxy
+  gather_facts: force
   hosts: swiftnode
   roles:
     - role: haproxy
@@ -103,6 +111,7 @@
       tags: ['openstack', 'client']
 
 - name: keystone code and config
+  gather_facts: force
   hosts: controller
   roles:
     - role: keystone
@@ -119,6 +128,7 @@
       tags: ['openstack', 'setup']
 
 - name: glance code and config
+  gather_facts: force
   hosts: controller
   roles:
     - role: glance
@@ -129,36 +139,42 @@
       tags: ['openstack', 'glance', 'control']
 
 - name: nova control plane
+  gather_facts: force
   hosts: controller
   roles:
     - role: nova-control
       tags: ['openstack', 'nova', 'control']
 
 - name: nova data plane
+  gather_facts: force
   hosts: compute
   roles:
     - role: nova-data
       tags: ['openstack', 'nova', 'data']
 
 - name: cinder control plane
+  gather_facts: force
   hosts: controller
   roles:
     - role: cinder-control
       tags: ['openstack', 'cinder', 'control']
 
 - name: cinder data plane
+  gather_facts: force
   hosts: cinder_volume
   roles:
     - role: cinder-data
       tags: ['openstack', 'cinder', 'data']
 
 - name: neutron control plane
+  gather_facts: force
   hosts: controller
   roles:
     - role: neutron-control
       tags: ['openstack', 'neutron', 'control']
 
 - name: neutron core data plane
+  gather_facts: force
   hosts: compute:network
   roles:
     - role: neutron-data
@@ -202,6 +218,7 @@
       tags: ['openstack', 'swift', 'data']
 
 - name: heat code and config
+  gather_facts: force
   hosts: controller
   roles:
     - role: heat
@@ -214,6 +231,7 @@
       when: heat.enabled == True
 
 - name: ironic control plane
+  gather_facts: force
   hosts: controller
   roles:
     - role: ironic-control


### PR DESCRIPTION
Previously, I had set gather_facts on the common play only.  This
will work if one is running a full ansible run, but if you intend to
use tags, which target specific plays, then you need to set
gather_facts: force on each play that needs it.

The measure for which plays need it are those that make use of
hostvars[$host] type logic.  This commit will address those.
