### PR TITLE
Fully allocate instance disks at launch

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -25,6 +25,7 @@ nova:
   librdb1_version: 0.80.9-0ubuntu0.14.04.1~cloud0
   glance_endpoint: http://{{ endpoints.glance }}:9292
   reserved_host_disk_mb: 51200
+  preallocate_images: space
   trusty:
     libvirt_bin_version: 1.2.2-0ubuntu13.1.10
     python_libvirt_version: 1.2.2-0ubuntu2

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -115,12 +115,15 @@ reserved_host_memory_mb=4096
 {% endif %}
 reserved_host_disk_mb = {{ nova.reserved_host_disk_mb }}
 
+# misc #
 compute_driver={{ nova.compute_driver }}
 resume_guests_state_on_host_boot=true
 
 use_virtio_for_bridges=true
 
 disable_libvirt_livesnapshot=false
+
+preallocate_images = {{ nova.preallocate_images }}
 
 [database]
 connection=mysql://nova:{{ secrets.db_password }}@{{ endpoints.db }}/nova?charset=utf8

--- a/roles/nova-data/tasks/libvirt.yml
+++ b/roles/nova-data/tasks/libvirt.yml
@@ -16,6 +16,7 @@
     - libvirt-dev={{ nova.libvirt_bin_version }}
     - pkg-config
     - genisoimage
+    - util-linux
   notify: restart nova services
   when: ansible_distribution_version == "12.04"
 
@@ -29,6 +30,7 @@
     - libvirt-dev={{ nova.trusty.libvirt_bin_version }}
     - pkg-config
     - genisoimage
+    - util-linux
   notify: restart nova services
   when: ansible_distribution_version == "14.04"
 


### PR DESCRIPTION
By default the disk was allocated on-demand. This could lead to a
scenario where space usage was not accounted for properly and space is
exhausted if instances start filling up their local disks. Changing data
within instances could be slower too due to copy on write happening vs
just writing to the already allocated space.

util-linux is required to get the fallocate utility which is used to
allocate the space.