### PR TITLE
Ansible needs a controlmasters directory to function.

### DIFF
--- a/bin/run_vagrant
+++ b/bin/run_vagrant
@@ -9,6 +9,11 @@ function get_vagrant_hosts {
 
 TYPE=$1
 
+# This directory is used by ansible and needs to exist before the first ansible run
+if [ ! -d ~/.ssh/controlmasters ]; then
+    mkdir -p ~/.ssh/controlmasters
+fi
+
 if [[ -z ${TYPE} ]]; then
     echo "Usage: run_vagrant TYPE [minimal]"
     echo "Where type is one of the following:"


### PR DESCRIPTION
The controlmasters directory (~/.ssh/controlmasters) apparently
used to be created by something, but now it's not so it all fails
on a virgin install. This corrects that my creating the directory
if it does not exist.