### PR TITLE
Fix enablement of backends accidentally

### DIFF
--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 cinder:
   rev: 7b1d7a31335bd8723551c9af5c270927ad830c3f
-  enabled_backends: None
-  default_backend: None
+  enabled_backends: 
+  default_backend: 
   backends: []
   api_workers: 5
 

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -47,10 +47,10 @@ rabbit_password = {{ secrets.rabbit_password }}
 volume_clear_size = {{ cinder.volume_clear_size }}
 {% endif -%}
 
-{% if cinder.enabled_backends is defined -%}
+{% if cinder.enabled_backends != None -%}
 enabled_backends = {{ cinder.enabled_backends }}
 {% endif %}
-{% if cinder.default_backend is defined -%}
+{% if cinder.default_backend != None -%}
 default_backend = {{ cinder.default_backend }}
 {% endif %}
 


### PR DESCRIPTION
enabled_backends and default_backend use broken logic. These should be
unset by default and we should check for None instead of 'is defined'.