### PR TITLE
Neutron: define name servers for subnets

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -174,6 +174,9 @@ neutron:
   service:
     envs:
       - "REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"
+  tenant_nameservers:
+    - 8.8.4.4
+    - 8.8.8.8
 
 glance:
   api_workers: 1

--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -180,6 +180,9 @@ neutron:
   router_interfaces: []
   logging:
     debug: True
+  tenant_nameservers:
+    - 8.8.4.4
+    - 8.8.8.8
 
 glance:
   api_workers: 1

--- a/library/neutron_subnet
+++ b/library/neutron_subnet
@@ -10,11 +10,11 @@
 #
 # This software is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+# along with this software. If not, see <http://www.gnu.org/licenses/>.
 
 try:
     from neutronclient.neutron import client
@@ -25,9 +25,10 @@ except ImportError:
 DOCUMENTATION = '''
 ---
 module: neutron_subnet
-short_description: Add/Remove floating ip from an instance
+version_added: "1.2"
+short_description: Add/Remove floating IP from an instance
 description:
-   - Add or Remove a floating ip to an instance
+   - Add or Remove a floating IP to an instance
 options:
    login_username:
      description:
@@ -46,7 +47,7 @@ options:
      default: True
    auth_url:
      description:
-        - The keystone url for authentication
+        - The keystone URL for authentication
      required: false
      default: 'http://127.0.0.1:35357/v2.0/'
    region_name:
@@ -61,12 +62,12 @@ options:
      default: present
    network_name:
      description:
-        - Name of the nework to which the subnet should be attached
+        - Name of the network to which the subnet should be attached
      required: true
      default: None
    cidr:
      description:
-        - The cidr representation of the subnet that should be assigned to the subnet
+        - The CIDR representation of the subnet that should be assigned to the subnet
      required: true
      default: None
    tenant_name:
@@ -81,7 +82,7 @@ options:
      default: 4
    enable_dhcp:
      description:
-        - Wether DHCP should be enabled for this subnet.
+        - Whether DHCP should be enabled for this subnet.
      required: false
      default: true
    gateway_ip:
@@ -89,26 +90,38 @@ options:
         - The ip that would be assigned to the gateway for this subnet
      required: false
      default: None
+   dns_nameservers:
+     description:
+        - DNS nameservers for this subnet, comma-separated
+     required: false
+     default: None
    allocation_pool_start:
      description:
-        - From the subnet pool the starting address from which the ip should be allocated
+        - From the subnet pool the starting address from which the IP should be allocated
      required: false
      default: None
    allocation_pool_end:
      description:
-        - From the subnet pool the last ip that should be assigned to the virtual machines
+        - From the subnet pool the last IP that should be assigned to the virtual machines
      required: false
      default: None
-examples:
-  - code: "neutron_subnet: state=present login_username=admin login_password=admin login_tenant_name=admin tenant_name=tenant1
-                     network_name=network1 name=net1subnet cidr=192.168.0.0/24"
-    description: "Create a subnet for a tenant with the specified subnet"
-
+   host_routes:
+     description:
+        - Host routes for this subnet, list of dictionaries, e.g. [{destination: 0.0.0.0/0, nexthop: 123.456.78.9}, {destination: 192.168.0.0/24, nexthop: 192.168.0.1}]
+     required: false
+     default: None
 requirements: ["neutron", "keystoneclient"]
 '''
 
-_os_keystone   = None
-_os_tenant_id  = None
+EXAMPLES = '''
+# Create a subnet for a tenant with the specified subnet
+- neutron_subnet: state=present login_username=admin login_password=admin
+                  login_tenant_name=admin tenant_name=tenant1
+                  network_name=network1 name=net1subnet cidr=192.168.0.0/24"
+'''
+
+_os_keystone = None
+_os_tenant_id = None
 _os_network_id = None
 
 def _get_ksclient(module, kwargs):
@@ -116,14 +129,13 @@ def _get_ksclient(module, kwargs):
         kclient = ksclient.Client(username=kwargs.get('login_username'),
                                  password=kwargs.get('login_password'),
                                  tenant_name=kwargs.get('login_tenant_name'),
-                                 auth_url=kwargs.get('auth_url'),
-                                 cacert=kwargs.get('cacert'))
+                                 auth_url=kwargs.get('auth_url'))
     except Exception as e:
         module.fail_json(msg = "Error authenticating to the keystone: %s" %e.message)
     global _os_keystone
     _os_keystone = kclient
     return kclient
-
+ 
 
 def _get_endpoint(module, ksclient):
     try:
@@ -134,17 +146,16 @@ def _get_endpoint(module, ksclient):
 
 def _get_neutron_client(module, kwargs):
     _ksclient = _get_ksclient(module, kwargs)
-    token     = _ksclient.auth_token
-    endpoint  = _get_endpoint(module, _ksclient)
+    token = _ksclient.auth_token
+    endpoint = _get_endpoint(module, _ksclient)
     kwargs = {
-            'token':        token,
-            'endpoint_url': endpoint,
-            'ca_cert': kwargs.get('cacert')
+            'token': token,
+            'endpoint_url': endpoint
     }
     try:
         neutron = client.Client('2.0', **kwargs)
     except Exception as e:
