### PR TITLE
Check tunnel_types for vxlan

### DIFF
--- a/roles/neutron-data/tasks/main.yml
+++ b/roles/neutron-data/tasks/main.yml
@@ -5,15 +5,15 @@
 # vxlan needs newer iproute
 - name: Add apt-key for bbg/openstack ppa
   apt_key: id=49DE63CB url='http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xC37BA5F849DE63CB'
-  when: neutron.tenant_network_type == 'vxlan' and neutron.plugin == 'ml2'
+  when: neutron.plugin == 'ml2' and 'vxlan' in neutron.tunnel_types
 
 - name: Add bbg/openstack ppa repo
   apt_repository: repo='ppa:blueboxgroup/openstack' update_cache=yes
-  when: neutron.tenant_network_type == 'vxlan' and neutron.plugin == 'ml2' 
+  when: neutron.plugin == 'ml2' and 'vxlan' in neutron.tunnel_types
 
 - name: update iproute2 to latest ppa
   apt: name=iproute2 state=latest
-  when: neutron.tenant_network_type == 'vxlan' and neutron.plugin == 'ml2'
+  when: neutron.plugin == 'ml2' and 'vxlan' in neutron.tunnel_types
 
 - name: install neutron-openvswitch-agent service
   upstart_service: name=neutron-openvswitch-agent


### PR DESCRIPTION
OTherwise we may have a cluster that has vxlan as a type but not the
default type. Wouldn't want to fall into that trap.