### PR TITLE
Cleanup remaining calls to restart_if_present

### DIFF
--- a/roles/heat/handlers/main.yml
+++ b/roles/heat/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: restart heat services
-  restart_if_present: service={{ item }}
+  service: name={{ item }} state=restarted must_exist=false
   when: restart|default('True')
   with_items:
     - heat-api

--- a/roles/horizon/handlers/main.yml
+++ b/roles/horizon/handlers/main.yml
@@ -1,10 +1,10 @@
 ---
 # not really a "horizon service" but horizon is the outlier
 - name: restart horizon services
-  restart_if_present: service=apache2
+  service: name=apache2 state=restarted must_exist=false
 
 - name: restart apache
-  restart_if_present: service=apache2
+  service: name=apache2 state=restarted must_exist=false
 
 - name: compress horizon assets
   command: sudo -u www-data tools/with_venv.sh ./manage.py compress

--- a/roles/ironic-common/handlers/main.yml
+++ b/roles/ironic-common/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: restart ironic services
-  restart_if_present: service={{ item }}
+  service: name={{ item }} state=restarted must_exist=false
   when: restart|default('True')
   with_items:
     - ironic-api


### PR DESCRIPTION
Now that restart_if_present is gone, update some existing handlers to
make use of must_exist=false instead.