### PR TITLE
Hard set the supposed metadata agent workers

### DIFF
--- a/roles/neutron-common/templates/etc/neutron/metadata_agent.ini
+++ b/roles/neutron-common/templates/etc/neutron/metadata_agent.ini
@@ -14,3 +14,5 @@ nova_metadata_ip = {{ endpoints.nova }}
 nova_metadata_port = 8775
 
 metadata_proxy_shared_secret = {{ secrets.metadata_proxy_shared_secret }}
+
+metadata_workers = 2


### PR DESCRIPTION
Docs say default is 2, but actually its getting NCPUs. 32 is far too
many.