### PR TITLE
haproxy socket perms

### DIFF
--- a/roles/collectd-client/tasks/main.yml
+++ b/roles/collectd-client/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: create collectd user
   user: name=collectd comment=collectd shell=/bin/false
         system=yes home=/nonexistent createhome=no
+        append=true groups=monitor
 
 - name: install collectd packages
   apt: name={{ item }} state=present update_cache=yes

--- a/roles/common/tasks/monitoring.yml
+++ b/roles/common/tasks/monitoring.yml
@@ -1,10 +1,16 @@
 ---
+- name: create monitoring group
+  group: name=monitor state=present
+
 - name: install sensu
   apt: pkg=sensu
 
 - name: sensu sudoers
   template: src=monitoring/sensu-sudoers dest=/etc/sudoers.d/sensu owner=root
             group=root mode=0440
+
+- name: add sensu to monitoring group
+  user: name=sensu groups=monitor append=yes
 
 - name: ensure /etc/sudoers.d/sensu permissions are 0440
   file: path=/etc/sudoers.d/sensu mode=0440

--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -25,7 +25,7 @@ global
   daemon
   pidfile /var/run/haproxy/haproxy.pid
   tune.bufsize {{ haproxy.bufsize }}
-  stats socket /var/run/haproxy/stats.sock mode 644
+  stats socket /var/run/haproxy/stats.sock mode 770 group monitor
 
 defaults
   log global

--- a/roles/haproxy/templates/etc/haproxy/haproxy_swift.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_swift.cfg
@@ -5,7 +5,7 @@ global
    group nogroup
   daemon
   pidfile /var/run/haproxy.pid
-  stats socket /var/run/haproxy/stats.sock mode 644
+  stats socket /var/run/haproxy/stats.sock mode 770 group monitor
 
 defaults
   log global


### PR DESCRIPTION
sensu check needs write perm to haproxy socket for some reason.

Add monitor group, add sensu/collectd to that
monitor group owns socket and has write access.

by default the socket can't write anything harmful

```
    - "operator" is the default level and fits most common uses. All data can
      be read, and only non-sensitive changes are permitted (eg: clear max
      counters).
```

(cherry picked from commit 939e6a5a3be24fedeb84575b8387ca4d95245145)