### PR TITLE
Fix nova-compute packages on trusty

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -19,6 +19,10 @@ nova:
   python_libvirt_version: 1.2.2-0ubuntu2~cloud0
   qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.6~cloud0
   librdb1_version: 0.80.5-0ubuntu0.14.04.1~cloud0
+  trusty:
+    libvirt_bin_version: 1.2.2-0ubuntu13.1.7
+    python_libvirt_version: 1.2.2-0ubuntu2
+    qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.9
 
   logs:
     - paths:

--- a/roles/nova-data/tasks/libvirt.yml
+++ b/roles/nova-data/tasks/libvirt.yml
@@ -11,6 +11,7 @@
 - name: install cloudarchive repos
   apt_repository: repo='deb http://ubuntu-cloud.archive.canonical.com/ubuntu precise-updates/icehouse main'
                   state=present update_cache=yes
+  when: ansible_distribution_version == "12.04"
 
 - name: install nova-compute packages
   apt: pkg={{ item }}
@@ -21,6 +22,17 @@
     - librbd1={{ nova.librdb1_version }}
     - open-iscsi
   notify: restart nova services
+  when: ansible_distribution_version == "12.04"
+
+- name: install nova-compute packages (trusty)
+  apt: pkg={{ item }}
+  with_items:
+    - libvirt-bin={{ nova.trusty.libvirt_bin_version }}
+    - python-libvirt={{ nova.trusty.python_libvirt_version }}
+    - qemu-kvm={{ nova.trusty.qemu_kvm_version }}
+    - open-iscsi
+  notify: restart nova services
+  when: ansible_distribution_version == "14.04"
 
 - name: update various lines in libvirtd.conf
   lineinfile: dest=/etc/libvirt/libvirtd.conf regexp="{{ item.value.regexp }}"


### PR DESCRIPTION
Specified versions of various packages were valid only for precise, so
this adds support for trusty as well.