### PR TITLE
IPv6 support

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -14,6 +14,7 @@ common:
   ssh:
     allow_from:
       - 0.0.0.0/0
+      - ::/0
     disable_root: False
     disable_dns: True
   docker:

--- a/roles/neutron-data-network/tasks/main.yml
+++ b/roles/neutron-data-network/tasks/main.yml
@@ -6,6 +6,7 @@
     - dnsmasq-utils
     - iputils-arping
     - ucarp
+    - radvd
 
 - include: dnsmasq.yml
 


### PR DESCRIPTION
Fix two items found during IPv6 testing:

* UFW didn't permit SSH over IPv6
* Neutron L3 agent requires radvd for DHCP stateless and SLAAC