### PR TITLE
Utilize a temporary admin_token during bootstrap

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -8,7 +8,6 @@ primary_ip: "{{ hostvars[inventory_hostname][primary_interface]['ipv4']['address
 undercloud_cidr: 10.230.7.0/24
 
 secrets:
-  admin_token:      asdf
   db_password:      asdf
   service_password: asdf
   rabbit_password:  asdf

--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -9,7 +9,6 @@ country_code: US
 fqdn: openstack.example.org
 undercloud_floating_ip: "{{ hostvars[groups['controller'][0]][primary_interface]['ipv4']['address'] }}"
 secrets:
-  admin_token:      asdf
   db_password:      asdf
   service_password: asdf
   rabbit_password:  asdf

--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -7,24 +7,41 @@
   set_fact: keystone_configured=True
   when: keystone_setup.stat.exists
 
+- name: generate admin_token
+  set_fact: admin_token="{{ 'asdf' * 9|random(start=2) }}"
+            insert_token=True
+
+- name: add admin_token to keystone conf
+  lineinfile: dest=/etc/keystone/keystone.conf
+              line="admin_token = {{ admin_token }}"
+              insertafter='\[DEFAULT\]'
+              state=present
+
+- name: add admin_token_auth to keystone pipeline
+  template: dest=/etc/keystone/keystone-paste.ini
+            src=roles/keystone/templates/etc/keystone/keystone-paste.ini
+
+- name: restart keystone api
+  service: name=keystone state=restarted
+
 - name: keystone tenants
   keystone_user: tenant={{ item }}
                  tenant_description="{{ item }} tenant"
-                 token={{ secrets.admin_token }}
+                 token={{ admin_token }}
   with_items: keystone.tenants
 
 - name: keystone users
   keystone_user: user={{ item.name }}
                  password={{ item.password }}
                  tenant={{ item.tenant }}
-                 token={{ secrets.admin_token }}
+                 token={{ admin_token }}
   with_items: keystone.users
 
 - name: keystone roles
   keystone_user: role={{ item.role }}
                  user={{ item.user }}
                  tenant={{ item.tenant }}
-                 token={{ secrets.admin_token }}
+                 token={{ admin_token }}
   with_items: keystone.user_roles
 
 - name: keystone endpoint
@@ -35,10 +52,25 @@
                     internal_url={{ item.internal_url }}
                     admin_url={{ item.admin_url }}
                     region=RegionOne
-                    token={{ secrets.admin_token }}
+                    token={{ admin_token }}
   # TODO refactor keystone.services data to be easier to pull out individual services
   with_items: keystone.services
   when: endpoints[item.name] is defined and item.name == 'keystone'
+
+- name: remote admin_token from keystone api
+  lineinfile: dest=/etc/keystone/keystone.conf
+              line="admin_token = {{ admin_token }}"
+              state=absent
+
+- name: set insert_token to false
+  set_fact: insert_token=False
+
+- name: remove admin_token_auth from keystone pipeline
+  template: dest=/etc/keystone/keystone-paste.ini
+            src=roles/keystone/templates/etc/keystone/keystone-paste.ini
+
+- name: restart keystone api
+  service: name=keystone state=restarted
 
 - name: set keystone setup status
   file: path=/etc/keystone/.setup state=touch

--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: discover keystone setup status
+  stat: path=/etc/keystone/.setup
+  register: keystone_setup
+
+- name: set keystone_configured fact
+  set_fact: keystone_configured=True
+  when: keystone_setup.stat.exists
+
 - name: keystone tenants
   keystone_user: tenant={{ item }}
                  tenant_description="{{ item }} tenant"
@@ -31,3 +39,6 @@
   # TODO refactor keystone.services data to be easier to pull out individual services
   with_items: keystone.services
   when: endpoints[item.name] is defined and item.name == 'keystone'
+
+- name: set keystone setup status
+  file: path=/etc/keystone/.setup state=touch

--- a/roles/keystone/templates/etc/keystone/keystone-paste.ini
+++ b/roles/keystone/templates/etc/keystone/keystone-paste.ini
@@ -73,13 +73,13 @@ paste.app_factory = keystone.service:v3_app_factory
 paste.app_factory = keystone.service:admin_app_factory
 
 [pipeline:public_api]
-pipeline = sizelimit url_normalize build_auth_context token_auth admin_token_auth json_body ec2_extension user_crud_extension public_service
+pipeline = sizelimit url_normalize build_auth_context token_auth json_body ec2_extension user_crud_extension public_service
 
 [pipeline:admin_api]
-pipeline = sizelimit url_normalize build_auth_context token_auth admin_token_auth json_body ec2_extension s3_extension crud_extension admin_service
+pipeline = sizelimit url_normalize build_auth_context token_auth{{ ' admin_token_auth' if insert_token|default(boolean=False) else '' }} json_body ec2_extension s3_extension crud_extension admin_service
 
 [pipeline:api_v3]
-pipeline = sizelimit url_normalize build_auth_context token_auth admin_token_auth json_body ec2_extension_v3 s3_extension simple_cert_extension revoke_extension service_v3
+pipeline = sizelimit url_normalize build_auth_context token_auth json_body ec2_extension_v3 s3_extension simple_cert_extension revoke_extension service_v3
 
 [app:public_version_service]
 paste.app_factory = keystone.service:public_version_app_factory

--- a/roles/keystone/templates/etc/keystone/keystone.conf
+++ b/roles/keystone/templates/etc/keystone/keystone.conf
@@ -1,6 +1,4 @@
 [DEFAULT]
-admin_token = {{ secrets.admin_token }}
-
 debug = {{ keystone.logging.debug }}
 verbose = {{ keystone.logging.verbose }}
 

--- a/site.yml
+++ b/site.yml
@@ -131,7 +131,9 @@
   hosts: controller[0]
   roles:
     - role: keystone-setup
+      keystone_configured: false
       tags: ['openstack', 'setup']
+      when: not keystone_configured
 
 - name: glance code and config
   gather_facts: force


### PR DESCRIPTION
This removes the hard coded static admin_token that we have been leaving enabled in our deploys. Instead it generates a psuedorandom token to be used during a bootstrap of keystone, provided keystone hasn't already been bootstrapped. Then the admin_token_auth method is only enabled long enough to bootstrap.