### PR TITLE
Update nova for vnc websocket vuln.

### DIFF
--- a/nova-CVE-2015-0259.yml
+++ b/nova-CVE-2015-0259.yml
@@ -1,0 +1,10 @@
+# Play for updating nova for CVE-2015-0259 (vnc websocket vuln.)
+# This will just run the nova role, minimizing potential disruption in
+# a cluster
+---
+- name: update nova
+  hosts: controller
+  gather_facts: force
+
+  roles:
+    - role: nova-control

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 nova:
   patches:
-  rev: 8526a727dc20a96d7245ae836e81c29967166f77
+  rev: d6683ba1b1af3b31b7260a51333295e8be68c470
   compute_driver: nova.virt.libvirt.LibvirtDriver
   firewall_driver: nova.virt.firewall.NoopFirewallDriver
   scheduler_host_manager: nova.scheduler.host_manager.HostManager


### PR DESCRIPTION
This updates the version of stable/juno we pull in, and adds a playbook
that can be used to fix JUST this nova issue.

Resolves CVE-2015-0259