### PR TITLE
Backport 1.2: upgrade Kernel to 3.13

### DIFF
--- a/playbooks/bootstrap_ml2_vlan.yml
+++ b/playbooks/bootstrap_ml2_vlan.yml
@@ -19,13 +19,11 @@
     lineinfile: dest=/etc/default/grub
                 line="GRUB_DISABLE_OS_PROBER=true"
 
-  # Upgrade Kernel to 3.5.0 on Precise
-  # and install Open vSwitch datapath (in mainline kernel on more recent distributions)
-  - apt: pkg={{ item }}
+  - name: Upgrade Kernel
+    apt: pkg={{ item }}
     with_items:
-    - linux-generic-lts-quantal
-    - linux-headers-generic-lts-quantal
-    - linux-image-generic-lts-quantal
+    - linux-generic-lts-trusty
+    - linux-tools-lts-trusty
     when: ansible_distribution_version == "12.04"
 
   - apt: cache_valid_time=3600 update_cache=yes

--- a/playbooks/bootstrap_ml2_vxlan.yml
+++ b/playbooks/bootstrap_ml2_vxlan.yml
@@ -19,12 +19,11 @@
     lineinfile: dest=/etc/default/grub
                 line="GRUB_DISABLE_OS_PROBER=true"
 
-  # Upgrade Kernel to 3.8.0 on Precise for VXLAN support
-  - apt: pkg={{ item }}
+  - name: Upgrade Kernel
+    apt: pkg={{ item }}
     with_items:
-    - linux-generic-lts-raring
-    - linux-headers-generic-lts-raring
-    - linux-image-generic-lts-raring
+    - linux-generic-lts-trusty
+    - linux-tools-lts-trusty
     when: ansible_distribution_version == "12.04"
 
   # Install vlan and ucarp packages

--- a/upgrade.yml
+++ b/upgrade.yml
@@ -4,6 +4,13 @@
 #
 # Assumes ml2 networking
 ---
+- name: Upgrade kernel to supported HWE
+  apt: pkg={{ item }}
+  with_items:
+    - linux-generic-lts-trusty
+    - linux-tools-lts-trusty
+  when: ansible_distribution_version == "12.04"
+
 - name: upgrade common bits first
   hosts: all
   max_fail_percentage: 1


### PR DESCRIPTION
We've been testing this kernel since b851042a in CI, but none of these files are covered in CI so merge at will.