### PR TITLE
WIP    Always use rabbitmq envs config

### DIFF
--- a/roles/rabbitmq/defaults/main.yml
+++ b/roles/rabbitmq/defaults/main.yml
@@ -3,7 +3,7 @@ rabbitmq:
   cluster: False
   erlang_cookie: 6IMgelGs3Ygu
   user: openstack
-  nodename: 'openstack@{{ ansible_hostname }}'
+  nodename: 'rabbit@{{ ansible_hostname }}'
   ip: '0.0.0.0'
   port: 5672
   management_port: 15672

--- a/roles/rabbitmq/tasks/cluster.yml
+++ b/roles/rabbitmq/tasks/cluster.yml
@@ -15,12 +15,6 @@
             owner=rabbitmq group=rabbitmq mode=0400
   register: erlang_cookie
 
-- name: add rabbitmq environment configuration
-  template: src=etc/rabbitmq/rabbitmq-env.conf
-            dest=/etc/rabbitmq/rabbitmq-env.conf
-            owner=root group=root mode=0644
-  register: cluster_configuration
-
 - name: add rabbitmq cluster configuration
   template: src=etc/rabbitmq/rabbitmq.config dest=/etc/rabbitmq/rabbitmq.config
             owner=root group=root mode=0644
@@ -54,15 +48,3 @@
                    node={{ rabbitmq.nodename }}
                    pattern='.*'
                    tags=ha-mode=all
-
-- name: install management plugin
-  rabbitmq_plugin: names=rabbitmq_management
-  notify: restart rabbitmq
-
-- meta: flush_handlers
-
-- name: install rabbitmqadmin
-  get_url: dest=/usr/local/bin/ url={{ rabbitmq.admin_cli_url }}
-
-- name: correct rabbitmqadmin modes
-  file: group=root owner=root mode=0755 path=/usr/local/bin/rabbitmqadmin

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+# set up some pieces before installing rabbit so that mnesia data
+# doesn't need to be deleted
+
+- name: add rabbitmq config directory
+  file: dest=/etc/rabbitmq state=directory owner=root mode=0755
+
+- name: add rabbitmq environment configuration
+  template: src=etc/rabbitmq/rabbitmq-env.conf
+            dest=/etc/rabbitmq/rabbitmq-env.conf
+            owner=root group=root mode=0644
+
 - name: install erlang-solutions erlang
   apt: pkg={{ item }}
   with_items:
@@ -7,29 +18,30 @@
 
 # Create the cluster if desired
 - include: cluster.yml
-  when: rabbitmq.cluster
+  when: rabbitmq.cluster|bool
 
 # Backward compatibility with existing configurations.
 - name: remove default rabbit user
-  rabbitmq_user: user=guest state=absent
+  rabbitmq_user: user=guest state=absent  node={{ rabbitmq.nodename }}
   when: not rabbitmq.cluster
-
-- name: remove default rabbit user clustered
-  rabbitmq_user: user=guest state=absent node={{ rabbitmq.nodename }}
-  when: rabbitmq.cluster
 
 - name: openstack rabbit user
   rabbitmq_user: user={{ rabbitmq.user }}
-                 password={{ secrets.rabbit_password }} vhost=/
-                 tags=administrator configure_priv=.* read_priv=.*
-                 write_priv=.* state=present
-  when: not rabbitmq.cluster
-
-- name: openstack rabbit user clustered
-  rabbitmq_user: user={{ rabbitmq.user }}
                  password={{ secrets.rabbit_password }}
                  node={{ rabbitmq.nodename }} vhost=/ tags=administrator
-                 configure_priv=.* read_priv=.* write_priv=.* state=present
-  when: rabbitmq.cluster
+                 configure_priv=.* read_priv=.*
+                 write_priv=.* state=present
+
+- name: install management plugin
+  rabbitmq_plugin: names=rabbitmq_management
+  notify: restart rabbitmq
+
+- meta: flush_handlers
+
+- name: install rabbitmqadmin
+  get_url: dest=/usr/local/bin/ url={{ rabbitmq.admin_cli_url }}
+
+- name: correct rabbitmqadmin modes
+  file: group=root owner=root mode=0755 path=/usr/local/bin/rabbitmqadmin
 
 - include: monitoring.yml tags=monitoring,common

--- a/roles/rabbitmq/templates/etc/rabbitmq/rabbitmq.config
+++ b/roles/rabbitmq/templates/etc/rabbitmq/rabbitmq.config
@@ -13,9 +13,15 @@
     {inet_dist_listen_min, 65535},
     {inet_dist_listen_max, 65535}
   ]},
+{% if rabbitmq.cluster|bool -%}
   {rabbit, [
     {cluster_nodes, [{{ rabbitmq_hosts() }}]},
+{% else -%}
+  {rabbit, [
+    {cluster_nodes, ["{{ rabbitmq.user }}@{{ ansible_hostname }}"]},
+{% endif -%}
     {default_user, <<"{{ rabbitmq.user }}">>},
     {default_pass, <<"{{ secrets.rabbit_password }}">>}
   ]}
+
 ].

--- a/site.yml
+++ b/site.yml
@@ -30,7 +30,7 @@
   serial: 1 # serial because clustering
   roles:
     - role: rabbitmq
-      tags: ['infra']
+      tags: ['infra', 'rabbitmq']
 
 - name: install common percona components and gather facts
   gather_facts: force


### PR DESCRIPTION
This may not be necessary,  but wanted to put it here to reference later.
    
    this sets the nodename so that the two (unclustered) rabbit services
    are named based on the hostname to make it easier for monitoring and/or
    alerting to determine what is going on.
