### PR TITLE
Update horizon logo URL for juno

### DIFF
--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 horizon:
   rev: e5a9037d2ff5f2fbd5bde8e073e90b8d290994d3
-  logo_url: https://s3.amazonaws.com/horizon-branding/bluebox.png
+  logo_url: https://s3.amazonaws.com/horizon-branding/bluebox-u1.1.x.png
   favicon_url: https://s3.amazonaws.com/horizon-branding/bluebox.ico
   keystone_api_version: 2.0


### PR DESCRIPTION
The logo needs to be sized different for horizon in icehouse and above.
This new url has the right sized image.