### PR TITLE
Switch to command to pip install inside package

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -5,7 +5,7 @@ country_code: US
 
 #openstack_install_method: 'source'
 openstack_install_method: 'package'
-openstack_package_version: '10.0-bbc54'
+openstack_package_version: '10.0-bbc56'
 
 primary_interface: 'ansible_eth0'
 primary_ip: "{{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}"

--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -8,7 +8,7 @@ country_code: US
 
 #openstack_install_method: 'source'
 openstack_install_method: 'package'
-openstack_package_version: '10.0-bbc54'
+openstack_package_version: '10.0-bbc56'
 
 fqdn: openstack.example.org
 undercloud_floating_ip: "{{ hostvars[groups['controller'][0]][primary_interface]['ipv4']['address'] }}"

--- a/roles/nova-data/tasks/libvirt.yml
+++ b/roles/nova-data/tasks/libvirt.yml
@@ -35,9 +35,13 @@
 # in the case of packaging, we want to be sure that libvirt python
 # modules are built against the libvirt running on the host, so build
 # this part of the virtualenv on the system itself
+# # This is done with command rather than pip due to a bug where the venv
+# # would get re-created on this task, breaking things badly. pip module
+# # needs to be fixed first.
 - name: install libvirt-python in package venv
-  pip: name=libvirt-python 
-       virtualenv="{{ 'nova'|ursula_package_path(openstack_package_version) }}"
+  command: "{{ 'nova'|ursula_package_path(openstack_package_version) }}/bin/pip install libvirt-python"
+  register: lvpout
+  changed_when: lvpout.stdout|search("Successfully installed")
   notify: restart nova services
   when: openstack_install_method == 'package'
 


### PR DESCRIPTION
pip module was re-creating the venv, triggering a bug on some ubuntu
installs that would put pip 1.1 into the venv rather than what's on the
system. All sorts of things went wrong.