### PR TITLE
Explicitly fall back to host-model cpu_mode

### DIFF
--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -130,6 +130,8 @@ virt_type={{ nova.libvirt_type }}
 {% if nova.libvirt_cpu_model -%}
 cpu_mode = custom
 cpu_model = {{ nova.libvirt_cpu_model }}
+{% else %}
+cpu_mode = host-model
 {% endif -%}
 
 # Reserved Resources


### PR DESCRIPTION
This is what happens by default anyway, but we want to be explicit in
case that changes or for easier reading.