### PR TITLE
Handle haproxy reload when no haproxy installed

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -7,6 +7,8 @@
 
 - name: reload haproxy
   service: name=haproxy state=reloaded
+  register: hareload
+  failed_when: hareload|failed and "service not found" not in hareload.stderr
 
 - name: apply-sysctl
   shell: "cat /etc/sysctl.conf /etc/sysctl.d/*.conf | sysctl -e -p -"


### PR DESCRIPTION
The handler fires for all when upgrading openssl, but not all systems
have haproxy. This used to be handled in the restart haproxy handler,
but was lost when that handler was collapsted into the reload haproxy
handler.
