### PR TITLE
Update glance to fix directory traversal flaw (1.0.x)

### DIFF
--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 glance:
-  rev: 252fe8572400c25c35
+  rev: 5218021e6fff46b4bb
+  git_mirror: https://github.com/blueboxgroup
   api_workers: 5
   sync:
     enabled: true

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: get glance source repo
   git: |
-    repo={{ openstack.git_mirror }}/glance.git
+    repo={{ glance.git_mirror }}/glance.git
     dest=/opt/stack/glance
     version={{ glance.rev }}
     update={{ openstack.git_update }}


### PR DESCRIPTION
https://bugs.launchpad.net/glance/+bug/1400966

Since stable/havana is dead upstream we had to fork glance and restore
the branch so that we could backport the fix. Manually tested.