### PR TITLE
Reduce haproxy refresh handlers to 1

### DIFF
--- a/roles/haproxy/handlers/main.yml
+++ b/roles/haproxy/handlers/main.yml
@@ -1,6 +1,3 @@
 ---
-- name: reload haproxy
-  service: name=haproxy state=reloaded enabled=yes
-
 - name: restart haproxy
   restart_if_running: service=haproxy

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -16,13 +16,13 @@
 - name: install ssl cert+key
   template: src=etc/haproxy/openstack.pem dest=/etc/haproxy/openstack.pem
             owner=haproxy group=haproxy mode=0600
-  notify: reload haproxy
+  notify: restart haproxy
   tags:
     - ssl
 
 - name: haproxy config
   template: src=etc/haproxy/haproxy_{{ haproxy_type }}.cfg
             dest=/etc/haproxy/haproxy.cfg mode=0644
-  notify: reload haproxy
+  notify: restart haproxy
 
 - include: monitoring.yml tags=monitoring,common


### PR DESCRIPTION
We had handlers for reload and restart, and sometimes both would happen
in quick succession and seemingly cause issues. Reduce them down to just
restart and call it good.
