### PR TITLE
nova hypervisor can be shortname or fqdn

### DIFF
--- a/roles/common/files/sensu_plugins/metrics-nova.py
+++ b/roles/common/files/sensu_plugins/metrics-nova.py
@@ -51,9 +51,10 @@ def main():
         hypervisors = client.hypervisors.list()
 
     for hv in hypervisors:
+        hostname = hv.hypervisor_hostname.split('.')[0]
         for key, value in hv.to_dict().iteritems():
             if key in METRIC_KEYS:
-                output_metric('{}.{}.{}'.format(args.scheme, hv.hypervisor_hostname, key), value)
+                output_metric('{}.{}.{}'.format(args.scheme, hostname, key), value)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
The metric should only be the shortname... because
of graphite dot pathing.