### PR TITLE
backport: logging: code cleanup

### DIFF
--- a/roles/logging-config/meta/main.yml
+++ b/roles/logging-config/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: logging

--- a/roles/logging-config/templates/etc/logstash-forwarder.d/template.conf
+++ b/roles/logging-config/templates/etc/logstash-forwarder.d/template.conf
@@ -1,23 +1,20 @@
 {
   "files": [
-    {% if logdata -%}
-      {% for item in logdata %}
-      {
-      "paths": [
-	{% for path in item.paths %}
-	"{{ path }}"{% if not loop.last %},{% endif %}
+    {% for item in logdata %}
+    {
+    "paths":
+      {{ item.paths | to_nice_json }}
+    ,
+    "fields":
+      {% if item.fields and logging.follow.global_fields %}
+      {# Merge the two field dicts together #}
+      {% set _dummy = item.fields.update(logging.follow.global_fields) %}
+      {{ item.fields | to_nice_json }}
+      {% elif logging.follow.global_fields %}
+      {{ logging.follow.global_fields | to_nice_json }}
+      {% endif %}
+    }{% if not loop.last %},{% endif %}
 
-	{% endfor %}
-      ],
-      "fields": {
-	{% for key, value in item.fields.items() %}
-	"{{ key }}": "{{ value }}"{% if not loop.last %},{% endif %}
-
-	{% endfor %}
-      }
-      }{% if not loop.last %},{% endif %}
-
-      {% endfor -%}
-    {%- endif -%}
+    {% endfor -%}
   ]
 }

--- a/roles/logging/defaults/main.yml
+++ b/roles/logging/defaults/main.yml
@@ -1,7 +1,17 @@
 logging:
+  version: 0.3.1
+  download:
+    url: http://repo.openstack.blueboxgrid.com/ubuntu/pool/main/l/logstash-forwarder/logstash-forwarder_0.3.1_amd64.deb
   follow:
     enabled: true
-    logs: []
+    global_fields:
+      customer_id: "unknown"
+      cluster_name: "unknown"
+    logs:
+      - paths:
+          - /var/log/syslog
+        fields:
+          type: syslog
   forward:
     host: null
     port: 4560

--- a/roles/logging/files/etc/init/logstash-forwarder.conf
+++ b/roles/logging/files/etc/init/logstash-forwarder.conf
@@ -10,6 +10,6 @@ respawn limit 3 30
 start on runlevel [2345]
 stop on runlevel [!2345]
 
-chdir /opt/logstash-forwarder
+chdir /var/lib/logstash
 
-exec bin/logstash-forwarder.sh -config /etc/logstash-forwarder.d
+exec /opt/logstash-forwarder/bin/logstash-forwarder.sh -config /etc/logstash-forwarder.d

--- a/roles/logging/meta/main.yml
+++ b/roles/logging/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: common

--- a/roles/logging/tasks/main.yml
+++ b/roles/logging/tasks/main.yml
@@ -1,21 +1,13 @@
 ---
 - name: create logstash user
-  user: name=logstash comment=logstash shell=/bin/false system=yes home=/opt/logstash-forwarder
-
-- name: install bbg openstack repo key
-  apt_key: url=http://apt.openstack.blueboxgrid.com/ubuntu/ursula-apt.gpg.key
-  when: ansible_distribution_version == "12.04"
-
-- name: install bbg openstack repo
-  apt_repository: repo='deb http://apt.openstack.blueboxgrid.com/ubuntu/ precise main' update_cache=yes
-  when: ansible_distribution_version == "12.04"
+  user: name=logstash comment="LogStash Service User" shell=/sbin/nologin system=yes home=/var/lib/logstash
 
 - name: install logstash-forwarder
   apt: pkg=logstash-forwarder
   when: ansible_distribution_version == "12.04"
 
 - name: download logstash
-  get_url: url=http://repo.openstack.blueboxgrid.com/ubuntu/pool/main/l/logstash-forwarder/logstash-forwarder_{{ logging.version }}_amd64.deb
+  get_url: url="{{ logging.download.url }}"
            dest=/tmp/logstash-forwarder_{{ logging.version }}_amd64.deb
   when: ansible_distribution_version == "14.04"
 

--- a/roles/logging/templates/etc/logstash-forwarder.d/main.conf
+++ b/roles/logging/templates/etc/logstash-forwarder.d/main.conf
@@ -2,23 +2,28 @@
   "network": {
     "servers": [
       "{{ logging.forward.host }}:{{ logging.forward.port }}"
-    ],
+    ]
 
     {% if logging.forward.tls.ca_cert %}
-    "ssl ca": "/usr/local/share/ca-certificates/logging-forward.crt"
+    ,"ssl ca": "/usr/local/share/ca-certificates/logging-forward.crt"
     {% endif -%}
   },
   "files": [
-    {% if logging.follow.logs %}
+    {% for item in logging.follow.logs %}
     {
-      "paths": [
-	{% for item in logging.follow.logs %}
-	"{{ item }}"{% if not loop.last %},{% endif %}
+    "paths":
+      {{ item.paths | to_nice_json }}
+    ,
+    "fields":
+      {% if item.fields and logging.follow.global_fields %}
+      {# Merge the two field dicts together #}
+      {% set _dummy = item.fields.update(logging.follow.global_fields) %}
+      {{ item.fields | to_nice_json }}
+      {% elif logging.follow.global_fields %}
+      {{ logging.follow.global_fields | to_nice_json }}
+      {% endif %}
+    }{% if not loop.last %},{% endif %}
 
-	{% endfor -%}
-      ],
-      "fields": { "type": "openstack" }
-    }
-    {% endif %}
+    {% endfor -%}
   ]
 }


### PR DESCRIPTION
There was a missing `logging.version` option. I fixed that, and also backported the rest of the updates I have made to the role while building out the ELK stack.

This now also supports the `logging.global_fields` dictionary which will be critical in proper log data placement.