### PR TITLE
Fix keystone setup false positive

### DIFF
--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: set keystone_configured fact
   set_fact: keystone_configured=True
-  when: keystone_setup.stat.exists
+  when: keystone_setup.stat.exists|bool
 
 - name: generate admin_token
   set_fact: admin_token="{{ 'asdf' * 9|random(start=2) }}"


### PR DESCRIPTION
Not sure how this snuck in, but this conditional will always be "true"
because the exists key exists. We need to run it as a bool to check the
/value/ of the key instead so that keystone setup will actually run.