### PR TITLE
Backport 1.0: Add prereboot tag and workaround grub-common crashkernel config

### DIFF
--- a/roles/common/tasks/ipmi.yml
+++ b/roles/common/tasks/ipmi.yml
@@ -1,4 +1,7 @@
 ---
+#
+# NOTE: this file is included by the prereboot tag, as such it should work not include anything that will break older releases
+#
 - name: install ipmitool
   apt: pkg=ipmitool
 

--- a/roles/common/tasks/kernel-tuning.yml
+++ b/roles/common/tasks/kernel-tuning.yml
@@ -1,4 +1,7 @@
 ---
+#
+# NOTE: this file is included by the prereboot tag, as such it should work not include anything that will break older releases
+#
 - name: Install prerequisites for acquiring crash dumps
   apt: name={{ item }}
   with_items:
@@ -36,4 +39,17 @@
   lineinfile: dest=/etc/default/grub
               regexp="^GRUB_CMDLINE_LINUX="
               line="GRUB_CMDLINE_LINUX=\"consoleblank=0 crashkernel=256M nmi_watchdog=1 {{ serial_console_cmdline|default('') }} console=tty0\""
+  notify: update grub config
+
+# This was removed in later distributions, but is in grub-common and if present
+# will override our crashkernel configuration above
+- name: Increase grub-common crashkernel reserved size
+  lineinfile: dest=/etc/grub.d/10_linux
+              regexp="^    GRUB_CMDLINE_EXTRA=.+crashkernel="
+              line="    GRUB_CMDLINE_EXTRA=\"$GRUB_CMDLINE_EXTRA crashkernel=256M\""
+  notify: update grub config
+
+- name: "Disable GRUB OS prober so we don't try to boot instance's cinder volumes"
+  lineinfile: dest=/etc/default/grub
+              line="GRUB_DISABLE_OS_PROBER=true"
   notify: update grub config

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -5,6 +5,7 @@
 
 - name: update apt index
   apt: update_cache=yes cache_valid_time=3600
+  tags: ['prereboot']
 
 - name: python dependencies
   apt: pkg={{ item }}
@@ -53,14 +54,20 @@
 
 # Include serial console before kernel-tuning to build serial_console_cmdline
 - include: serial-console.yml tty=ttyS0
+  tags: ['prereboot']
 
 - include: ipmi.yml
   when: common.ipmi.enabled
+  tags: ['prereboot']
+
+- include: security-patches.yml
 
 - include: kernel-tuning.yml
+  tags: ['prereboot']
+
 - include: system_tools.yml
-- include: security-patches.yml
-- include: disable_swap.yml
+
+- include: disable-swap.yml
 
 - include: hwraid.yml
   when: common.hwraid.enabled

--- a/roles/common/tasks/networking.yml
+++ b/roles/common/tasks/networking.yml
@@ -1,10 +1,12 @@
 ---
 - copy: content="{{ network_interfaces }}" dest=/etc/network/interfaces force=yes owner=root group=root mode=0644
   when: network_interfaces is defined
+  tags: ['prereboot']
 
 - copy: content="{{ item.contents }}" dest=/etc/network/interfaces.d/{{ item.filename }} force=yes owner=root group=root mode=0644
   when: network_interfaces_d is defined
   with_items: network_interfaces_d
+  tags: ['prereboot']
 
 - template: src=etc/hosts dest=/etc/hosts owner=root group=root mode=0644 backup=yes
 

--- a/roles/common/tasks/serial-console.yml
+++ b/roles/common/tasks/serial-console.yml
@@ -1,4 +1,7 @@
 ---
+#
+# NOTE: this file is included by the prereboot tag, as such it should work not include anything that will break older releases
+#
 - name: serial console init script
   template: src=etc/init/tty_console.conf dest=/etc/init/{{ tty }}.conf
 


### PR DESCRIPTION
Tag for items which should be updated before a reboot. Intention is that
this can be run from -master or another recent branch on an existing
stack before scheduled reboots occur on that stack.

In Precise grub-common includes an automatic crashkernel config, but it
isn't large enough for our updater kernels and configurations. Rather
than removing grub-common or backporting from a later release, just fix
the size of the crashkernel reservation to 256M.

Conflicts:
	roles/common/tasks/kernel-tuning.yml
	roles/common/tasks/main.yml