### PR TITLE
Utilize running conductor service

### DIFF
--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -127,7 +127,7 @@ reserved_host_memory_mb=4096
 {% endif %}
 
 [conductor]
-use_local = True
+use_local = False
 workers = {{ nova.conductor_workers }}
 
 [keystone_authtoken]


### PR DESCRIPTION
This makes use of the nova conductor, shielding some services from
directly reading/writing to the database, instead passing messages in
rabbit to the conductor service to interact with the database. It also
provides translations for RPC message objects when an object is recieved
by a nova service and that service cannot understand the version of the
object.

Conductor service will enable better orchestrated upgrades of nova to
reduce downtime as much as possible and allows for mixed versions of
services running, and allows for database to be migrated before
upgrading nova-compute.

Conflicts with PR #689
