### PR TITLE
Allow live snapshots in nova

### DIFF
--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -122,6 +122,8 @@ resume_guests_state_on_host_boot=true
 
 use_virtio_for_bridges=true
 
+disable_libvirt_livesnapshot=false
+
 [libvirt]
 virt_type={{ nova.libvirt_type }}
 {% if nova.libvirt_cpu_model -%}


### PR DESCRIPTION
There is a workarounds option to enable/disable live snapshots. It
defaults to disabling so we need to explicitly enable it. The code that
will read this is on master nova and in a bbg fork of stable/juno.