### PR TITLE
Pull newer nova for vnc websocket vuln. for src

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -36,7 +36,7 @@ nova:
       dest: /opt/stack/novadocker
 
   source:
-    rev: '8526a727dc20a96d7245ae836e81c29967166f77'
+    rev: 'd6683ba1b1af3b31b7260a51333295e8be68c470'
   package:
     console_scripts:
       - nova-all


### PR DESCRIPTION
fixes CVE-2015-0259 for source based installs. Packaging installs will
be fixed with newer packages.