### PR TITLE
Reserve disk space for nova hosts

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -99,6 +99,7 @@ nova:
   api_workers: 1
   conductor_workers: 1
   metadata_api_workers: 1
+  reserved_host_disk_mb: 50
   logging:
     debug: True
     verbose: True

--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -144,6 +144,7 @@ nova:
   metadata_api_workers: 1
   ec2_workers: 1
   libvirt_type: qemu
+  reserved_host_disk_mb: 50
   logging:
     debug: True
 

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -24,6 +24,7 @@ nova:
   qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.6~cloud0
   librdb1_version: 0.80.5-0ubuntu0.14.04.1~cloud0
   glance_endpoint: http://{{ endpoints.glance }}:9292
+  reserved_host_disk_mb: 51200
   trusty:
     libvirt_bin_version: 1.2.2-0ubuntu13.1.7
     python_libvirt_version: 1.2.2-0ubuntu2

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -116,6 +116,7 @@ reserved_host_memory_mb=0
 {% elif inventory_hostname in groups['controller'] -%}
 reserved_host_memory_mb=4096
 {% endif %}
+reserved_host_disk_mb = {{ nova.reserved_host_disk_mb }}
 
 compute_driver={{ nova.compute_driver }}
 resume_guests_state_on_host_boot=true


### PR DESCRIPTION
Without reserving space an user could easily exhaust all the space on a
host leading to difficult situations. Instead of hardcoding at 50G this
is configurable with a default, and set to much smaller for our test and
CI environments.