### PR TITLE
Only sync databases once

### DIFF
--- a/roles/cinder-control/tasks/main.yml
+++ b/roles/cinder-control/tasks/main.yml
@@ -11,6 +11,7 @@
 - name: sync cinder database
   command: cinder-manage db sync
   when: database_create.changed or force_sync|default('false')|bool
+  run_once: true
 
 - name: start cinder controller services
   service: name={{ item }} state=started

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -64,6 +64,7 @@
 - name: sync glance database
   command: glance-manage db_sync
   when: database_create.changed or force_sync|default('false')|bool
+  run_once: true
 
 - name: start glance services
   service: name={{ item }} state=started

--- a/roles/ironic-control/tasks/main.yml
+++ b/roles/ironic-control/tasks/main.yml
@@ -41,6 +41,7 @@
 - name: sync cinder database
   command: "{{ ironic.virtualenv }}/bin/ironic-dbsync upgrade"
   when: database_create.changed or force_sync|default('false')|bool
+  run_once: true
 
 - name: start ironic controller services
   service: name={{ item }} state=started

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -90,6 +90,7 @@
 - name: sync keystone database
   command: keystone-manage db_sync
   when: database_create.changed or force_sync|default('false')|bool
+  run_once: true
 
 - meta: flush_handlers
 

--- a/roles/neutron-control/tasks/main.yml
+++ b/roles/neutron-control/tasks/main.yml
@@ -21,6 +21,7 @@
   command: neutron-db-manage --config-file /etc/neutron/neutron.conf \
            --config-file /etc/neutron/plugins/ml2/ml2_plugin.ini upgrade head
   when: database_create.changed or force_sync|default('false')|bool
+  run_once: true
 
 - name: start neutron-server
   action: service name=neutron-server state=started

--- a/roles/nova-control/tasks/main.yml
+++ b/roles/nova-control/tasks/main.yml
@@ -13,6 +13,7 @@
 - name: sync nova database
   command: nova-manage db sync
   when: database_create.changed or force_sync|default('false')|bool
+  run_once: true
 
 - name: start nova controller services
   service: name={{ item }} state=started


### PR DESCRIPTION
Without run_once, all controllers would attempt to sync the db, which
would cause a collision.