### PR TITLE
Package installs

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,5 +7,6 @@ transport = ssh
 vars_plugins = plugins/vars
 connection_plugins = plugins/connection
 callback_plugins = plugins/callbacks
+filter_plugins = plugins/filters
 transport = monkeypatched_ssh
 forks = 25

--- a/bin/ursula
+++ b/bin/ursula
@@ -89,7 +89,7 @@ process_opts() {
 }
 
 set_vars() {
-  PREDEPLOY_PLAYBOOK=${URSULA_ENV}/playbooks/predeploy.yml
+  #PREDEPLOY_PLAYBOOK=${URSULA_ENV}/playbooks/predeploy.yml
   POSTDEPLOY_PLAYBOOK=${URSULA_ENV}/playbooks/postdeploy.yml
   HOSTS=${URSULA_ENV}/hosts
   SSH_CONFIG=${URSULA_ENV}/ssh_config

--- a/bin/ursula
+++ b/bin/ursula
@@ -89,7 +89,7 @@ process_opts() {
 }
 
 set_vars() {
-  #PREDEPLOY_PLAYBOOK=${URSULA_ENV}/playbooks/predeploy.yml
+  PREDEPLOY_PLAYBOOK=${URSULA_ENV}/playbooks/predeploy.yml
   POSTDEPLOY_PLAYBOOK=${URSULA_ENV}/playbooks/postdeploy.yml
   HOSTS=${URSULA_ENV}/hosts
   SSH_CONFIG=${URSULA_ENV}/ssh_config

--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -5,7 +5,7 @@ country_code: US
 
 #openstack_install_method: 'source'
 openstack_install_method: 'package'
-openstack_package_version: '10.0-bbc33'
+openstack_package_version: '10.0-bbc34'
 
 primary_interface: 'ansible_eth0'
 primary_ip: "{{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}"

--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -3,7 +3,9 @@ stack_env: example
 
 country_code: US
 
-openstack_install_method: source
+#openstack_install_method: 'source'
+openstack_install_method: 'package'
+openstack_package_version: '10.0-bbc33'
 
 primary_interface: 'ansible_eth0'
 primary_ip: "{{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}"

--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -6,7 +6,9 @@ undercloud_cidr: '172.16.0.0/24'
 
 country_code: US
 
-openstack_install_method: source
+#openstack_install_method: 'source'
+openstack_install_method: 'package'
+openstack_package_version: '10.0-bbc33'
 
 fqdn: openstack.example.org
 undercloud_floating_ip: "{{ hostvars[groups['controller'][0]][primary_interface]['ipv4']['address'] }}"

--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -8,7 +8,7 @@ country_code: US
 
 #openstack_install_method: 'source'
 openstack_install_method: 'package'
-openstack_package_version: '10.0-bbc33'
+openstack_package_version: '10.0-bbc34'
 
 fqdn: openstack.example.org
 undercloud_floating_ip: "{{ hostvars[groups['controller'][0]][primary_interface]['ipv4']['address'] }}"

--- a/plugins/filters/filter_plugin.py
+++ b/plugins/filters/filter_plugin.py
@@ -1,0 +1,16 @@
+import os
+
+
+def ursula_package_path(project, version):
+    package_name_format = "openstack-%(version)s" % locals()
+    path = os.path.join("/opt/bbc", package_name_format, project)
+    return path
+    
+
+class FilterModule(object):
+    ''' ursula utility filters '''
+
+    def filters(self):
+        return {
+            'ursula_package_path': ursula_package_path
+        }

--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -7,6 +7,17 @@ cinder:
 
   source:
     rev: '7b1d7a31335bd8723551c9af5c270927ad830c3f'
+  package:
+    console_scripts:
+      - cinder-all
+      - cinder-api
+      - cinder-backup
+      - cinder-manage
+      - cinder-rootwrap
+      - cinder-rtstool
+      - cinder-scheduler
+      - cinder-volume
+      - cinder-volume-usage-audit
 
   logs:
   - paths:

--- a/roles/cinder-common/meta/main.yml
+++ b/roles/cinder-common/meta/main.yml
@@ -9,4 +9,8 @@ dependencies:
     project_rev: "{{ cinder.source.rev }}"
     rootwrap: True
     when: openstack_install_method == 'source'
-
+  - role: openstack-package
+    project_name: cinder
+    rootwrap: True
+    package_alternatives: "{{ cinder.package.console_scripts }}"
+    when: openstack_install_method == 'package'

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -81,3 +81,4 @@ admin_tenant_name = service
 admin_user = cinder
 admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/cinder/api
+cafile = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt

--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -15,6 +15,18 @@ glance:
 
   source:
     rev: '0e355462833feeaa6f3124fda4bd5ff7064c8512'
+  package:
+    console_scripts:
+      - glance-api
+      - glance-cache-cleaner
+      - glance-cache-manage
+      - glance-cache-prefetcher
+      - glance-cache-pruner
+      - glance-control
+      - glance-manage
+      - glance-registry
+      - glance-replicator
+      - glance-scrubber
 
   logs:
     - paths:

--- a/roles/glance/meta/main.yml
+++ b/roles/glance/meta/main.yml
@@ -8,3 +8,7 @@ dependencies:
     project_name: glance
     project_rev: "{{ glance.source.rev }}"
     when: openstack_install_method == 'source'
+  - role: openstack-package
+    project_name: glance
+    package_alternatives: "{{ glance.package.console_scripts }}"
+    when: openstack_install_method == 'package'

--- a/roles/glance/templates/etc/glance/glance-api.conf
+++ b/roles/glance/templates/etc/glance/glance-api.conf
@@ -56,6 +56,7 @@ admin_tenant_name = service
 admin_user = glance
 admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/glance/api
+cafile = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
 
 [paste_deploy]
 flavor = keystone

--- a/roles/glance/templates/etc/glance/glance-registry.conf
+++ b/roles/glance/templates/etc/glance/glance-registry.conf
@@ -54,6 +54,7 @@ admin_tenant_name = service
 admin_user = glance
 admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/glance/registry
+cafile = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
 
 [paste_deploy]
 flavor = keystone

--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -4,6 +4,16 @@ heat:
 
   source:
     rev: 'cbef40647e35cc065e36ee86b4ca1305676f4c1b'
+  package:
+    console_scripts:
+      - heat-api
+      - heat-api-cfn
+      - heat-api-cloudwatch
+      - heat-db-setup
+      - heat-engine
+      - heat-keystone-setup
+      - heat-keystone-setup-domain
+      - heat-manage
 
   logs:
     - paths:

--- a/roles/heat/meta/main.yml
+++ b/roles/heat/meta/main.yml
@@ -8,3 +8,7 @@ dependencies:
     project_name: heat
     project_rev: "{{ heat.source.rev }}"
     when: openstack_install_method == 'source'
+  - role: openstack-package
+    project_name: heat
+    package_alternatives: "{{ heat.package.console_scripts }}"
+    when: openstack_install_method == 'package'

--- a/roles/heat/templates/etc/heat/heat.conf
+++ b/roles/heat/templates/etc/heat/heat.conf
@@ -32,3 +32,4 @@ auth_uri = https://{{ endpoints.keystone }}:5001/v2.0
 admin_tenant_name = service
 admin_user = heat
 admin_password = {{ secrets.service_password }}
+cafile = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt

--- a/roles/horizon/meta/main.yml
+++ b/roles/horizon/meta/main.yml
@@ -9,3 +9,6 @@ dependencies:
       - { name: python-memcached, version: '1.48' }
     additional_handlers: [ "compress horizon assets" ]
     when: openstack_install_method == 'source'
+  - role: openstack-package
+    project_name: horizon 
+    when: openstack_install_method == 'package'

--- a/roles/ironic-common/defaults/main.yml
+++ b/roles/ironic-common/defaults/main.yml
@@ -19,6 +19,13 @@ ironic:
 
   source:
     rev: '53171f75a64a26dcec91facbdec95b2ed7f74338'
+  package:
+    console_scripts:
+      - ironic-api
+      - ironic-conductor
+      - ironic-dbsync
+      - ironic-nova-bm-migrate  
+      - ironic-rootwrap
 
   logging:
     debug: False

--- a/roles/ironic-common/meta/main.yml
+++ b/roles/ironic-common/meta/main.yml
@@ -5,3 +5,7 @@ dependencies:
     project_rev: "{{ ironic.source.rev }}"
     rootwrap: True
     when: openstack_install_method == 'source'
+  - role: openstack-package
+    project_name: ironic
+    package_alternatives: "{{ ironic.package.console_scripts }}"
+    when: openstack_install_method == 'package'

--- a/roles/ironic-common/templates/etc/ironic/ironic.conf
+++ b/roles/ironic-common/templates/etc/ironic/ironic.conf
@@ -38,6 +38,7 @@ auth_protocol = https
 admin_tenant_name = service
 admin_user = ironic
 admin_password = {{ secrets.service_password }}
+cafile = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
 
 [neutron]
 url=https://{{ endpoints.main }}:9797

--- a/roles/keystone/defaults/main.yml
+++ b/roles/keystone/defaults/main.yml
@@ -7,6 +7,10 @@ keystone:
 
   source:
     rev: '8a7282bebd1ebfb92d9ccd87f85b8490a89da4e0'
+  package:
+    console_scripts:
+      - keystone-manage
+      - keystone-all
 
   logs:
     - paths:

--- a/roles/keystone/meta/main.yml
+++ b/roles/keystone/meta/main.yml
@@ -11,3 +11,7 @@ dependencies:
     python_requirements:
       - { name: babel, version: "{{ keystone.babel_version }}" }
     when: openstack_install_method == 'source'
+  - role: openstack-package 
+    project_name: keystone
+    package_alternatives: "{{ keystone.package.console_scripts }}"
+    when: openstack_install_method == 'package'

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -13,6 +13,37 @@ neutron:
 
   source:
     rev: '679246d7280e9fb374f8db0972b21b3653724c42'
+  package:
+    console_scripts:
+      - neutron-check-nsx-config
+      - neutron-cisco-cfg-agent
+      - neutron-db-manage
+      - neutron-debug
+      - neutron-dhcp-agent
+      - neutron-hyperv-agent
+      - neutron-ibm-agent
+      - neutron-l3-agent
+      - neutron-lbaas-agent
+      - neutron-linuxbridge-agent
+      - neutron-metadata-agent
+      - neutron-metering-agent
+      - neutron-mlnx-agent
+      - neutron-nec-agent
+      - neutron-netns-cleanup
+      - neutron-ns-metadata-proxy
+      - neutron-nsx-manage
+      - neutron-nvsd-agent
+      - neutron-ofagent-agent
+      - neutron-openvswitch-agent
+      - neutron-ovs-cleanup
+      - neutron-rootwrap
+      - neutron-rootwrap-xen-dom0
+      - neutron-ryu-agent
+      - neutron-sanity-check
+      - neutron-server
+      - neutron-sriov-nic-agent
+      - neutron-usage-audit
+      - neutron-vpn-agent
 
   logs:
     - paths:

--- a/roles/neutron-common/meta/main.yml
+++ b/roles/neutron-common/meta/main.yml
@@ -11,3 +11,8 @@ dependencies:
       - { name: alembic, version: "{{ neutron.alembic_version }}" }
     rootwrap: True
     when: openstack_install_method == 'source'
+  - role: openstack-package
+    project_name: neutron
+    rootwrap: True
+    package_alternatives: "{{ neutron.package.console_scripts }}"
+    when: openstack_install_method == 'package'

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -81,6 +81,7 @@ admin_tenant_name = service
 admin_user = neutron
 admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/neutron/api
+cafile = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
 
 [DATABASE]
 sqlalchemy_pool_size = 60

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -33,6 +33,32 @@ nova:
 
   source:
     rev: '8526a727dc20a96d7245ae836e81c29967166f77'
+  package:
+    console_scripts:
+      - nova-all
+      - nova-api
+      - nova-api-ec2
+      - nova-api-metadata
+      - nova-api-os-compute
+      - nova-baremetal-deploy-helper
+      - nova-baremetal-manage
+      - nova-cells
+      - nova-cert
+      - nova-compute
+      - nova-conductor
+      - nova-console
+      - nova-consoleauth
+      - nova-dhcpbridge
+      - nova-idmapshift
+      - nova-manage
+      - nova-network
+      - nova-novncproxy
+      - nova-objectstore
+      - nova-rootwrap
+      - nova-scheduler
+      - nova-serialproxy
+      - nova-spicehtml5proxy
+      - nova-xvpvncproxy
 
   logs:
     - paths:

--- a/roles/nova-common/meta/main.yml
+++ b/roles/nova-common/meta/main.yml
@@ -9,3 +9,9 @@ dependencies:
     project_rev: "{{ nova.source.rev }}"
     rootwrap: True
     when: openstack_install_method == 'source'
+  - role: openstack-package
+    project_name: nova
+    rootwrap: True
+    package_alternatives: "{{ nova.package.console_scripts }}"
+    when: openstack_install_method == 'package'
+

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -157,6 +157,7 @@ admin_tenant_name = service
 admin_user = nova
 admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/nova/api
+cafile = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
 
 [neutron]
 url=https://{{ endpoints.neutron }}:9797

--- a/roles/openstack-package/defaults/main.yml
+++ b/roles/openstack-package/defaults/main.yml
@@ -1,0 +1,5 @@
+openstack_package:
+  package_name: 'openstack-{{ project_name }}-{{ openstack_package_version }}'
+  repo: 'deb http://repo.openstack.blueboxgrid.com/bbc precise main'
+  repo_key_url: 'http://repo.openstack.blueboxgrid.com/blue_box_cloud.gpg.key'
+  rootwrap: "{{ rootwrap|default(False)|bool }}"

--- a/roles/openstack-package/tasks/main.yml
+++ b/roles/openstack-package/tasks/main.yml
@@ -23,6 +23,10 @@
         state=link
   when: symlink_exists.rc != 0
 
+- name: ensure project config directory exists
+  file: name="/etc/{{ project_name }}" state=directory
+  when: openstack_package.rootwrap|bool
+
 - name: stat rootwrap.d
   stat: path="/etc/{{ project_name }}/rootwrap.d"
   register: st

--- a/roles/openstack-package/tasks/main.yml
+++ b/roles/openstack-package/tasks/main.yml
@@ -30,7 +30,7 @@
 
 - name: remove rootwrap.d if a directory
   file: dest="/etc/{{ project_name }}/rootwrap.d" state=absent
-  when: openstack_package.rootwrap|bool and st.stat.isdir|bool
+  when: openstack_package.rootwrap|bool and st.stat is defined and st.stat.isdir
 
 - name: "setup {{ project_name }} rootwrap"
   file: src="/opt/openstack/current/{{ project_name }}/etc/{{ project_name }}/rootwrap.d"

--- a/roles/openstack-package/tasks/main.yml
+++ b/roles/openstack-package/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+- name: add openstack package repo key
+  apt_key: url='{{ openstack_package.repo_key_url }}'
+
+- name: add openstack package repo
+  apt_repository: repo='{{ openstack_package.repo }}'
+
+- name: "install {{ project_name }} package"
+  apt: pkg="{{ package_name|default(openstack_package.package_name) }}" 
+       update_cache=yes cache_valid_time=3600
+
+- name: setup openstack current base path
+  file: dest=/opt/openstack state=directory
+
+- name: test whether current {{ project_name }} symlink exists
+  shell: 'test -h /opt/openstack/current'
+  register: symlink_exists
+  ignore_errors: True
+
+- name: setup current symlink if it doesnt exist
+  file: src="/opt/bbc/openstack-{{ openstack_package_version }}"
+        dest=/opt/openstack/current
+        state=link
+  when: symlink_exists.rc != 0
+
+- name: stat rootwrap.d
+  stat: path="/etc/{{ project_name }}/rootwrap.d"
+  register: st
+  when: openstack_package.rootwrap|bool
+
+- name: remove rootwrap.d if a directory
+  file: dest="/etc/{{ project_name }}/rootwrap.d" state=absent
+  when: openstack_package.rootwrap|bool and st.stat.isdir|bool
+
+- name: "setup {{ project_name }} rootwrap"
+  file: src="/opt/openstack/current/{{ project_name }}/etc/{{ project_name }}/rootwrap.d"
+        dest="/etc/{{ project_name }}/rootwrap.d" state=link
+  when: openstack_package.rootwrap|bool
+
+- name: update-alternatives
+  shell: update-alternatives --install /usr/local/bin/{{ item }} {{ item }} /opt/openstack/current/{{ project_name }}/bin/{{ item }} 10 --force
+  with_items: package_alternatives
+  when: package_alternatives is defined

--- a/roles/swift-common/defaults/main.yml
+++ b/roles/swift-common/defaults/main.yml
@@ -7,3 +7,39 @@ swift:
 
   source:
     rev: '4765537cba6a6970110953f11f4e1b419d0730d3'
+  package:
+    console_scripts:
+      - swift-account-audit
+      - swift-account-auditor
+      - swift-account-info
+      - swift-account-reaper
+      - swift-account-replicator
+      - swift-account-server
+      - swift-config
+      - swift-container-auditor
+      - swift-container-info
+      - swift-container-reconciler
+      - swift-container-replicator
+      - swift-container-server
+      - swift-container-sync
+      - swift-container-updater
+      - swift-dispersion-populate
+      - swift-dispersion-report
+      - swift-drive-audit
+      - swift-form-signature
+      - swift-get-nodes
+      - swift-init
+      - swift-object-auditor
+      - swift-object-expirer
+      - swift-object-info
+      - swift-object-replicator
+      - swift-object-server
+      - swift-object-updater
+      - swift-oldies
+      - swift-orphans
+      - swift-proxy-server
+      - swift-recon
+      - swift-reconciler-enqueue
+      - swift-recon-cron
+      - swift-ring-builder
+      - swift-temp-url

--- a/roles/swift-common/meta/main.yml
+++ b/roles/swift-common/meta/main.yml
@@ -7,3 +7,7 @@ dependencies:
       - { name: python-keystoneclient, version: '1.0.0' }
     project_rev: "{{ swift.source.rev }}"
     when: openstack_install_method == 'source'
+  - role: openstack-package
+    project_name: swift
+    package_alternatives: "{{ swift.package.console_scripts }}"
+    when: openstack_install_method == 'package'


### PR DESCRIPTION
This change is similar to the recent change to support installing
from source via a common dependent role. The difference here is that
we are installing from a giftwrap artifact. This artifact includes
a virtualenv of the project being installed & the sample etc configs
for that build, but does not deal with installing services into
$PATH.
    
As we want multiple versions to be able to live side-by-side, these
packages merely provide the bits. It is up to ursula to stich them
into a running set of services.  To do that, we install the package
and ensure that '/opt/openstack/current/' exists. This will be the
point from which all other activities (ie. dealing with rootwrap,
update-alternatives, and dealing with upgrades) will take place.