### PR TITLE
Explicitly get bbg-ppa for neutron-data (backport)

### DIFF
--- a/roles/neutron-data/meta/main.yml
+++ b/roles/neutron-data/meta/main.yml
@@ -1,3 +1,8 @@
 ---
 dependencies:
+  - role: apt-repos
+    repos:
+      - repo: 'deb {{ apt_repos.bbg_openstack_ppa.repo }} precise main'
+        key_url: '{{ apt_repos.bbg_openstack_ppa.key_url }}'
+    when: ansible_distribution_version == "12.04"
   - role: neutron-common


### PR DESCRIPTION
Neutron-data often relies on iproute2, which comes from our ppa, but
there was nothing in place to enforce this dependency and thus the role
could fail. This now explicitly adds the repo.

(cherry picked from commit 73e15e794d80c5256981b0a4a6f6d135cf6cddae)