### PR TITLE
Sensu should use own embedded ruby

### DIFF
--- a/roles/common/tasks/monitoring.yml
+++ b/roles/common/tasks/monitoring.yml
@@ -10,15 +10,15 @@
 - name: install sensu
   apt: pkg=sensu
 
-- name: install sensu-plugin gem
-  gem: name=sensu-plugin user_install=no include_dependencies=yes state=latest
-
 - name: sensu sudoers
   template: src=monitoring/sensu-sudoers dest=/etc/sudoers.d/sensu owner=root
             group=root mode=0440
 
 - name: ensure /etc/sudoers.d/sensu permissions are 0440
   file: path=/etc/sudoers.d/sensu mode=0440
+
+- name: sensu gems directory
+  file: dest=/opt/sensu/gems state=directory owner=sensu mode=0750
 
 - name: sensu cert directory
   file: dest=/etc/sensu/ssl state=directory owner=sensu mode=0750
@@ -35,9 +35,9 @@
   notify: restart sensu-client
   when: monitoring.client_key is defined
 
-- name: disable embedded ruby
+- name: use embedded ruby
   lineinfile: dest=/etc/default/sensu regexp=^EMBEDDED_RUBY
-              line=EMBEDDED_RUBY=false
+              line=EMBEDDED_RUBY=true
   notify: restart sensu-client
 
 - name: sensu client config

--- a/roles/memcached/defaults/main.yml
+++ b/roles/memcached/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+memcached:
+  gem:
+    url: https://rubygems.org/downloads/memcached-1.8.0.gem
+    name: memcached-1.8.0.gem

--- a/roles/memcached/tasks/main.yml
+++ b/roles/memcached/tasks/main.yml
@@ -14,7 +14,4 @@
   notify:
     - restart memcached
 
-- name: memcached gem for sensu check
-  gem: name=memcached state=latest user_install=no include_dependencies=yes
-
 - include: monitoring.yml tags=monitoring,common

--- a/roles/memcached/tasks/monitoring.yml
+++ b/roles/memcached/tasks/monitoring.yml
@@ -1,4 +1,18 @@
 ---
+- name: memcached gem requirements
+  apt: pkg={{ item }} state=present
+  with_items:
+    - libsasl2-dev
+
+- name: grab memcached gem
+  get_url: url={{ memcached.gem.url }}
+           dest=/opt/sensu/gems/{{ memcached.gem.name }}
+
+- name: memcached gem for sensu check
+  gem: name=memcached user_install=no include_dependencies=yes
+       gem_source=/opt/sensu/gems/{{ memcached.gem.name }}
+       executable=/opt/sensu/embedded/bin/gem
+
 - name: memcached stats check
   sensu_check: name=memcached-stats plugin=check-memcached-stats.rb
                args='--host {{ primary_ip }}'


### PR DESCRIPTION
* memcached gem has no deps, so pull it directly from url.  This means
  we don't need to mirror rubygems just to get a single gem.