### PR TITLE
logging: add surgical playbook

### DIFF
--- a/playbooks/logging.yml
+++ b/playbooks/logging.yml
@@ -1,42 +1,82 @@
 ---
-- name: Install logging and dependencies
+- name: cleanup old configs and install logstash-forwarder
   hosts: all
+  tasks:
+    - include: ../roles/cleanup/tasks/logging.yml
+    - include: ../roles/common/tasks/bbg-repo.yml
   roles:
-    - ../roles/common
     - ../roles/logging
 
-- name: keystone code and config
-  hosts: controller:db
-  roles:
-    - ../roles/keystone-common
-
-- name: neutron code and config
-  hosts: controller:db:compute:network
+- name: keystone logging
+  hosts: controller
   vars_files:
-    - ../roles/rabbitmq/defaults/main.yml
+    - ../roles/keystone/defaults/main.yml
   roles:
-    - ../roles/neutron-common
+    - role: ../roles/logging-config
+      service: keystone
+      logdata: "{{ keystone.logs }}"
 
-- name: nova code and config
-  hosts: controller:db:compute
+- name: glance logging
+  hosts: controller
   vars_files:
-    - ../roles/rabbitmq/defaults/main.yml
+    - ../roles/glance/defaults/main.yml
   roles:
-    - ../roles/nova-common
+    - role: ../roles/logging-config
+      service: glance
+      logdata: "{{ glance.logs }}"
 
-- name: swift common code and config
-  hosts: swiftnode
-  roles:
-    - ../roles/swift-common
-
-- name: glance code and config
-  hosts: controller:db
-  roles:
-    - ../roles/glance-common
-
-- name: cinder code and config
-  hosts: controller:db:compute
+- name: nova logging
+  hosts: controller:compute
   vars_files:
-    - ../roles/rabbitmq/defaults/main.yml
+    - ../roles/nova-common/defaults/main.yml
   roles:
-    - ../roles/cinder-common
+    - role: ../roles/logging-config
+      service: nova
+      logdata: "{{ nova.logs }}"
+
+- name: cinder logging
+  hosts: controller:compute
+  vars_files:
+    - ../roles/cinder-common/defaults/main.yml
+  roles:
+    - role: ../roles/logging-config
+      service: cinder
+      logdata: "{{ cinder.logs }}"
+
+- name: neutron logging
+  hosts: network:compute
+  vars_files:
+    - ../roles/neutron-common/defaults/main.yml
+  roles:
+    - role: ../roles/logging-config
+      service: neutron
+      logdata: "{{ neutron.logs }}"
+
+
+# TODO: These roles are missing logging configs!!!
+#- name: horizon logging
+#  hosts: controller
+#  roles:
+#  - role: ../roles/logging-config
+#    service: horizon
+#    logdata: "{{ horizon.logs }}"
+#
+#- name: swift logging
+#  hosts: swiftnode
+#  roles:
+#  - role: ../roles/logging-config
+#    service: swift
+#    logdata: "{{ swift.logs }}"
+
+- name: heat logging
+  hosts: heatnode
+  roles:
+  - role: ../roles/logging-config
+    service: heat
+    logdata: "{{ heat.logs }}"
+
+- name: start and check logstash-forwarder is running
+  hosts: all
+  tasks:
+    - name: start and enable logstash-forwarder service
+      service: name=logstash-forwarder state=started enabled=yes

--- a/roles/logging-config/handlers/main.yml
+++ b/roles/logging-config/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart logstash-forwarder
+  service: name=logstash-forwarder state=restarted

--- a/roles/logging-config/meta/main.yml
+++ b/roles/logging-config/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - role: logging

--- a/roles/logging-config/tasks/main.yml
+++ b/roles/logging-config/tasks/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: install log template
   template: src=etc/logstash-forwarder.d/template.conf dest=/etc/logstash-forwarder.d/{{ service }}.conf
+  notify: restart logstash-forwarder

--- a/roles/logging/tasks/main.yml
+++ b/roles/logging/tasks/main.yml
@@ -2,8 +2,26 @@
 - name: create logstash user
   user: name=logstash comment=logstash shell=/bin/false system=yes home=/opt/logstash-forwarder
 
+- name: install bbg openstack repo key
+  apt_key: url=http://apt.openstack.blueboxgrid.com/ubuntu/ursula-apt.gpg.key
+  when: ansible_distribution_version == "12.04"
+
+- name: install bbg openstack repo
+  apt_repository: repo='deb http://apt.openstack.blueboxgrid.com/ubuntu/ precise main' update_cache=yes
+  when: ansible_distribution_version == "12.04"
+
 - name: install logstash-forwarder
   apt: pkg=logstash-forwarder
+  when: ansible_distribution_version == "12.04"
+
+- name: download logstash
+  get_url: url=http://repo.openstack.blueboxgrid.com/ubuntu/pool/main/l/logstash-forwarder/logstash-forwarder_{{ logging.version }}_amd64.deb
+           dest=/tmp/logstash-forwarder_{{ logging.version }}_amd64.deb
+  when: ansible_distribution_version == "14.04"
+
+- name: install logstash
+  apt: deb=/tmp/logstash-forwarder_{{ logging.version }}_amd64.deb
+  when: ansible_distribution_version == "14.04"
 
 - name: install logstash-forwarder service
   copy: src=etc/init/logstash-forwarder.conf dest=/etc/init/logstash-forwarder.conf mode=0644


### PR DESCRIPTION
Need a more surgical approach to deploying updates to logging on existing clusters. This playbook facilitates that.

It should probably be extended to also handle logrotate and other logging related items, but this is a start to handle the log shipping.