### PR TITLE
Increase neutron vif plugging timeout to 300

### DIFF
--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -73,7 +73,7 @@ libvirt_vif_driver=nova.virt.libvirt.vif.LibvirtHybridOVSBridgeDriver
 
 # Require Neutron callback to boot instance
 vif_plugging_is_fatal = True
-vif_plugging_timeout = 60
+vif_plugging_timeout = 300
 
 security_group_api=neutron
 firewall_driver=nova.virt.firewall.NoopFirewallDriver


### PR DESCRIPTION
This matches the upstream default and does drastically reduce neutron
interface timeouts on builds.