### PR TITLE
sensu checks and stats for haproxy

### DIFF
--- a/roles/collectd-client/tasks/main.yml
+++ b/roles/collectd-client/tasks/main.yml
@@ -27,6 +27,18 @@
   notify:
     - restart collectd
 
+- name: set up log rotation for collectd
+  logrotate: name=collectd path={{ collectd.plugins.logfile.file }}
+  args:
+    options:
+      - daily
+      - missingok
+      - rotate 7
+      - compress
+      - postrotate
+      - /bin/kill -HUP `cat /var/run/collectdmon.pid 2> /dev/null` 2> /dev/null || true
+      - endscript
+
 - meta: flush_handlers
 
 - name: ensure apache is running

--- a/roles/haproxy/meta/main.yml
+++ b/roles/haproxy/meta/main.yml
@@ -6,3 +6,5 @@ dependencies:
         repo: 'deb {{ apt_repos.haproxy.repo }} precise main'
         key_url: '{{ apt_repos.haproxy.key_url }}'
   - role: monitoring-common
+  - role: collectd-plugin
+    when: collectd is defined and collectd.enabled|bool

--- a/roles/haproxy/tasks/monitoring.yml
+++ b/roles/haproxy/tasks/monitoring.yml
@@ -3,3 +3,14 @@
   sensu_check: name=haproxy plugin=check-procs.rb
                args="-p 'haproxy.*-f /etc/haproxy/haproxy.cfg' -w 5 -c 10 -W 1 -C 1"
   notify: restart sensu-client
+
+- name: haproxy check backends
+  sensu_check: name=haproxy plugin=check-haproxy.rb
+               args="-p '-c 100 -S /var/run/haproxy.stat -A"
+  notify: restart sensu-client
+
+- name: haproxy metrics
+  template: src=etc/collectd/plugins/haproxy.conf dest=/etc/collectd/plugins/haproxy.conf
+  notify: restart collectd
+  when: collectd is defined and collectd.enabled|bool
+  tags: collectd

--- a/roles/haproxy/templates/etc/collectd/plugins/haproxy.conf
+++ b/roles/haproxy/templates/etc/collectd/plugins/haproxy.conf
@@ -1,0 +1,16 @@
+<LoadPlugin "python">
+    Globals true
+</LoadPlugin>
+
+<Plugin "python">
+    ModulePath "/opt/ursula-monitoring/collectd/plugins/haproxy"
+
+    Import "haproxy"
+
+    <Module "haproxy">
+      Socket "/var/run/haproxy/stats.sock"
+      ProxyMonitor "server"
+      ProxyMonitor "backend"
+      ProxyMonitor "frontend"
+    </Module>
+</Plugin>

--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -25,6 +25,7 @@ global
   daemon
   pidfile /var/run/haproxy/haproxy.pid
   tune.bufsize {{ haproxy.bufsize }}
+  stats socket /var/run/haproxy/stats.sock mode 600
 
 defaults
   log global


### PR DESCRIPTION
requires https://github.com/blueboxgroup/ursula-monitoring/pull/3

```
$ /etc/sensu/plugins/check-haproxy.rb -c 100 -S /var/run/haproxy/stats.sock -A
CheckHAProxy OK: UP: 100% of 24 // services
$ /etc/sensu/plugins/check-haproxy.rb -c 100 -S /var/run/haproxy/stats.sock -A
CheckHAProxy OK: UP: 100% of 24 // services
root@allinone:~# service nova-api stop
nova-api stop/waiting
$ /etc/sensu/plugins/check-haproxy.rb -c 100 -S /var/run/haproxy/stats.sock -A
CheckHAProxy CRITICAL: UP: 91% of 24 // services, DOWN: allinone, BACKEND
$ service nova-api start
nova-api start/running, process 6485
$ /etc/sensu/plugins/check-haproxy.rb -c 100 -S /var/run/haproxy/stats.sock -A
CheckHAProxy OK: UP: 100% of 24 // services
```

![haproxy_stats](https://cloud.githubusercontent.com/assets/2488346/6907549/c4f08cc2-d6fc-11e4-8b9b-1ce493d9b9b7.png)
