### PR TITLE
Disable GRUB OS prober

### DIFF
--- a/roles/common/tasks/kernel-tuning.yml
+++ b/roles/common/tasks/kernel-tuning.yml
@@ -11,3 +11,8 @@
               regexp="^GRUB_CMDLINE_LINUX_DEFAULT="
               line="GRUB_CMDLINE_LINUX_DEFAULT=\"console=tty1{{ serial_console_cmdline|default('') }} consoleblank=0\""
   notify: update grub config
+
+- name: "Disable GRUB OS prober so we don't try to boot instance's cinder volumes"
+  lineinfile: dest=/etc/default/grub
+              line="GRUB_DISABLE_OS_PROBER=true"
+  notify: update grub config


### PR DESCRIPTION
Disable GRUB OS prober so we don't try to boot instance's cinder volumes.