### PR TITLE
Revert "Enable PKI tokens for keystone"

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -1,8 +1,6 @@
 ---
 stack_env: example
 
-country_code: US
-
 primary_interface: 'ansible_eth0'
 primary_ip: "{{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}"
 undercloud_cidr: 10.230.7.0/24

--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -4,8 +4,6 @@ primary_interface: ansible_eth1
 primary_ip: "{{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}"
 undercloud_cidr: '172.16.0.0/24'
 
-country_code: US
-
 fqdn: openstack.example.org
 undercloud_floating_ip: "{{ hostvars[groups['controller'][0]][primary_interface]['ipv4']['address'] }}"
 secrets:

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -49,44 +49,6 @@
   notify:
     - restart keystone services
 
-- name: create keystone PKI dirs
-  file: path={{ item }} state=directory owner=keystone group=keystone
-        mode=0700
-  with_items:
-    - /etc/keystone/ssl/certs
-    - /etc/keystone/ssl/private
-
-- name: generate keystone PKI certs
-  command: keystone-manage pki_setup --keystone-user keystone
-           --keystone-group keystone
-           creates=/etc/keystone/ssl/private/cakey.pem
-  run_once: true
-  notify:
-    - restart keystone services
-
-- name: slurp keystone certs
-  slurp: src={{ item }}
-  with_items:
-    - /etc/keystone/ssl/certs/ca.pem
-    - /etc/keystone/ssl/certs/signing_cert.pem
-    - /etc/keystone/ssl/private/cakey.pem
-    - /etc/keystone/ssl/private/signing_key.pem
-  register: pki_certs
-  run_once: true
-  no_log: true
-
-- name: write out keystone certs
-  copy:
-    dest: "{{ item.item }}"
-    content: "{{ item.content | b64decode }}"
-    owner: keystone
-    group: keystone
-    mode: 0700
-  with_items: pki_certs.results
-  no_log: true
-  notify:
-    - restart keystone services
-
 - name: stop keystone service before db sync
   service: name=keystone state=stopped
   when: database_create.changed or force_sync|default('false')|bool

--- a/roles/keystone/templates/etc/keystone/keystone.conf
+++ b/roles/keystone/templates/etc/keystone/keystone.conf
@@ -22,7 +22,7 @@ driver = keystone.catalog.backends.sql.Catalog
 
 [token]
 driver = keystone.token.persistence.backends.sql.Token
-provider = keystone.token.providers.pki.Provider
+provider = keystone.token.providers.uuid.Provider
 
 # Amount of time a token should remain valid (in seconds)
 expiration = {{ keystone.token_expiration_in_seconds }}
@@ -54,7 +54,12 @@ enable = False
 #cert_required = True
 
 [signing]
-cert_subject = /C={{ country_code }}/ST=Unset/L=Unset/O=Unset/CN={{ endpoints.main }}
+#certfile = /etc/keystone/ssl/certs/signing_cert.pem
+#keyfile = /etc/keystone/ssl/private/signing_key.pem
+#ca_certs = /etc/keystone/ssl/certs/ca.pem
+#key_size = 1024
+#valid_days = 3650
+#ca_password = None
 
 [paste_deploy]
 config_file = /etc/keystone/keystone-paste.ini


### PR DESCRIPTION
PKI tokens are actually slower and are more complex. A better system
might be coming with kilo, but in the short term there is not a strong
reason to move away from UUID.

This should be backported to 1.1.x as well.