### PR TITLE
Backport 1.0: Create monitoring user in openstack admin tenant

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -15,6 +15,7 @@ secrets:
   metadata_proxy_shared_secret: asdf
   horizon_secret_key:           asdf
   glance_sync:      ADQ64XUQLUWH75M634RVBLP55RKPGGOWG
+  monitor_password: asdf
 
 fqdn: openstack.example.com
 floating_ip: "{{ controller_primary }}"
@@ -70,6 +71,12 @@ monitoring:
   keepalive:
     handler: email
   scan_for_log_errors: true
+  openstack:
+    user:
+      username: monitor
+      password: "{{ secrets.monitor_password }}"
+      tenant: admin
+      role: monitor
 
 openstack:
   pypi_mirror: https://pypi.python.org/simple/
@@ -188,6 +195,9 @@ keystone:
     - name: heat
       password: "{{ secrets.service_password }}"
       tenant: service
+    - name: "{{ monitoring.openstack.user.username }}"
+      password: "{{ monitoring.openstack.user.password }}"
+      tenant: "{{ monitoring.openstack.user.tenant }}"
 
   user_roles:
     - user: admin
@@ -220,6 +230,9 @@ keystone:
     - user: heat
       tenant: service
       role: service
+    - user: "{{ monitoring.openstack.user.username }}"
+      tenant: "{{ monitoring.openstack.user.tenant }}"
+      role: "{{ monitoring.openstack.user.role }}"
 
   services:
     - name: keystone

--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -17,6 +17,7 @@ secrets:
   metadata_proxy_shared_secret: asdf
   horizon_secret_key:           asdf
   glance_sync:      ADQ64XUQLUWH75M634RVBLP55RKPGGOWG
+  monitor_password: asdf
 
 endpoints:
   main:     "{{ fqdn }}"
@@ -131,9 +132,12 @@ glance:
       url: https://launchpad.net/cirros/trunk/0.3.0/+download/cirros-0.3.0-x86_64-disk.img
 
 keystone:
+  logging:
+    debug: True
   tenants:
     - admin
     - service
+    - demo
 
   users:
     - name: admin
@@ -161,6 +165,9 @@ keystone:
     - name: heat
       password: "{{ secrets.service_password }}"
       tenant: service
+    - name: "{{ monitoring.openstack.user.username }}"
+      password: "{{ monitoring.openstack.user.password }}"
+      tenant: "{{ monitoring.openstack.user.tenant }}"
 
   user_roles:
     - user: admin
@@ -190,6 +197,9 @@ keystone:
     - user: heat
       tenant: service
       role: admin
+    - user: "{{ monitoring.openstack.user.username }}"
+      tenant: "{{ monitoring.openstack.user.tenant }}"
+      role: "{{ monitoring.openstack.user.role }}"
 
   services:
     - name: keystone

--- a/playbooks/monitoring/files/sensu_plugins/check-neutron-agents.sh
+++ b/playbooks/monitoring/files/sensu_plugins/check-neutron-agents.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-source /root/stackrc
 if neutron agent-list -c alive | grep xxx; then
   echo "a neutron agent is down"
   exit 2

--- a/playbooks/monitoring/files/sensu_plugins/check-os-api.rb
+++ b/playbooks/monitoring/files/sensu_plugins/check-os-api.rb
@@ -23,14 +23,12 @@ class CheckOSApi < Sensu::Plugin::Check::CLI
     when "nova"
       "nova list"
     when "glance"
-      "glance index"
+      "glance image-list"
     when "keystone"
       "keystone endpoint-list"
     when "heat"
       "heat stack-list"
     end
-
-    ". /root/stackrc; #{cmd}"
   end
 
   def run

--- a/playbooks/monitoring/tasks/main.yml
+++ b/playbooks/monitoring/tasks/main.yml
@@ -32,6 +32,17 @@
   template: src=config.json dest=/etc/sensu/config.json owner=root group=root mode=0444
   notify: restart sensu-client
 
+- name: sensu monitoring credentials
+  template: dest=/etc/sensu/stackrc src=etc/sensu/stackrc
+            owner=root group=sensu mode=0640
+  when: monitoring.openstack.user is defined
+
+- name: load monitoring credentials
+  lineinfile: dest=/etc/default/sensu regexp="^\. /etc/sensu/stackrc"
+              line=". /etc/sensu/stackrc"
+  notify: restart sensu-client
+  when: monitoring.openstack.user is defined
+
 - name: enable and start sensu-client
   service: name=sensu-client state=started enabled=yes
 

--- a/playbooks/monitoring/templates/etc/sensu/stackrc
+++ b/playbooks/monitoring/templates/etc/sensu/stackrc
@@ -1,0 +1,8 @@
+export OS_PASSWORD={{ monitoring.openstack.user.password }}
+export OS_AUTH_URL=https://{{ endpoints.main }}:5001/v2.0
+export OS_USERNAME={{ monitoring.openstack.user.username }}
+export OS_TENANT_NAME={{ monitoring.openstack.user.tenant }}
+{% if client.self_signed_cert -%}
+export OS_CACERT=/opt/stack/ssl/openstack.crt
+{% endif -%}
+export OS_NO_CACHE=True


### PR DESCRIPTION
put stackrc in /etc/sensu and source it in /etc/default/sensu

remove sourcing /root/stackrc from checks

Conflicts:
	envs/example/defaults.yml
	envs/vagrant/defaults.yml
	roles/common/tasks/monitoring.yml
	roles/glance/tasks/monitoring.yml
	roles/heat/tasks/monitoring.yml
	roles/keystone/tasks/monitoring.yml
	roles/nova-control/tasks/monitoring.yml
	site.yml