### PR TITLE
Remove hard set metadata_workers

### DIFF
--- a/roles/neutron-common/templates/etc/neutron/metadata_agent.ini
+++ b/roles/neutron-common/templates/etc/neutron/metadata_agent.ini
@@ -16,5 +16,3 @@ nova_metadata_ip = {{ endpoints.nova }}
 nova_metadata_port = 8775
 
 metadata_proxy_shared_secret = {{ secrets.metadata_proxy_shared_secret }}
-
-metadata_workers = 2


### PR DESCRIPTION
A later PR added configurable metadata_workers and we want to use that
one instead of the hard set 2.