### PR TITLE
Add keystonev3 service to the catalog

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -272,6 +272,12 @@ keystone:
       public_url: https://{{ endpoints.main }}:5001/v2.0
       internal_url: https://{{ endpoints.main }}:5001/v2.0
       admin_url: https://{{ endpoints.main }}:35358/v2.0
+    - name: keystonev3
+      type: identityv3
+      description: 'Identity Service v3'
+      public_url: https://{{ endpoints.main }}:5001/v3
+      internal_url: https://{{ endpoints.main }}:5001/v3
+      admin_url: https://{{ endpoints.main }}:35358/v3
     - name: nova
       type: compute
       description: 'Compute Service'

--- a/roles/client/templates/root/stackrc
+++ b/roles/client/templates/root/stackrc
@@ -1,5 +1,5 @@
 export OS_PASSWORD={{ secrets.provider_admin_password }}
-export OS_AUTH_URL=https://{{ endpoints.main }}:5001/v2.0
+export OS_AUTH_URL={{ endpoints.auth_uri }}
 export OS_USERNAME=provider_admin
 export OS_TENANT_NAME=admin
 {% if client.self_signed_cert -%}

--- a/roles/common/templates/etc/sensu/stackrc
+++ b/roles/common/templates/etc/sensu/stackrc
@@ -1,5 +1,5 @@
 export OS_PASSWORD={{ monitoring.openstack.user.password }}
-export OS_AUTH_URL=https://{{ endpoints.main }}:5001/v2.0
+export OS_AUTH_URL={{ endpoints.auth_uri }}
 export OS_USERNAME={{ monitoring.openstack.user.username }}
 export OS_TENANT_NAME={{ monitoring.openstack.user.tenant }}
 {% if client.self_signed_cert -%}

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -62,7 +62,7 @@ nova_region_name = RegionOne
 nova_admin_username = neutron
 nova_admin_tenant_id = {{ service_tenant.id }}
 nova_admin_password = {{ secrets.service_password }}
-nova_admin_auth_url = https://{{ endpoints.keystone }}:5001/v2.0
+nova_admin_auth_url = {{ endpoints.auth_uri }}
 nova_ca_certificates_file = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
 
 [QUOTAS]

--- a/roles/openstack-setup/tasks/cinder.yml
+++ b/roles/openstack-setup/tasks/cinder.yml
@@ -3,7 +3,7 @@
   action: |
     cinder_volume_type
       volume_type={{ item }}
-      auth_url=https://{{ endpoints.main }}:5001/v2.0/
+      auth_url={{ endpoints.auth_uri }}
       login_username=provider_admin
       login_password={{ secrets.provider_admin_password }}
       login_tenant_name=admin
@@ -18,7 +18,7 @@
       cipher={{ item.cipher }}
       key_size={{ item.key_size }}
       control_location={{ item.control_location }}
-      auth_url=https://{{ endpoints.main }}:5001/v2.0/
+      auth_url={{ endpoints.auth_uri }}
       login_username=provider_admin
       login_password={{ secrets.provider_admin_password }}
       login_tenant_name=admin

--- a/roles/openstack-setup/tasks/images.yml
+++ b/roles/openstack-setup/tasks/images.yml
@@ -4,7 +4,7 @@
                 copy_from={{ item.url }}
                 container_format=bare
                 disk_format=qcow2
-                auth_url=https://{{ endpoints.main }}:5001/v2.0/
+                auth_url={{ endpoints.auth_uri }}
                 login_tenant_name=admin
                 login_username=provider_admin
                 login_password={{ secrets.provider_admin_password }}

--- a/roles/openstack-setup/tasks/networks.yml
+++ b/roles/openstack-setup/tasks/networks.yml
@@ -7,7 +7,7 @@
                    router_external={{ item.external }}
                    provider_segmentation_id={{ item.segmentation_id }}
                    provider_physical_network={{ item.provider_physical_network }}
-                   auth_url=https://{{ endpoints.main }}:5001/v2.0/
+                   auth_url={{ endpoints.auth_uri }}
                    login_tenant_name=admin
                    login_username=provider_admin
                    login_password={{ secrets.provider_admin_password }}
@@ -21,7 +21,7 @@
                   gateway_ip={{ item.gateway_ip }}
                   ip_version={{ item.ip_version }}
                   state=present
-                  auth_url=https://{{ endpoints.main }}:5001/v2.0/
+                  auth_url={{ endpoints.auth_uri }}
                   login_tenant_name=admin
                   login_username=provider_admin
                   login_password={{ secrets.provider_admin_password }}
@@ -32,7 +32,7 @@
                   name={{ item.name }}
                   tenant_name={{ item.tenant_name }}
                   admin_state_up=true
-                  auth_url=https://{{ endpoints.main }}:5001/v2.0/
+                  auth_url={{ endpoints.auth_uri }}
                   login_tenant_name=admin
                   login_username=provider_admin
                   login_password={{ secrets.provider_admin_password }}
@@ -42,7 +42,7 @@
   neutron_router_gateway: state=present
                           router_name={{ item.name }}
                           network_name=external
-                          auth_url=https://{{ endpoints.main }}:5001/v2.0/
+                          auth_url={{ endpoints.auth_uri }}
                           login_tenant_name=admin
                           login_username=provider_admin
                           login_password={{ secrets.provider_admin_password }}
@@ -53,7 +53,7 @@
                             subnet_name={{ item.subnet_name }}
                             tenant_name={{ item.tenant_name }}
                             state=present
-                            auth_url=https://{{ endpoints.main }}:5001/v2.0/
+                            auth_url={{ endpoints.auth_uri }}
                             login_tenant_name=admin
                             login_username=provider_admin
                             login_password={{ secrets.provider_admin_password }}

--- a/roles/openstack-setup/tasks/users.yml
+++ b/roles/openstack-setup/tasks/users.yml
@@ -7,7 +7,7 @@
                     internal_url={{ item.internal_url }}
                     admin_url={{ item.admin_url }}
                     region=RegionOne
-                    auth_url=https://{{ endpoints.main }}:5001/v2.0/
+                    auth_url={{ endpoints.auth_uri }}
                     tenant_name=admin
                     login_user=provider_admin
                     login_password={{ secrets.provider_admin_password }}

--- a/roles/swift-common/templates/etc/swift/dispersion.conf
+++ b/roles/swift-common/templates/etc/swift/dispersion.conf
@@ -1,5 +1,5 @@
 [dispersion]
-auth_url = https://{{ endpoints.keystone }}:5001/v2.0
+auth_url = {{ endpoints.auth_uri }}
 auth_user = service:swift
 auth_key = {{ secrets.service_password }}
 auth_version = 2.0


### PR DESCRIPTION
This is one way of exposing the v3 API by way of the catalog. The
api-paste already exposes the v3 API, but it wasn't advertised anywhere.
Clients still won't automatically use the v3 API as nothing really looks
for this service name/type, however users who wish to manually make use
of the v3 API can discover it by way of the catalog.

This change also removes long form reference to the auth_uri and
instead makes use of the variable, which will help if we ever change
versions exposed.