### PR TITLE
Limit neutron metadata workers

### DIFF
--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -2,6 +2,7 @@
 neutron:
   rev: dbeaa70172bc2f40e587c5e2f62bb28b600b7e25
   api_workers: 3
+  metadata_workers: 3
   agent_down_time: 20
   report_interval: 4
   dhcp_dns_servers:

--- a/roles/neutron-common/templates/etc/neutron/metadata_agent.ini
+++ b/roles/neutron-common/templates/etc/neutron/metadata_agent.ini
@@ -7,6 +7,8 @@ admin_tenant_name = service
 admin_user = neutron
 admin_password = {{ secrets.service_password }}
 
+metadata_workers = {{ neutron.metadata_workers }}
+
 # Network service endpoint type to pull from the keystone catalog
 # endpoint_type = adminURL
 


### PR DESCRIPTION
The default is not 2 as documented, but NCPUs which can be... large.
Some evidence shows a lot of metadata workers can overwork neutron, so
limit them down.