### PR TITLE
bootstrap for vxlan doesn't need to install iproute2

### DIFF
--- a/playbooks/bootstrap_ml2_vxlan.yml
+++ b/playbooks/bootstrap_ml2_vxlan.yml
@@ -15,12 +15,6 @@
   - apt: pkg=python-pycurl
     when: ansible_distribution_version == "12.04"
 
-  # Blue Box Group OpenStack PPA (needed for our version of iproute2)
-  - apt_key: id=49DE63CB url='http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xC37BA5F849DE63CB'
-    when: ansible_distribution_version == "12.04"
-  - apt_repository: repo='ppa:blueboxgroup/openstack' update_cache=yes
-    when: ansible_distribution_version == "12.04"
-
   # Upgrade Kernel to 3.8.0 on Precise for VXLAN support
   - apt: pkg={{ item }}
     with_items:
@@ -35,9 +29,6 @@
     with_items:
     - vlan
     - ucarp
-
-  # Install customized iproute2 for vxlan
-  - apt: name: iproute2=3.12.0-2~ubuntu12.04.1~ppa1  update_cache=yes
 
   # Upgrade the distribution (we want to preform this outside of normal site.yml)
   - apt: upgrade=dist


### PR DESCRIPTION
As @j2sol mentioned in https://github.com/blueboxgroup/ursula/pull/740, we don't need this because the neutron-data role handles installing the BlueBox PPA and iproute2.