### PR TITLE
Template the cafile location for services

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -413,6 +413,8 @@ ssl:
     5Im92LzyPb58EoEcMB/T87pmawzogg+scOPh6UqGvShZit5OMINIjPKCoCM+nwPt
     U8i/S4ozAUKrGKLlEUVL1MgZeJkPMxd1IZ1Xxjq3PcEJxfVldJXWn/ROERE=
     -----END RSA PRIVATE KEY-----
+  # remove this line out if using a real CA supplied cert
+  cafile: /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
 
 openstack_setup:
   add_users: True

--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -132,6 +132,8 @@ monitoring:
     WRiRItwHQxTunlN0gK4qty2rczWIv/yzWALHJAOFLIyX0ynO4xY7x/3H9df9IuDe
     Gs1548GcEmUG0CWujFXsEJkjjBxT4/fabx4NOJjg9Ij1Mi3LYmB2
     -----END RSA PRIVATE KEY-----
+  # remove this line out if using a real CA supplied cert
+  cafile: /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
 
 openstack:
   pypi_mirror: https://pypi.python.org/simple/

--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -55,3 +55,4 @@ cinder:
   logging:
     debug: False
     verbose: True
+  cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -89,4 +89,4 @@ admin_tenant_name = service
 admin_user = cinder
 admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/cinder/api
-cafile = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
+cafile = {{ cinder.cafile }}

--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -60,3 +60,4 @@ glance:
   logging:
     debug: False
     verbose: True
+  cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"

--- a/roles/glance/templates/etc/glance/glance-api.conf
+++ b/roles/glance/templates/etc/glance/glance-api.conf
@@ -56,7 +56,7 @@ admin_tenant_name = service
 admin_user = glance
 admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/glance/api
-cafile = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
+cafile = {{ glance.cafile }}
 
 [paste_deploy]
 flavor = keystone

--- a/roles/glance/templates/etc/glance/glance-registry.conf
+++ b/roles/glance/templates/etc/glance/glance-registry.conf
@@ -54,7 +54,7 @@ admin_tenant_name = service
 admin_user = glance
 admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/glance/registry
-cafile = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
+cafile = {{ glance.cafile }}
 
 [paste_deploy]
 flavor = keystone

--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -34,3 +34,4 @@ heat:
   logging:
     debug: False
     verbose: True
+  cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"

--- a/roles/heat/templates/etc/heat/heat.conf
+++ b/roles/heat/templates/etc/heat/heat.conf
@@ -32,4 +32,4 @@ auth_uri = https://{{ endpoints.keystone }}:5001/v2.0
 admin_tenant_name = service
 admin_user = heat
 admin_password = {{ secrets.service_password }}
-cafile = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
+cafile = {{ heat.cafile }}

--- a/roles/ironic-common/defaults/main.yml
+++ b/roles/ironic-common/defaults/main.yml
@@ -49,3 +49,4 @@ ironic:
   logging:
     debug: False
     verbose: True
+  cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"

--- a/roles/ironic-common/templates/etc/ironic/ironic.conf
+++ b/roles/ironic-common/templates/etc/ironic/ironic.conf
@@ -38,7 +38,7 @@ auth_protocol = https
 admin_tenant_name = service
 admin_user = ironic
 admin_password = {{ secrets.service_password }}
-cafile = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
+cafile = {{ ironic.cafile }}
 
 [neutron]
 url=https://{{ endpoints.main }}:9797

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -105,3 +105,4 @@ neutron:
   logging:
     debug: False
     verbose: True
+  cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -63,7 +63,7 @@ nova_admin_username = neutron
 nova_admin_tenant_id = {{ service_tenant.id }}
 nova_admin_password = {{ secrets.service_password }}
 nova_admin_auth_url = {{ endpoints.auth_uri }}
-nova_ca_certificates_file = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
+nova_ca_certificates_file = {{ neutron.cafile }}
 
 [QUOTAS]
 
@@ -81,7 +81,7 @@ admin_tenant_name = service
 admin_user = neutron
 admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/neutron/api
-cafile = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
+cafile = {{ neutron.cafile }}
 
 [DATABASE]
 sqlalchemy_pool_size = 60

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -131,3 +131,4 @@ nova:
   logging:
     debug: False
     verbose: True
+  cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -150,7 +150,7 @@ admin_tenant_name = service
 admin_user = nova
 admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/nova/api
-cafile = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
+cafile = {{ nova.cafile }}
 
 [neutron]
 url=https://{{ endpoints.neutron }}:9797
@@ -159,7 +159,7 @@ admin_tenant_name=service
 admin_username=neutron
 admin_password={{ secrets.service_password }}
 admin_auth_url=https://{{ endpoints.keystone }}:35358/v2.0
-ca_certificates_file=/usr/local/share/ca-certificates/{{ endpoints.main }}.crt
+ca_certificates_file={{ nova.cafile }}
 
 service_metadata_proxy=true
 metadata_proxy_shared_secret={{ secrets.metadata_proxy_shared_secret }}
@@ -169,7 +169,7 @@ api_servers={{ nova.glance_endpoint }}
 
 [cinder]
 catalog_info = volumev2:cinderv2:publicURL
-ca_certificates_file = /usr/local/share/ca-certificates/{{ endpoints.main }}.crt
+ca_certificates_file = {{ nova.cafile }}
 
 {% if ironic.enabled -%}
 [ironic]


### PR DESCRIPTION
Pointing to the env's cert file works for self-signed certs where the
file is actually both the CA and the cert. For real certs the CA exists
elsewhere, like in the system CA bundle. For that reason we need to
template out where we point to find this.