### PR TITLE
Enable PKI tokens for keystone

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -1,6 +1,8 @@
 ---
 stack_env: example
 
+country_code: US
+
 primary_interface: 'ansible_eth0'
 primary_ip: "{{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}"
 undercloud_cidr: 10.230.7.0/24

--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -4,6 +4,8 @@ primary_interface: ansible_eth1
 primary_ip: "{{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}"
 undercloud_cidr: '172.16.0.0/24'
 
+country_code: US
+
 fqdn: openstack.example.org
 undercloud_floating_ip: "{{ hostvars[groups['controller'][0]][primary_interface]['ipv4']['address'] }}"
 secrets:

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -49,6 +49,46 @@
   notify:
     - restart keystone services
 
+- name: create keystone PKI dirs
+  file: path={{ item }} state=directory owner=keystone group=keystone
+        mode=0700
+  with_items:
+    - /etc/keystone/ssl/certs
+    - /etc/keystone/ssl/private
+
+- name: generate keystone PKI certs
+  command: keystone-manage pki_setup --keystone-user keystone
+           --keystone-group keystone
+           creates=/etc/keystone/ssl/private/cakey.pem
+  run_once: true
+  notify:
+    - restart keystone services
+
+- name: slurp keystone certs
+  slurp: src={{ item }}
+  with_items:
+    - /etc/keystone/ssl/certs/ca.pem
+    - /etc/keystone/ssl/certs/signing_cert.pem
+    - /etc/keystone/ssl/private/cakey.pem
+    - /etc/keystone/ssl/private/signing_key.pem
+  register: pki_certs
+  run_once: true
+  no_log: true
+
+- name: write out keystone certs
+  copy:
+    dest: "{{ item.item }}"
+    content: "{{ item.content | b64decode }}"
+    owner: keystone
+    group: keystone
+    mode: 0700
+  with_items: pki_certs.results
+  no_log: true
+  notify:
+    - restart keystone services
+
+- meta: flush_handlers
+
 - name: start keystone
   service: name=keystone state=started
 

--- a/roles/keystone/templates/etc/keystone/keystone.conf
+++ b/roles/keystone/templates/etc/keystone/keystone.conf
@@ -23,7 +23,7 @@ driver = keystone.catalog.backends.sql.Catalog
 
 [token]
 driver = keystone.token.persistence.backends.sql.Token
-provider = keystone.token.providers.uuid.Provider
+provider = keystone.token.providers.pki.Provider
 
 # Amount of time a token should remain valid (in seconds)
 expiration = {{ keystone.token_expiration_in_seconds }}
@@ -55,12 +55,7 @@ enable = False
 #cert_required = True
 
 [signing]
-#certfile = /etc/keystone/ssl/certs/signing_cert.pem
-#keyfile = /etc/keystone/ssl/private/signing_key.pem
-#ca_certs = /etc/keystone/ssl/certs/ca.pem
-#key_size = 1024
-#valid_days = 3650
-#ca_password = None
+cert_subject = /C={{ country_code }}/ST=Unset/L=Unset/O=Unset/CN={{ endpoints.main }}
 
 [paste_deploy]
 config_file = /etc/keystone/keystone-paste.ini


### PR DESCRIPTION
This switches from UUID based tokens to PKI tokens. Tokens get signed by
keystone, services can validate the token without having to communicate
with keystone API. This setup is using self signed keystone generated
certs as the certs are only used within the services.

Introduces a new variable, countrycode, used when generating keystone's
signing cert.
