### PR TITLE
Enable nova live snapshots for source installs

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -36,7 +36,8 @@ nova:
       dest: /opt/stack/novadocker
 
   source:
-    rev: 'd6683ba1b1af3b31b7260a51333295e8be68c470'
+    rev: 'd67ce79795feb2dcc8e1f90e50a17f866febff69'
+    git_mirror: https://github.com/blueboxgroup
   package:
     console_scripts:
       - nova-all

--- a/roles/nova-common/meta/main.yml
+++ b/roles/nova-common/meta/main.yml
@@ -12,6 +12,7 @@ dependencies:
   - role: openstack-source
     project_name: nova
     project_rev: "{{ nova.source.rev }}"
+    git_mirror: "{{ nova.source.git_mirror }}"
     rootwrap: True
     when: openstack_install_method == 'source'
   - role: openstack-package


### PR DESCRIPTION
This switches to the blueboxgroup git mirror of nova, the juno-bbg
branch and the commit that brings back the ability for nova to do live
snapshots. This will read the config file added earlier for enabling
live snapshots.