### PR TITLE
system tools: add mcelog

### DIFF
--- a/roles/common/tasks/system-tools.yml
+++ b/roles/common/tasks/system-tools.yml
@@ -15,6 +15,7 @@
     - iotop
     - iperf
     - ltrace
+    - mcelog
     - mtr
     - netcat
     - pstack


### PR DESCRIPTION
Add mcelog for monitoring hardware ECC type errors