### PR TITLE
Update iproute2 as required for vxlan

### DIFF
--- a/roles/neutron-data/tasks/main.yml
+++ b/roles/neutron-data/tasks/main.yml
@@ -2,6 +2,19 @@
 - name: install ipset
   apt: name=ipset
 
+# vxlan needs newer iproute
+- name: Add apt-key for bbg/openstack ppa
+  apt_key: id=49DE63CB url='http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xC37BA5F849DE63CB'
+  when: neutron.tenant_network_type == 'vxlan'
+
+- name: Add bbg/openstack ppa repo
+  apt_repository: repo='ppa:blueboxgroup/openstack' update_cache=yes
+  when: neutron.tenant_network_type == 'vxlan'
+
+- name: update iproute2 to latest ppa
+  apt: name=iproute2 state=latest
+  when: neutron.tenant_network_type == 'vxlan'
+
 - name: install neutron-openvswitch-agent service
   upstart_service: name=neutron-openvswitch-agent
                    user=neutron


### PR DESCRIPTION
This was only happening in a side playbook, rather than in the site
proper. This moves it into the neutron role where it should be done when
vxlan is the network type.