### PR TITLE
Add support for vagrant libvirt provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,6 +61,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       v.customize ["modifyvm", :id, "--nicpromisc3", "allow-all"]
       v.customize ["modifyvm", :id, "--nicpromisc4", "allow-all"]
     end
+    allinone_config.vm.provider "libvirt" do |v|
+      v.memory = 6144
+      v.cpus = 2
+      v.nested = true
+    end
   end
 
   (1..NUM_CONTROLLERS).each do |i|
@@ -73,6 +78,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       controller_config.vm.provider "virtualbox" do |v|
         v.memory = 3072
         v.customize ["modifyvm", :id, "--nicpromisc3", "allow-all"]
+      end
+      controller_config.vm.provider "libvirt" do |v|
+        v.memory = 3072
+        v.nested = true
       end
     end
   end
@@ -87,6 +96,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       compute_config.vm.provider "virtualbox" do |v|
         v.memory = 1536
         v.customize ["modifyvm", :id, "--nicpromisc3", "allow-all"]
+      end
+      compute_config.vm.provider "libvirt" do |v|
+        v.memory = 1536
+        v.nested = true
       end
     end
   end
@@ -105,6 +118,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       swiftnode_config.vm.network :private_network, ip: "10.1.1.13#{i}", :netmask => "255.255.255.0"
       swiftnode_config.vm.provider "virtualbox" do |v|
         v.memory = 768
+      end
+      swiftnode_config.vm.provider "libvirt" do |v|
+        v.memory = 768
+        v.nested = true
       end
     end
   end

--- a/bin/run_vagrant
+++ b/bin/run_vagrant
@@ -8,6 +8,7 @@ function get_vagrant_hosts {
 }
 
 TYPE=$1
+PROVIDER=${VAGRANT_DEFAULT_PROVIDER:-virtualbox}
 
 # This directory is used by ansible and needs to exist before the first ansible run
 if [ ! -d ~/.ssh/controlmasters ]; then
@@ -36,7 +37,7 @@ else
     exit -1
 fi
 
-vagrant up --provider=virtualbox ${BOXES}
+vagrant up --provider=${PROVIDER} ${BOXES}
 
 # Write the Vagrant SSH config to be used by ansible
 TEMPFILE=`mktemp 2>/dev/null || mktemp -t 'ursula-fifo'`


### PR DESCRIPTION
Turns out, virtualbox doesn't work on my machine because I alredy
run KVM instances for other reasons. This adds support for using
the libvirt provider to fix that.

How to use:
Install the vagrant libvirt provider plugin
  (see https://github.com/pradels/vagrant-libvirt - install deps first!)
Install the vargant mutate plugin:
  vagrant plugin install vagrant-mutate
Download the existing virtualbox image
Use vagrant mutate on the existing box image:
  vagrant mutate ursula-precise libvirt
Run as normal!

Really, that's it. The rest of the changes are covered by this
commit. Everything _seems_ to work for now, and it makes life
better for non-Mac people :D