### PR TITLE
Backport: Bump package to pick up horizon port fix

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -5,7 +5,7 @@ country_code: US
 
 #openstack_install_method: 'source'
 openstack_install_method: 'package'
-openstack_package_version: '10.0-bbc60'
+openstack_package_version: '10.0-bbc62'
 
 primary_interface: 'ansible_eth0'
 primary_ip: "{{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}"

--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -8,7 +8,7 @@ country_code: US
 
 #openstack_install_method: 'source'
 openstack_install_method: 'package'
-openstack_package_version: '10.0-bbc60'
+openstack_package_version: '10.0-bbc62'
 
 fqdn: openstack.example.org
 undercloud_floating_ip: "{{ hostvars[groups['controller'][0]][primary_interface]['ipv4']['address'] }}"


### PR DESCRIPTION
Horizon will not show ports to attach floating IPs to if the user is a
non-admin and the network is an admin shared network. Upstream fix is in
the 62 build.

(cherry picked from commit d38750ff0b9fd8df518b97a62b1b08a7df663282)