### PR TITLE
Remove antsy install

### DIFF
--- a/roles/common/tasks/system-tools.yml
+++ b/roles/common/tasks/system-tools.yml
@@ -28,6 +28,3 @@
     - cdpr
     - sysstat
     - logrotate
-
-- name: required by custom ansible modules
-  gem: name=antsy state=latest user_install=no include_dependencies=yes


### PR DESCRIPTION
Nothing else will use this so remove the install.

This needs to merge after #791 #790 and #787