### PR TITLE
logrotate: compress log after rotation

### DIFF
--- a/playbooks/logging.yml
+++ b/playbooks/logging.yml
@@ -3,7 +3,6 @@
   hosts: all
   tasks:
     - include: ../roles/cleanup/tasks/logging.yml
-    - include: ../roles/common/tasks/bbg-repo.yml
   roles:
     - ../roles/logging
 

--- a/playbooks/logging.yml
+++ b/playbooks/logging.yml
@@ -15,6 +15,8 @@
     - role: ../roles/logging-config
       service: keystone
       logdata: "{{ keystone.logs }}"
+  tasks:
+    - include: ../roles/keystone/tasks/logging.yml
 
 - name: glance logging
   hosts: controller
@@ -24,6 +26,8 @@
     - role: ../roles/logging-config
       service: glance
       logdata: "{{ glance.logs }}"
+  tasks:
+    - include: ../roles/glance/tasks/logging.yml
 
 - name: nova logging
   hosts: controller:compute
@@ -33,6 +37,8 @@
     - role: ../roles/logging-config
       service: nova
       logdata: "{{ nova.logs }}"
+  tasks:
+    - include: ../roles/nova-common/tasks/logging.yml
 
 - name: cinder logging
   hosts: controller:compute
@@ -42,6 +48,8 @@
     - role: ../roles/logging-config
       service: cinder
       logdata: "{{ cinder.logs }}"
+  tasks:
+    - include: ../roles/cinder-common/tasks/logging.yml
 
 - name: neutron logging
   hosts: network:compute
@@ -51,7 +59,8 @@
     - role: ../roles/logging-config
       service: neutron
       logdata: "{{ neutron.logs }}"
-
+  tasks:
+    - include: ../roles/neutron-common/tasks/logging.yml
 
 # TODO: These roles are missing logging configs!!!
 #- name: horizon logging
@@ -60,13 +69,11 @@
 #  - role: ../roles/logging-config
 #    service: horizon
 #    logdata: "{{ horizon.logs }}"
-#
-#- name: swift logging
-#  hosts: swiftnode
-#  roles:
-#  - role: ../roles/logging-config
-#    service: swift
-#    logdata: "{{ swift.logs }}"
+
+- name: swift logging
+  hosts: swiftnode
+  tasks:
+    - include: ../roles/swift-common/tasks/logging.yml
 
 - name: heat logging
   hosts: heatnode
@@ -74,6 +81,8 @@
   - role: ../roles/logging-config
     service: heat
     logdata: "{{ heat.logs }}"
+  tasks:
+    - include: ../roles/heat/tasks/logging.yml
 
 - name: start and check logstash-forwarder is running
   hosts: all

--- a/playbooks/logging.yml
+++ b/playbooks/logging.yml
@@ -1,8 +1,17 @@
 ---
-- name: cleanup old configs and install logstash-forwarder
+- name: cleanup old configs
   hosts: all
+  handlers:
+    - include: ../roles/cleanup/handlers/main.yml
   tasks:
+    - name: stop logstash-forwarder service
+      service: name=logstash-forwarder state=stopped enabled=yes
+      register: lsfstop
+      failed_when: lsfstop|failed and ("service not found" not in lsfstop.msg)
     - include: ../roles/cleanup/tasks/logging.yml
+
+- name: install or update logstash-forwarder
+  hosts: all
   roles:
     - ../roles/logging
 

