### PR TITLE
Backport: Add check-storcli to sensu's sudoers

### DIFF
--- a/roles/common/templates/monitoring/sensu-sudoers
+++ b/roles/common/templates/monitoring/sensu-sudoers
@@ -6,6 +6,7 @@ sensu ALL= NOPASSWD: /etc/sensu/plugins/check-rabbitmq-cluster.rb
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check-rabbitmq-queues.rb
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check_3ware_raid.py
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check_megaraid_sas.pl
+sensu ALL= NOPASSWD: /etc/sensu/plugins/check-storcli.pl
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check-swift-dispersion.sh
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check-nova-services.sh
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check-cinder-services.sh


### PR DESCRIPTION
Otherwise sensu is not able to run this privileged command.

(cherry picked from commit f2acbcd1ba30783903866044441dc9813d4c62d4)