### PR TITLE
Allow tuning haproxy bufsize

### DIFF
--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+haproxy:
+  bufsize: 16384

--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -24,6 +24,7 @@ global
   group haproxy
   daemon
   pidfile /var/run/haproxy/haproxy.pid
+  tune.bufsize {{ haproxy.bufsize }}
 
 defaults
   log global


### PR DESCRIPTION
In larger capacity environments it's possible to have nova generate
requests to neutron that are larger than the haproxy allowed default of
1/2 bufsize (since it has to rewrite). Tuning this up will consume more
memory and reduce capacity though, so it should only be done on larger
systems. This provides an easy way to bump it up from the default when
deemed necessary.