### PR TITLE
Add genisoimage to libvirt hosts for config-drive

### DIFF
--- a/roles/nova-data/tasks/libvirt.yml
+++ b/roles/nova-data/tasks/libvirt.yml
@@ -15,6 +15,7 @@
     - open-iscsi
     - libvirt-dev={{ nova.libvirt_bin_version }}
     - pkg-config
+    - genisoimage
   notify: restart nova services
   when: ansible_distribution_version == "12.04"
 
@@ -27,6 +28,7 @@
     - open-iscsi
     - libvirt-dev={{ nova.libvirt_bin_version }}
     - pkg-config
+    - genisoimage
   notify: restart nova services
   when: ansible_distribution_version == "14.04"
 


### PR DESCRIPTION
nova-compute will call this in order to make the config drive. Without
this the instance will fail with No such file or directory.