### PR TITLE
Cinder volume encryption by way of Openstack

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -108,7 +108,6 @@ nova:
 cinder:
   volume_file: /opt/stack/cinder-volumes
   volume_file_size: 5G
-  passphrase: asdf
   logging:
     debug: True
     verbose: True

--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -108,22 +108,16 @@ nova:
 cinder:
   volume_file: /opt/stack/cinder-volumes
   volume_file_size: 5G
+  #fixed_key: 6a5c55db5e250f234b6af7807dafda77433dddcf372b6d04801a45f578a35aa7
   logging:
     debug: True
     verbose: True
-  volume_types:
-    - encrypted-aes-256
-    - encrypted-aes-128
+  volume_types: []
   encrypted_volume_types:
-    - volume_type: encrypted-aes-256
-      cipher: aes
-      key_size: 256
-      provider: path.to.ProviderModule
-      control_location: front-end
-    - volume_type: encrypted-aes-128
-      cipher: aes
-      key_size: 128
-      provider: path.to.ProviderModule
+    - volume_type: encrypted-aes-512
+      cipher: aes-xts-plain64
+      key_size: 512
+      provider: nova.volume.encryptors.luks.LuksEncryptor
       control_location: front-end
 
 neutron:

--- a/library/cinder_volume_group
+++ b/library/cinder_volume_group
@@ -18,9 +18,6 @@ options:
       - The file path on the filesystem to create
     required: false
     aliases: ["dest"]
-  passphrase:
-    description:
-      - A passphrase to encrypt the file with LUKS (optional)
   vgname:
     description:
       - The name for the volume group
@@ -65,14 +62,12 @@ def main():
         argument_spec  = dict(
             size       = dict(required=True),
             file       = dict(required=True, aliases=['dest']),
-            passphrase = dict(),
             vgname     = dict(default='cinder-volumes'),
         ),
     )
 
     size = module.params.get('size')
     dest = module.params.get('file')
-    passphrase = module.params.get('passphrase')
     vgname = module.params.get('vgname')
 
     # see if we have this vg already
@@ -104,31 +99,6 @@ def main():
 
     cmd = ['losetup', device, dest]
     rc, out, err = module.run_command(cmd, check_rc=True)
-
-    # Crypt the device if desired
-    if passphrase:
-        for cryptmod in ['cryptoloop', 'aes']:
-            cmd = ['modprobe', cryptmod]
-            rc, out, err = module.run_command(cmd, check_rc=True)
-
-        luksfmt = ['cryptsetup', 'luksFormat', '--key-file=-',
-                   device]
-        luksopn = ['cryptsetup', 'luksOpen', '--key-file=-',
-                   device, vgname]
-
-        try:
-            # format
-            ps = subprocess.Popen(['echo', '-n', passphrase],
-                                   stdout=subprocess.PIPE)
-            output = subprocess.check_output(luksfmt, stdin=ps.stdout)
-            # open
-            ps = subprocess.Popen(['echo', '-n', passphrase],
-                                   stdout=subprocess.PIPE)
-            output = subprocess.check_output(luksopn, stdin=ps.stdout)
-        except Exception, e:
-            module.fail_json(msg="Failed to setup crypt device: %s" % e)
-
-        device = "/dev/mapper/%s" % vgname
 
     if is_luks('/dev/mapper/%s' % vgname, module):
         module.fail_json(msg="%s is a LUKS volume" % device)

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -77,6 +77,11 @@ nimble_subnet_label = {{ backend.nimble_subnet_label }}
 
 {% endfor -%}
 
+{% if cinder.fixed_key is defined %}
+[keymgr]
+fixed_key = NOT_A_KEY
+{% endif %}
+
 [keystone_authtoken]
 identity_uri = {{ endpoints.identity_uri }}
 auth_uri = {{ endpoints.auth_uri }}

--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -28,6 +28,9 @@
 - name: cinder volume group
   cinder_volume_group: file={{ cinder.volume_file }}
                        size={{ cinder.volume_file_size }}
+  when: cinder.fixed_key is not defined or (cinder.fixed_key is defined and "compute" not in group_names)
+  # a fixed_key cannot be used with a local cinder volume group on a compute
+  # node. This would be a security risk, DO NOT CHANGE.
 
 - name: iscsi start
   service: name=open-iscsi state=started

--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -28,21 +28,9 @@
 - name: cinder volume group
   cinder_volume_group: file={{ cinder.volume_file }}
                        size={{ cinder.volume_file_size }}
-  when: cinder.passphrase is not defined
-
-- name: encrypted cinder volume group
-  cinder_volume_group: file={{ cinder.volume_file }}
-                       size={{ cinder.volume_file_size }}
-                       passphrase={{ cinder.passphrase }}
-  when: cinder.passphrase is defined
 
 - name: iscsi start
   service: name=open-iscsi state=started
-
-- name: create cinder-volumes crypttab entry
-  crypttab: state=present target=cinder-volumes source={{ cinder.volume_file }}
-            opts=luks,aes,noauto
-  when: cinder.passphrase is defined
 
 - name: install cinder-volume service
   upstart_service: name=cinder-volume user=cinder

--- a/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
+++ b/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
@@ -148,10 +148,6 @@ OPENSTACK_KEYSTONE_BACKEND = {
 
 OPENSTACK_HYPERVISOR_FEATURES = {
     'can_set_mount_point': False,
-
-    # NOTE: as of Grizzly this is not yet supported in Nova so enabling this
-    # setting will not do anything useful
-    'can_encrypt_volumes': False
 }
 
 # The OPENSTACK_QUANTUM_NETWORK settings can be used to enable optional

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -179,3 +179,8 @@ admin_url=https://{{ endpoints.main }}:35358/v2.0
 admin_tenant_name=service
 api_endpoint=https://{{ endpoints.main }}:6384/v1
 {% endif -%}
+
+{% if cinder.fixed_key is defined %}
+[keymgr]
+fixed_key = {{ cinder.fixed_key }}
+{% endif %}


### PR DESCRIPTION
No longer support LUKS encrypted loop back LVM device for a cinder volume group. Instead use OpenStack's method of encrypting on a per-volume basis on the front end (nova). Requires separation of nova-compute from cinder-volume store.