### PR TITLE
cinder: explicitly define glance host

### DIFF
--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -72,6 +72,8 @@ san_password = {{ backend.san_password }}
 
 {% endfor -%}
 
+glance_host = {{ endpoints.glance }}
+
 [keystone_authtoken]
 identity_uri = {{ endpoints.identity_uri }}
 auth_uri = {{ endpoints.auth_uri }}


### PR DESCRIPTION
Explicitly define the glance endpoint for Cinder to support creating a volume block from an image on the compute hosts which are not running a local `glance-api` service.