### PR TITLE
Add cinder v2 endpoint to catalog

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -51,6 +51,7 @@ endpoints:
   neutron:  "{{ fqdn }}"
   vnc:      "{{ fqdn }}"
   cinder:   "{{ fqdn }}"
+  cinderv2: "{{ fqdn }}"
   heat:     "{{ fqdn }}"
   heat-cfn: "{{ fqdn }}"
   ironic: "{{ fqdn }}"
@@ -296,6 +297,12 @@ keystone:
       public_url: https://{{ endpoints.main }}:8778/v1/%(tenant_id)s
       internal_url: https://{{ endpoints.main }}:8778/v1/%(tenant_id)s
       admin_url: https://{{ endpoints.main }}:8778/v1/%(tenant_id)s
+    - name: cinderv2
+      type: volumev2
+      description: 'Volume Service v2'
+      public_url: https://{{ endpoints.main }}:8778/v2/%(tenant_id)s
+      internal_url: https://{{ endpoints.main }}:8778/v2/%(tenant_id)s
+      admin_url: https://{{ endpoints.main }}:8778/v2/%(tenant_id)s
     - name: heat
       type: orchestration
       description: 'Heat Orchestration API'

--- a/roles/client/templates/root/stackrc
+++ b/roles/client/templates/root/stackrc
@@ -6,3 +6,4 @@ export OS_TENANT_NAME=admin
 export OS_CACERT=/opt/stack/ssl/openstack.crt
 {% endif -%}
 export OS_NO_CACHE=True
+export OS_VOLUME_API_VERSION=2

--- a/roles/common/templates/etc/sensu/stackrc
+++ b/roles/common/templates/etc/sensu/stackrc
@@ -7,3 +7,4 @@ export OS_CACERT=/opt/stack/ssl/openstack.crt
 {% endif -%}
 export OS_NO_CACHE=True
 export NOVACLIENT_UUID_CACHE_DIR=/tmp/sensu
+export OS_VOLUME_API_VERSION=2

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -165,6 +165,7 @@ metadata_proxy_shared_secret={{ secrets.metadata_proxy_shared_secret }}
 api_servers={{ nova.glance_endpoint }}
 
 [cinder]
+catalog_info = volumev2:cinderv2:publicURL
 ca_certificates_file = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
 
 {% if ironic.enabled -%}


### PR DESCRIPTION
nova-api filters cinder endpoints by "volume" and "volumev2", but needs
 a further hint to actually use volumev2 from the catalog to use the v2
 API. cinderclient also expects the endpoint to be volumev2 when asked to
 use the v2 API. This commit adds the new endpoint in. The v1 endpoint is
 left in place so that cinderclient continues to work without end users
 needing to add the forced switch to v2, however we DO put that switch
 into our stackrc.