### PR TITLE
Backport: Enable serial console on ttyS0

### DIFF
--- a/roles/common/tasks/ipmi.yml
+++ b/roles/common/tasks/ipmi.yml
@@ -9,5 +9,4 @@
     - ipmi_si
     - ipmi_msghandler
 
-- name: IPMI serial over LAN console
-  template: src=etc/init/tty_ipmi_console.conf dest=/etc/init/{{ common.ipmi.serial_console }}.conf
+- include: serial-console.yml tty=common.ipmi.serial_console baud_rate=115200

--- a/roles/common/tasks/kernel-tuning.yml
+++ b/roles/common/tasks/kernel-tuning.yml
@@ -6,5 +6,5 @@
 - name: "Kernel boot parameters: disable console screen blanking, enabled serial console on IPMI serial over LAN"
   lineinfile: dest=/etc/default/grub
               regexp="^GRUB_CMDLINE_LINUX_DEFAULT="
-              line="GRUB_CMDLINE_LINUX_DEFAULT=\"console=tty1 console={{ common.ipmi.serial_console }},115200n8 consoleblank=0\""
+              line="GRUB_CMDLINE_LINUX_DEFAULT=\"console=tty1{{ serial_console_cmdline|default('') }} consoleblank=0\""
   notify: update grub config

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -50,6 +50,13 @@
 - include: ssh.yml
 - include: networking.yml
 - include: ufw.yml
+
+# Include serial console before kernel-tuning to build serial_console_cmdline
+- include: serial-console.yml tty=ttyS0
+
+- include: ipmi.yml
+  when: common.ipmi.enabled
+
 - include: kernel-tuning.yml
 - include: system_tools.yml
 - include: security-patches.yml
@@ -62,6 +69,3 @@
 - name: drop an motd with ursula metadata
   action: template src=etc/motd.tail dest=/etc/motd.tail mode=0644
   changed_when: False
-
-- include: ipmi.yml
-  when: common.ipmi.enabled

--- a/roles/common/tasks/serial-console.yml
+++ b/roles/common/tasks/serial-console.yml
@@ -1,0 +1,9 @@
+---
+- name: serial console init script
+  template: src=etc/init/tty_console.conf dest=/etc/init/{{ tty }}.conf
+
+- name: start serial console
+  service: name={{ tty }} state=started enabled=yes
+
+- name: append serial console kernel command line
+  set_fact: serial_console_cmdline="{{ serial_console_cmdline|default('') }} console={{ tty }},{{ baud_rate|default('9600') }}n8"

--- a/roles/common/templates/etc/init/tty_console.conf
+++ b/roles/common/templates/etc/init/tty_console.conf
@@ -1,6 +1,6 @@
-# {{ common.ipmi.serial_console }} - getty
+# {{ tty }} - getty
 #
-# This service maintains a getty on {{ common.ipmi.serial_console }} from the point the system is
+# This service maintains a getty on {{ tty }} from the point the system is
 # started until it is shut down again.
 
 start on stopped rc RUNLEVEL=[2345] and (
@@ -11,5 +11,5 @@ start on stopped rc RUNLEVEL=[2345] and (
 stop on runlevel [!2345]
 
 respawn
-exec /sbin/getty -L {{ common.ipmi.serial_console }} 115200 vt100
+exec /sbin/getty -L {{ tty }} {{ baud_rate|default('9600') }} vt100
 


### PR DESCRIPTION
Combine login getty logic with IPMI serial over LAN, adding all serial
consoles to the kernel command line.

Backporting for upgrades to existing customers with serial consoles.

Conflicts:
	roles/common/tasks/main.yml