### PR TITLE
Make the clean up work again

### DIFF
--- a/playbooks/testenv/tasks/delete.yml
+++ b/playbooks/testenv/tasks/delete.yml
@@ -1,9 +1,12 @@
 ---
 - name: de-provision test instances
-  hosts: local
-  connection: local
+  hosts: localhost
+
   vars_files:
-  - ../vars/main.yml
+    - ../vars/main.yml
+  vars:
+    ansible_python_interpreter: "/usr/bin/env python"
+
   tasks:
     - name: delete test instances
       local_action: nova_compute name={{ item }} state=absent


### PR DESCRIPTION
local group doesn't exist at this point, so just call localhost
explicitly since you can do that. Also override the ansible python
interpreter for those that are running a non-standard one.