### PR TITLE
Update keystone config to clear warnings

### DIFF
--- a/roles/keystone/templates/etc/keystone/keystone-paste.ini
+++ b/roles/keystone/templates/etc/keystone/keystone-paste.ini
@@ -12,15 +12,6 @@ paste.filter_factory = keystone.middleware:TokenAuthMiddleware.factory
 [filter:admin_token_auth]
 paste.filter_factory = keystone.middleware:AdminTokenAuthMiddleware.factory
 
-[filter:xml_body]
-paste.filter_factory = keystone.middleware:XmlBodyMiddleware.factory
-
-[filter:xml_body_v2]
-paste.filter_factory = keystone.middleware:XmlBodyMiddlewareV2.factory
-
-[filter:xml_body_v3]
-paste.filter_factory = keystone.middleware:XmlBodyMiddlewareV3.factory
-
 [filter:json_body]
 paste.filter_factory = keystone.middleware:JsonBodyMiddleware.factory
 
@@ -82,13 +73,13 @@ paste.app_factory = keystone.service:v3_app_factory
 paste.app_factory = keystone.service:admin_app_factory
 
 [pipeline:public_api]
-pipeline = sizelimit url_normalize build_auth_context token_auth admin_token_auth xml_body_v2 json_body ec2_extension user_crud_extension public_service
+pipeline = sizelimit url_normalize build_auth_context token_auth admin_token_auth json_body ec2_extension user_crud_extension public_service
 
 [pipeline:admin_api]
-pipeline = sizelimit url_normalize build_auth_context token_auth admin_token_auth xml_body_v2 json_body ec2_extension s3_extension crud_extension admin_service
+pipeline = sizelimit url_normalize build_auth_context token_auth admin_token_auth json_body ec2_extension s3_extension crud_extension admin_service
 
 [pipeline:api_v3]
-pipeline = sizelimit url_normalize build_auth_context token_auth admin_token_auth xml_body_v3 json_body ec2_extension_v3 s3_extension simple_cert_extension revoke_extension service_v3
+pipeline = sizelimit url_normalize build_auth_context token_auth admin_token_auth json_body ec2_extension_v3 s3_extension simple_cert_extension revoke_extension service_v3
 
 [app:public_version_service]
 paste.app_factory = keystone.service:public_version_app_factory
@@ -97,10 +88,10 @@ paste.app_factory = keystone.service:public_version_app_factory
 paste.app_factory = keystone.service:admin_version_app_factory
 
 [pipeline:public_version_api]
-pipeline = sizelimit url_normalize xml_body public_version_service
+pipeline = sizelimit url_normalize public_version_service
 
 [pipeline:admin_version_api]
-pipeline = sizelimit url_normalize xml_body admin_version_service
+pipeline = sizelimit url_normalize admin_version_service
 
 [composite:main]
 use = egg:Paste#urlmap

--- a/roles/keystone/templates/etc/keystone/keystone.conf
+++ b/roles/keystone/templates/etc/keystone/keystone.conf
@@ -22,7 +22,8 @@ driver = keystone.identity.backends.sql.Identity
 driver = keystone.catalog.backends.sql.Catalog
 
 [token]
-driver = keystone.token.backends.sql.Token
+driver = keystone.token.persistence.backends.sql.Token
+provider = keystone.token.providers.uuid.Provider
 
 # Amount of time a token should remain valid (in seconds)
 expiration = {{ keystone.token_expiration_in_seconds }}
@@ -54,7 +55,6 @@ enable = False
 #cert_required = True
 
 [signing]
-token_format = UUID
 #certfile = /etc/keystone/ssl/certs/signing_cert.pem
 #keyfile = /etc/keystone/ssl/private/signing_key.pem
 #ca_certs = /etc/keystone/ssl/certs/ca.pem
@@ -64,3 +64,6 @@ token_format = UUID
 
 [paste_deploy]
 config_file = /etc/keystone/keystone-paste.ini
+
+[revoke]
+driver = keystone.contrib.revoke.backends.sql.Revoke


### PR DESCRIPTION
These options were causing deprecation warnings. A couple of these are
now different from the stable/juno defaults, but that's because these
defaults were fixed after the stable branch was created. These changes
should not alter current behavior, other than clearning the deprecation
warnings.

xml_body middleware is deprecated, and removed in kilo
token driver path changed
token_format is now driver under [token]
revoke default driver path changed
