### PR TITLE
Set Nimble subnet label when appropriate

### DIFF
--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -70,6 +70,9 @@ volume_clear_size = {{ cinder.volume_clear_size }}
 san_ip = {{ backend.san_ip }}
 san_login = {{ backend.san_login }}
 san_password = {{ backend.san_password }}
+{% if backend.nimble_subnet_label is defined %}
+nimble_subnet_label = {{ backend.nimble_subnet_label }}
+{% endif %}
 {% endif %}
 
 {% endfor -%}


### PR DESCRIPTION
When a Nimble device sans 2 networks we need to tell it which subnet
to use for the volume's provider_location. This options provides for
that ability.