--- a/roles/cinder-common/tasks/logging.yml
+++ b/roles/cinder-common/tasks/logging.yml
@@ -1,0 +1,8 @@
+---
+- name: set up log rotation for cinder
+  logrotate: name=cinder path=/var/log/cinder/*.log
+  args:
+    options:
+      - daily
+      - missingok
+      - rotate 7

--- a/roles/cinder-common/tasks/logging.yml
+++ b/roles/cinder-common/tasks/logging.yml
@@ -6,3 +6,4 @@
       - daily
       - missingok
       - rotate 7
+      - compress

--- a/roles/cinder-common/tasks/main.yml
+++ b/roles/cinder-common/tasks/main.yml
@@ -39,10 +39,7 @@
   template: src=etc/sudoers.d/cinder dest=/etc/sudoers.d/cinder owner=root
             group=root mode=0440
 
-- name: set up log rotation for cinder
-  logrotate: name=cinder path=/var/log/cinder/*.log
-  args:
-    options:
-      - daily
-      - missingok
-      - rotate 7
+- include: logging.yml
+  tags:
+    - logrotate
+    - logging

--- a/roles/cleanup/handlers/main.yml
+++ b/roles/cleanup/handlers/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: refresh cert auths
   command: update-ca-certificates
+
+- name: restart rsyslog
+  service: name=rsyslog state=restarted

--- a/roles/cleanup/tasks/logging.yml
+++ b/roles/cleanup/tasks/logging.yml
@@ -8,11 +8,12 @@
     - /var/log/keystone/access.log
 
 - name: remove rsyslog configs
-  file: dest=/etc/rsyslog.d/{{ item }}.conf state=absent
+  file: dest=/etc/rsyslog.d/{{ item }} state=absent
   with_items:
     - follow.conf
     - forward.conf
     - udp.conf
+  notify: restart rsyslog
 
 - name: remove rsyslog forward cert auth
   file: dest=/usr/local/share/ca-certificates/rsyslog-forward.crt state=absent

--- a/roles/glance/tasks/logging.yml
+++ b/roles/glance/tasks/logging.yml
@@ -1,0 +1,8 @@
+---
+- name: set up log rotation for glance
+  logrotate: name=glance path=/var/log/glance/*.log
+  args:
+    options:
+      - daily
+      - missingok
+      - rotate 7

--- a/roles/glance/tasks/logging.yml
+++ b/roles/glance/tasks/logging.yml
@@ -6,3 +6,4 @@
       - daily
       - missingok
       - rotate 7
+      - compress

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -75,10 +75,7 @@
 
 - include: monitoring.yml tags=monitoring,common
 
-- name: set up log rotation for glance
-  logrotate: name=glance path=/var/log/glance/*.log
-  args:
-    options:
-      - daily
-      - missingok
-      - rotate 7
+- include: logging.yml
+  tags:
+    - logrotate
+    - logging

--- a/roles/heat/tasks/logging.yml
+++ b/roles/heat/tasks/logging.yml
@@ -1,0 +1,8 @@
+---
+- name: set up log rotation for heat
+  logrotate: name=heat path=/var/log/heat/*.log
+  args:
+    options:
+      - daily
+      - missingok
+      - rotate 7

--- a/roles/heat/tasks/logging.yml
+++ b/roles/heat/tasks/logging.yml
@@ -6,3 +6,4 @@
       - daily
       - missingok
       - rotate 7
+      - compress

--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -41,7 +41,7 @@
   run_once: true
   changed_when: true
   notify:
-    - restart heat services 
+    - restart heat services
   # we want this to always be changed so that it can notify the service restart
 
 - meta: flush_handlers

--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -55,10 +55,7 @@
 
 - include: monitoring.yml tags=monitoring,common
 
-- name: set up log rotation for heat
-  logrotate: name=heat path=/var/log/heat/*.log
-  args:
-    options:
-      - daily
-      - missingok
-      - rotate 7
+- include: logging.yml
+  tags:
+    - logrotate
+    - logging

--- a/roles/ironic-common/tasks/logging.yml
+++ b/roles/ironic-common/tasks/logging.yml
@@ -6,3 +6,4 @@
       - daily
       - missingok
       - rotate 7
+      - compress

--- a/roles/ironic-common/tasks/logging.yml
+++ b/roles/ironic-common/tasks/logging.yml
@@ -1,0 +1,8 @@
+---
+- name: set up log rotation for ironic
+  logrotate: name=ironic path=/var/log/ironic/*.log
+  args:
+    options:
+      - daily
+      - missingok
+      - rotate 7

--- a/roles/ironic-common/tasks/main.yml
+++ b/roles/ironic-common/tasks/main.yml
@@ -41,10 +41,7 @@
             group=root
             mode=0440
 
-- name: set up log rotation for ironic
-  logrotate: name=ironic path=/var/log/ironic/*.log
-  args:
-    options:
-      - daily
-      - missingok
-      - rotate 7
+- include: logging.yml
+  tags:
+    - logrotate
+    - logging

--- a/roles/keystone/tasks/logging.yml
+++ b/roles/keystone/tasks/logging.yml
@@ -1,0 +1,8 @@
+---
+- name: set up log rotation for keystone
+  logrotate: name=keystone path=/var/log/keystone/*.log
+  args:
+    options:
+      - daily
+      - missingok
+      - rotate 7

--- a/roles/keystone/tasks/logging.yml
+++ b/roles/keystone/tasks/logging.yml
@@ -6,3 +6,4 @@
       - daily
       - missingok
       - rotate 7
+      - compress

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -67,10 +67,7 @@
 
 - include: monitoring.yml tags=monitoring,common
 
-- name: set up log rotation for keystone
-  logrotate: name=keystone path=/var/log/keystone/*.log
-  args:
-    options:
-      - daily
-      - missingok
-      - rotate 7
+- include: logging.yml
+  tags:
+    - logrotate
+    - logging

--- a/roles/logging-config/meta/main.yml
+++ b/roles/logging-config/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: logging

--- a/roles/logging-config/templates/etc/logstash-forwarder.d/template.conf
+++ b/roles/logging-config/templates/etc/logstash-forwarder.d/template.conf
@@ -1,23 +1,20 @@
 {
   "files": [
-    {% if logdata -%}
-      {% for item in logdata %}
-      {
-      "paths": [
-	{% for path in item.paths %}
-	"{{ path }}"{% if not loop.last %},{% endif %}
+    {% for item in logdata %}
+    {
+    "paths":
+      {{ item.paths | to_nice_json }}
+    ,
+    "fields":
+      {% if item.fields and logging.follow.global_fields %}
+      {# Merge the two field dicts together #}
+      {% set _dummy = item.fields.update(logging.follow.global_fields) %}
+      {{ item.fields | to_nice_json }}
+      {% elif logging.follow.global_fields %}
+      {{ logging.follow.global_fields | to_nice_json }}
+      {% endif %}
+    }{% if not loop.last %},{% endif %}
 
-	{% endfor %}
-      ],
-      "fields": {
-	{% for key, value in item.fields.items() %}
-	"{{ key }}": "{{ value }}"{% if not loop.last %},{% endif %}
-
-	{% endfor %}
-      }
-      }{% if not loop.last %},{% endif %}
-
-      {% endfor -%}
-    {%- endif -%}
+    {% endfor -%}
   ]
 }

--- a/roles/logging/defaults/main.yml
+++ b/roles/logging/defaults/main.yml
@@ -1,9 +1,17 @@
 logging:
   version: 0.3.1
-  logstashforwarder_url: http://repo.openstack.blueboxgrid.com/ubuntu/pool/main/l/logstash-forwarder/logstash-forwarder_0.3.1_amd64.deb
+  download:
+    url: http://repo.openstack.blueboxgrid.com/ubuntu/pool/main/l/logstash-forwarder/logstash-forwarder_0.3.1_amd64.deb
   follow:
     enabled: true
+    global_fields:
+      customer_id: "unknown"
+      cluster_name: "unknown"
     logs:
+      - paths:
+          - /var/log/syslog
+        fields:
+          type: syslog
   forward:
     host: null
     port: 4560

--- a/roles/logging/files/etc/init/logstash-forwarder.conf
+++ b/roles/logging/files/etc/init/logstash-forwarder.conf
@@ -10,6 +10,6 @@ respawn limit 3 30
 start on runlevel [2345]
 stop on runlevel [!2345]
 
-chdir /opt/logstash-forwarder
+chdir /var/lib/logstash
 
-exec bin/logstash-forwarder.sh -config /etc/logstash-forwarder.d
+exec /opt/logstash-forwarder/bin/logstash-forwarder.sh -config /etc/logstash-forwarder.d

--- a/roles/logging/files/etc/rsyslog.d/49-haproxy.conf
+++ b/roles/logging/files/etc/rsyslog.d/49-haproxy.conf
@@ -1,7 +1,0 @@
-# Create an additional socket in haproxy's chroot in order to allow logging via
-# /dev/log to chroot'ed HAProxy processes
-$AddUnixListenSocket /var/lib/haproxy/dev/log
-
-# Write HAProxy messages to async dedicated logfile
-if $programname startswith 'haproxy' then -/var/log/haproxy.log
-& stop

--- a/roles/logging/tasks/main.yml
+++ b/roles/logging/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: create logstash user
-  user: name=logstash comment=logstash shell=/bin/false system=yes home=/opt/logstash-forwarder
+  user: name=logstash comment="Logstash Service User" shell=/sbin/nologin system=yes home=/var/lib/logstash
 
 - name: install logstash-forwarder
   apt: pkg=logstash-forwarder
   when: ansible_distribution_version == "12.04"
 
 - name: download logstash
-  get_url: url={{ logging.logstashforwarder_url }}
+  get_url: url={{ logging.download.url }}
            dest=/tmp/logstash-forwarder_{{ logging.version }}_amd64.deb
   when: ansible_distribution_version == "14.04"
 
@@ -32,7 +32,7 @@
 - name: logstash-forwarder config directory
   file: dest=/etc/logstash-forwarder.d state=directory mode=0755
 
-- name: configure logstash-forwarder
+- name: configure logstash-forwarder forwarding
   template: src=etc/logstash-forwarder.d/main.conf dest=/etc/logstash-forwarder.d/main.conf mode=0644
   notify: restart logstash-forwarder
   when: logging.forward.host

--- a/roles/logging/tasks/main.yml
+++ b/roles/logging/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: stop logstash-forwarder service
+  service: name=logstash-forwarder state=stopped enabled=yes
+  register: lsfstop
+  failed_when: lsfstop|failed and ("service not found" not in lsfstop.msg)
+
 - name: create logstash user
   user: name=logstash comment="Logstash Service User" shell=/sbin/nologin system=yes home=/var/lib/logstash
 

--- a/roles/logging/templates/etc/logstash-forwarder.d/main.conf
+++ b/roles/logging/templates/etc/logstash-forwarder.d/main.conf
@@ -2,23 +2,28 @@
   "network": {
     "servers": [
       "{{ logging.forward.host }}:{{ logging.forward.port }}"
-    ],
+    ]
 
     {% if logging.forward.tls.ca_cert %}
-    "ssl ca": "/usr/local/share/ca-certificates/logging-forward.crt"
+    ,"ssl ca": "/usr/local/share/ca-certificates/logging-forward.crt"
     {% endif -%}
   },
   "files": [
-    {% if logging.follow.logs %}
+    {% for item in logging.follow.logs %}
     {
-      "paths": [
-	{% for item in logging.follow.logs %}
-	"{{ item }}"{% if not loop.last %},{% endif %}
+    "paths":
+      {{ item.paths | to_nice_json }}
+    ,
+    "fields":
+      {% if item.fields and logging.follow.global_fields %}
+      {# Merge the two field dicts together #}
+      {% set _dummy = item.fields.update(logging.follow.global_fields) %}
+      {{ item.fields | to_nice_json }}
+      {% elif logging.follow.global_fields %}
+      {{ logging.follow.global_fields | to_nice_json }}
+      {% endif %}
+    }{% if not loop.last %},{% endif %}
 
-	{% endfor -%}
-      ],
-      "fields": { "type": "openstack" }
-    }
-    {% endif %}
+    {% endfor -%}
   ]
 }

--- a/roles/neutron-common/tasks/logging.yml
+++ b/roles/neutron-common/tasks/logging.yml
@@ -1,0 +1,8 @@
+---
+- name: set up log rotation for neutron
+  logrotate: name=neutron path=/var/log/neutron/*.log
+  args:
+    options:
+      - daily
+      - missingok
+      - rotate 7

--- a/roles/neutron-common/tasks/logging.yml
+++ b/roles/neutron-common/tasks/logging.yml
@@ -6,3 +6,4 @@
       - daily
       - missingok
       - rotate 7
+      - compress

--- a/roles/neutron-common/tasks/main.yml
+++ b/roles/neutron-common/tasks/main.yml
@@ -104,10 +104,7 @@
             dest=/usr/local/bin/neutron-restart-all
             mode=0755
 
-- name: set up log rotation for neutron
-  logrotate: name=neutron path=/var/log/neutron/*.log
-  args:
-    options:
-      - daily
-      - missingok
-      - rotate 7
+- include: logging.yml
+  tags:
+    - logrotate
+    - logging

--- a/roles/nova-common/tasks/logging.yml
+++ b/roles/nova-common/tasks/logging.yml
@@ -6,3 +6,4 @@
       - daily
       - missingok
       - rotate 7
+      - compress

--- a/roles/nova-common/tasks/logging.yml
+++ b/roles/nova-common/tasks/logging.yml
@@ -1,0 +1,8 @@
+---
+- name: set up log rotation for nova
+  logrotate: name=nova path=/var/log/nova/*.log
+  args:
+    options:
+      - daily
+      - missingok
+      - rotate 7

--- a/roles/nova-common/tasks/main.yml
+++ b/roles/nova-common/tasks/main.yml
@@ -25,10 +25,7 @@
     group=root
     mode=0440
 
-- name: set up log rotation for nova
-  logrotate: name=nova path=/var/log/nova/*.log
-  args:
-    options:
-      - daily
-      - missingok
-      - rotate 7
+- include: logging.yml
+  tags:
+    - logrotate
+    - logging

--- a/roles/swift-common/tasks/logging.yml
+++ b/roles/swift-common/tasks/logging.yml
@@ -1,0 +1,9 @@
+---
+- name: set up log rotation for swift
+  logrotate: name=keystone path=/var/log/swift/*.log
+  args:
+    options:
+      - daily
+      - missingok
+      - rotate 7
+      - compress

--- a/roles/swift-common/tasks/main.yml
+++ b/roles/swift-common/tasks/main.yml
@@ -69,6 +69,11 @@
 
 - include: monitoring.yml tags=monitoring,common
 
+- include: logging.yml
+  tags:
+    - logrotate
+    - logging
+
 - name: include swift warning in message of the day
   lineinfile: dest=/etc/motd.tail
               regexp="^WARNING Swift node"

--- a/test/run
+++ b/test/run
@@ -22,22 +22,22 @@ if [ "${ACTION}" == "all" -o "${ACTION}" == "unit" ]; then
 fi
 
 if [ "${ACTION}" == "all" -o "${ACTION}" == "deploy" ]; then
-  time ursula "envs/test" -u ${LOGIN_USER} --sudo "site.yml $@"
+  time ursula "envs/test" site.yml -u ${LOGIN_USER} --sudo "$@"
   ring_bell
 fi
 
 if [ "${ACTION}" == "all" -o "${ACTION}" == "test" ]; then
-  time ursula "envs/test" -u ${LOGIN_USER} --sudo ${ROOT}/playbooks/tests/tasks/main.yml $@ 
+  time ursula "envs/test" ${ROOT}/playbooks/tests/tasks/main.yml -u ${LOGIN_USER} --sudo  $@
   ring_bell
 fi
 
 if [ "${ACTION}" == "all" -o "${ACTION}" == "cleanup" ]; then
-  time ursula "envs/test" -u ${LOGIN_USER} --sudo ${ROOT}/playbooks/tests/tasks/cleanup.yml
+  time ursula "envs/test" ${ROOT}/playbooks/tests/tasks/cleanup.yml -u ${LOGIN_USER} --sudo
   ring_bell
 fi
 
 if [ "${ACTION}" == "upgrade" ]; then
-  time ursula "envs/test" -u ${LOGIN_USER} --sudo "upgrade.yml $@"
+  time ursula "envs/test" upgrade.yml -u ${LOGIN_USER} --sudo "$@"
   ring_bell
 fi
 

--- a/test/setup
+++ b/test/setup
@@ -55,6 +55,9 @@ eof
 cat ${CERT_DIR}/openstack.example.com.key | sed 's/^/    /' >> ${ROOT}/envs/test/group_vars/all.yml
 cat >> ${ROOT}/envs/test/defaults.yml <<eof
 logging:
+  follow:
+    global_fields:
+      cluster_name: "ci-test"
   forward:
     host: kibana.sea03.blueboxgrid.com
     port: 4560

--- a/test/setup
+++ b/test/setup
@@ -89,7 +89,7 @@ $(public_ip "${testenv_instance_prefix}-compute-0")
 eof
 
 echo "copying files"
-ursula "envs/test" -u ${LOGIN_USER} --sudo ${ROOT}/playbooks/testenv/tasks/pre-deploy.yml
+ursula "envs/test" ${ROOT}/playbooks/testenv/tasks/pre-deploy.yml -u ${LOGIN_USER} --sudo
 
 ring_bell
 echo "vms are up: ${VMS} !!"

--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,4 @@ setenv =
    VIRTUAL_ENV={envdir}
 deps = -r{toxinidir}/requirements.txt
 commands =
-  ursula -t -e envs/example -p site.yml
+  ursula --ursula-test envs/example site.yml


### PR DESCRIPTION
To better handle logs when logrotate was not previously configured and reduce overall disk usage, compress logs after rotation.
`zgrep` and other tools easily handle searching compressed logs anyway.