### PR TITLE
Cloud archive bumped libvirt version

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -19,14 +19,14 @@ nova:
   novnc_rev: 292f6a5d
   novnc_url: https://github.com/kanaka/noVNC/archive/v0.5.1.tar.gz
   scheduler_default_filters: AvailabilityZoneFilter,RamFilter,ComputeFilter,CoreFilter
-  libvirt_bin_version: 1.2.2-0ubuntu13.1.6~cloud2
+  libvirt_bin_version: 1.2.2-0ubuntu13.1.9~cloud0
   python_libvirt_version: 1.2.2-0ubuntu2~cloud0
-  qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.6~cloud0
-  librdb1_version: 0.80.5-0ubuntu0.14.04.1~cloud0
+  qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.10~cloud0
+  librdb1_version: 0.80.9-0ubuntu0.14.04.1~cloud0
   glance_endpoint: http://{{ endpoints.glance }}:9292
   reserved_host_disk_mb: 51200
   trusty:
-    libvirt_bin_version: 1.2.2-0ubuntu13.1.9
+    libvirt_bin_version: 1.2.2-0ubuntu13.1.10
     python_libvirt_version: 1.2.2-0ubuntu2
     qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.10
   driver:


### PR DESCRIPTION
So we need to bump it here too. One day this won't be so explicit...