### PR TITLE
Install open-iscsi for cinder-data

### DIFF
--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -5,6 +5,7 @@
     - lvm2
     - tgt
     - nbd-client
+    - open-iscsi
 
 - name: iscsi target framework conf dir
   file: dest=/etc/tgt/conf.d state=directory


### PR DESCRIPTION
If cinder-data runs on a standalone system, it wouldn't have gotten the
libvirt role, where open-scsi is installed. Therefor we should list
open-iscsi here to ensure we have it.
