### PR TITLE
Enable neutron namespace deletion

### DIFF
--- a/roles/neutron-common/templates/etc/neutron/dhcp_agent.ini
+++ b/roles/neutron-common/templates/etc/neutron/dhcp_agent.ini
@@ -17,5 +17,7 @@ use_namespaces = True
 
 dnsmasq_config_file = /etc/dnsmasq.conf
 
+dhcp_delete_namespaces = True
+
 [AGENT]
 root_helper = sudo /usr/local/bin/neutron-rootwrap /etc/neutron/rootwrap.conf

--- a/roles/neutron-common/templates/etc/neutron/l3_agent.ini
+++ b/roles/neutron-common/templates/etc/neutron/l3_agent.ini
@@ -19,5 +19,7 @@ use_namespaces = True
 external_network_bridge =
 {% endif %}
 
+router_delete_namespaces = True
+
 [AGENT]
 root_helper = sudo /usr/local/bin/neutron-rootwrap /etc/neutron/rootwrap.conf

--- a/roles/neutron-data/tasks/main.yml
+++ b/roles/neutron-data/tasks/main.yml
@@ -4,7 +4,6 @@
 
 - name: update iproute2 to latest ppa
   apt: name=iproute2 state=latest
-  when: neutron.plugin == 'ml2' and 'vxlan' in neutron.tunnel_types
 
 - name: permit VXLAN traffic
   ufw: rule=allow to_port=4789 proto=udp


### PR DESCRIPTION
This was disabled by default upstream due to a bug in iproute2, but
we're installing a version of iproute2 that has this bug resolved. Now
we'll install that version all the time  not just for vxlan, and we'll
enable deletino of l3 and dhcp namespaces.