### PR TITLE
Enable ssh pipelining in Ansible

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -9,3 +9,6 @@ connection_plugins = plugins/connection
 callback_plugins = plugins/callbacks
 transport = monkeypatched_ssh
 forks = 25
+
+[ssh_connection]
+pipelining=true


### PR DESCRIPTION
This uses a single ssh connection per task rather than 3. Could save us
some time.