### PR TITLE
Temporarily pin the version of python-novaclient

### DIFF
--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -4,7 +4,7 @@ client:
   names:
     - python-keystoneclient
     - python-glanceclient
-    - python-novaclient
+    - python-novaclient==2.20.0
     - python-neutronclient
     - python-cinderclient
     - python-heatclient


### PR DESCRIPTION
This avoids getting 404s on volume attach:
https://bugs.launchpad.net/nova/+bug/1423695

Can be removed when something newer than 2.21.0 ships. Fix is merged to
master but no new pip yet.