-        module.fail_json(msg = " Error in connecting to neutron: %s" % str(e))
+        module.fail_json(msg = " Error in connecting to Neutron: %s" % e.message)
     return neutron
 
 def _set_tenant_id(module):
@@ -169,7 +180,7 @@ def _get_net_id(neutron, module):
     try:
         networks = neutron.list_networks(**kwargs)
     except Exception as e:
-        module.fail_json(msg = "Error in listing neutron networks: %s" % str(e))
+        module.fail_json("Error in listing Neutron networks: %s" % e.message)
     if not networks['networks']:
             return None
     return networks['networks'][0]['id']
@@ -197,59 +208,68 @@ def _get_subnet_id(module, neutron):
 def _create_subnet(module, neutron):
     neutron.format = 'json'
     subnet = {
-            'name':        module.params['name'],
-            'ip_version':  module.params['ip_version'],
+            'name': module.params['name'],
+            'ip_version': module.params['ip_version'],
             'enable_dhcp': module.params['enable_dhcp'],
-            'tenant_id':   _os_tenant_id,
-            'gateway_ip':  module.params['gateway_ip'],
-            'network_id':  _os_network_id,
-            'cidr':        module.params['cidr'],
+            'tenant_id': _os_tenant_id,
+            'gateway_ip': module.params['gateway_ip'],
+            'dns_nameservers': module.params['dns_nameservers'],
+            'network_id': _os_network_id,
+            'cidr': module.params['cidr'],
+            'host_routes': module.params['host_routes'],
     }
     if module.params['allocation_pool_start'] and module.params['allocation_pool_end']:
         allocation_pools = [
             {
                 'start' : module.params['allocation_pool_start'],
-                'end'   :  module.params['allocation_pool_end']
+                'end' : module.params['allocation_pool_end']
             }
         ]
         subnet.update({'allocation_pools': allocation_pools})
     if not module.params['gateway_ip']:
         subnet.pop('gateway_ip')
+    if module.params['dns_nameservers']:
+        subnet['dns_nameservers'] = module.params['dns_nameservers'].split(',')
+    else:
+        subnet.pop('dns_nameservers')
+    if not module.params['host_routes']:
+        subnet.pop('host_routes')
     try:
         new_subnet = neutron.create_subnet(dict(subnet=subnet))
     except Exception, e:
         module.fail_json(msg = "Failure in creating subnet: %s" % e.message)
     return new_subnet['subnet']['id']
-
-
+        
+                
 def _delete_subnet(module, neutron, subnet_id):
     try:
         neutron.delete_subnet(subnet_id)
     except Exception as e:
         module.fail_json( msg = "Error in deleting subnet: %s" % e.message)
     return True
-
-
+        
+                
 def main():
-
+    
     module = AnsibleModule(
         argument_spec = dict(
-            login_username          = dict(default='admin'),
-            login_password          = dict(required=True),
-            login_tenant_name       = dict(required='True'),
-            auth_url                = dict(default='http://127.0.0.1:35357/v2.0/'),
-            cacert                  = dict(default=None),
-            region_name             = dict(default=None),
-            name                    = dict(required=True),
-            network_name            = dict(required=True),
-            cidr                    = dict(required=True),
-            tenant_name             = dict(default=None),
-            state                   = dict(default='present', choices=['absent', 'present']),
-            ip_version              = dict(default='4', choices=['4', '6']),
-            enable_dhcp             = dict(default='true', choices=BOOLEANS),
-            gateway_ip              = dict(default=None),
-            allocation_pool_start   = dict(default=None),
-            allocation_pool_end     = dict(default=None),
+            login_username = dict(default='admin'),
+            login_password = dict(required=True),
+            login_tenant_name = dict(required='True'),
+            auth_url = dict(default='http://127.0.0.1:35357/v2.0/'),
+            region_name = dict(default=None),
+            name = dict(required=True),
+            network_name = dict(required=True),
+            cidr = dict(required=True),
+            tenant_name = dict(default=None),
+            state = dict(default='present', choices=['absent', 'present']),
+            ip_version = dict(default='4', choices=['4', '6']),
+            enable_dhcp = dict(default='true', choices=BOOLEANS),
+            gateway_ip = dict(default=None),
+            dns_nameservers = dict(default=None),
+            allocation_pool_start = dict(default=None),
+            allocation_pool_end = dict(default=None),
+            host_routes = dict(default=None),
         ),
     )
     neutron = _get_neutron_client(module, module.params)
@@ -268,8 +288,7 @@ def main():
         else:
             _delete_subnet(module, neutron, subnet_id)
             module.exit_json(changed = True, result = "deleted")
-
+                
 # this is magic, see lib/ansible/module.params['common.py
-#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+from ansible.module_utils.basic import *
 main()
-

--- a/roles/openstack-setup/tasks/networks.yml
+++ b/roles/openstack-setup/tasks/networks.yml
@@ -20,6 +20,7 @@
                   enable_dhcp={{ item.enable_dhcp }}
                   gateway_ip={{ item.gateway_ip }}
                   ip_version={{ item.ip_version }}
+                  dns_nameservers={{ neutron.tenant_nameservers|join(',') }}
                   state=present
                   auth_url=https://{{ endpoints.main }}:5001/v2.0/
                   login_tenant_name=admin


### PR DESCRIPTION
This will allow instances to use a external nameserver whose IP will not
change when migrating the DHCP namespaces between network nodes on
failover.