### PR TITLE
iptables: apply iptables DHCP checksum fix to network nodes

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -104,7 +104,7 @@
       tags: ['haproxy', 'infra']
 
 - name: iptables
-  hosts: controller
+  hosts: network
   roles:
     - role: iptables
       tags: ['iptables', 'infra']


### PR DESCRIPTION
The iptables role is a fix for UDP checksums on DHCP packets, it should be applied to the network nodes which run neutron DHCP agent rather than the controller nodes. This only affects stacks which are running non-collapsed roles.