### PR TITLE
disable-branch-fixup: move into a script file

### DIFF
--- a/roles/common/files/swap_off_all
+++ b/roles/common/files/swap_off_all
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+awk '/^\// {print $1 "\t" $4}' /proc/swaps | \
+while read SWAPDEV SWAPUSED; do 
+  if [ ${SWAPUSED} -eq 0 ]; then
+    swapoff ${SWAPDEV}
+  fi
+done

--- a/roles/common/tasks/disable_swap.yml
+++ b/roles/common/tasks/disable_swap.yml
@@ -1,10 +1,5 @@
 ---
 - lineinfile: dest=/etc/fstab regexp='\s+swap\s+' state=absent
-# Disable unused swap devices
-- shell: |
-    awk '/^\// {print $1 "\t" $4}' /proc/swaps | \
-    while read SWAPDEV SWAPUSED; do
-      if [ ${SWAPUSED} -eq 0 ]; then
-        swapoff ${SWAPDEV}
-      fi
-    done
+
+- name: disable swap on all devices
+  script: swap_off_all


### PR DESCRIPTION
Several times I have seen disabling swap fail  with a while loop error
Moving this into it's own script fixes it.