### PR TITLE
Upgrade rabbit before openstack services (backport)

### DIFF
--- a/upgrade.yml
+++ b/upgrade.yml
@@ -68,6 +68,16 @@
     - name: restart mysql
       service: name=mysql state=restarted
 
+- name: upgrade rabbitmq
+  gather_facts: force
+  hosts: controller
+  max_fail_percentage: 1
+  tags: rabbitmq
+  serial: 1
+
+  roles:
+    - role: rabbitmq
+
 - name: upgrade glance
   hosts: controller
   max_fail_percentage: 1


### PR DESCRIPTION
1.0.x to 1.2.x upgrades rabbit, which can cause some services to stop
working until they are restarted. By doing the rabbit upgrade first
before picking it up in site.yml we can ensure services come back to
working after they are restarted as part of their upgrade.

(cherry picked from commit 97a593564e8101a0ff9b3e2b4a415152cb193501)