### PR TITLE
standalone cinder node

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -126,4 +126,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
+  config.vm.define "cinder" do |cinder_config|
+    cinder_config.vm.box = "ursula-precise"
+    cinder_config.vm.box_url = BOX_URL
+    cinder_config.vm.hostname = "cinder"
+    cinder_config.vm.network :private_network, ip: "172.16.0.155", :netmask => "255.255.255.0"
+    cinder_config.vm.provider "virtualbox" do |v|
+      v.memory = 512
+    end
+    cinder_config.vm.provider "libvirt" do |v|
+      v.memory = 512
+      v.nested = true
+    end
+  end
+
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -133,6 +133,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     cinder_config.vm.network :private_network, ip: "172.16.0.155", :netmask => "255.255.255.0"
     cinder_config.vm.provider "virtualbox" do |v|
       v.memory = 512
+      v.customize ['createhd', '--filename', 'cinder.1.vdi', '--size', 5120]
+      v.customize ['storagectl', :id, '--name', 'SATA Controller', '--add', 'sata']
+      v.customize ['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium', 'cinder.1.vdi']
     end
     cinder_config.vm.provider "libvirt" do |v|
       v.memory = 512

--- a/bin/run_vagrant
+++ b/bin/run_vagrant
@@ -32,6 +32,8 @@ elif [ "${TYPE}" == "standard" -o "${TYPE}" == "novadocker" ]; then
     BOXES="controller1 controller2 compute1"
 elif [ "${TYPE}" == "allinone" -o "${TYPE}" == "ironic" -o "${TYPE}" == "mirrors" ]; then
     BOXES="allinone"
+elif [ "${TYPE}" == "cinder" ]; then
+    BOXES="allinone cinder"
 else
     echo "I dont know how to provision '${TYPE}'"
     exit -1

--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -106,6 +106,7 @@ nova:
     verbose: True
 
 cinder:
+  volume_type: file
   volume_file: /opt/stack/cinder-volumes
   volume_file_size: 5G
   #fixed_key: 6a5c55db5e250f234b6af7807dafda77433dddcf372b6d04801a45f578a35aa7

--- a/envs/vagrant/cinder/group_vars/all.yml
+++ b/envs/vagrant/cinder/group_vars/all.yml
@@ -1,0 +1,27 @@
+---
+stack_env: vagrant
+floating_ip: 10.1.1.100
+
+xtradb:
+  sst_auth_password: asdf
+
+percona:
+  replication: False
+
+nova:
+  scheduler_default_filters: AvailabilityZoneFilter,ComputeFilter
+
+cinder:
+  volume_file: /opt/stack/cinder-volumes
+  volume_file_size: 5G
+  fixed_key: 6a5c55db5e250f234b6af7807dafda77433dddcf372b6d04801a45f578a35aa7
+  logging:
+    debug: True
+    verbose: True
+  volume_types: []
+  encrypted_volume_types:
+    - volume_type: encrypted-aes-512
+      cipher: aes-xts-plain64
+      key_size: 512
+      provider: nova.volume.encryptors.luks.LuksEncryptor
+      control_location: front-end

--- a/envs/vagrant/cinder/group_vars/all.yml
+++ b/envs/vagrant/cinder/group_vars/all.yml
@@ -12,8 +12,8 @@ nova:
   scheduler_default_filters: AvailabilityZoneFilter,ComputeFilter
 
 cinder:
-  volume_file: /opt/stack/cinder-volumes
-  volume_file_size: 5G
+  volume_type: device
+  volume_device: /dev/sdb
   fixed_key: 6a5c55db5e250f234b6af7807dafda77433dddcf372b6d04801a45f578a35aa7
   logging:
     debug: True

--- a/envs/vagrant/cinder/hosts
+++ b/envs/vagrant/cinder/hosts
@@ -1,0 +1,14 @@
+[controller]
+allinone
+
+[network]
+allinone
+
+[db]
+allinone
+
+[compute]
+allinone
+
+[cinder_volume]
+cinder

--- a/envs/vagrant/cinder/playbooks
+++ b/envs/vagrant/cinder/playbooks
@@ -1,0 +1,1 @@
+../../../playbooks/vagrant

--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -33,6 +33,7 @@ endpoints:
   neutron:  "{{ fqdn }}"
   vnc:      "{{ fqdn }}"
   cinder:   "{{ fqdn }}"
+  cinderv2: "{{ fqdn }}"
   heat:     "{{ fqdn }}"
   heat-cfn: "{{ fqdn }}"
   ironic: "{{ fqdn }}"

--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -309,6 +309,12 @@ keystone:
       public_url: https://{{ endpoints.main }}:8778/v1/%(tenant_id)s
       internal_url: https://{{ endpoints.main }}:8778/v1/%(tenant_id)s
       admin_url: https://{{ endpoints.main }}:8778/v1/%(tenant_id)s
+    - name: cinderv2
+      type: volumev2
+      description: 'Volume Service v2'
+      public_url: https://{{ endpoints.main }}:8778/v2/%(tenant_id)s
+      internal_url: https://{{ endpoints.main }}:8778/v2/%(tenant_id)s
+      admin_url: https://{{ endpoints.main }}:8778/v2/%(tenant_id)s
     - name: swift
       type: object-store
       description: 'Object Storage Service'

--- a/library/cinder_volume_type
+++ b/library/cinder_volume_type
@@ -88,7 +88,7 @@ EXAMPLES = '''
 
 try:
     from keystoneclient.v2_0 import client as ksclient
-    from cinderclient.v1 import client
+    from cinderclient.v2 import client
 except ImportError as e:
     print("failed=True msg='python-cinderclient is required'")
 
@@ -154,7 +154,11 @@ def _create_encrypted_volume_type(module, cinderclient, volume_type, provider,
                                   key_size=None):
     volume_type_id = _get_volume_type_id(cinderclient, volume_type)
     if not volume_type_id:
-        raise ValueError("volume type '%s' not found" % volume_type)
+        _create_volume_type(module, cinderclient, volume_type)
+
+    volume_type_id = _get_volume_type_id(cinderclient, volume_type)
+    if not volume_type_id:
+        raise ValueError("volume type '%s' not found and could not be created" % volume_type)
 
     enc_volume_type = _get_encrypted_volume_type_id_name(cinderclient,
                                                          volume_type_id)

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -75,11 +75,6 @@ nimble_subnet_label = {{ backend.nimble_subnet_label }}
 
 {% endfor -%}
 
-{% if cinder.fixed_key is defined %}
-[keymgr]
-fixed_key = NOT_A_KEY
-{% endif %}
-
 [database]
 connection=mysql://cinder:{{ secrets.db_password }}@{{ endpoints.db }}/cinder?charset=utf8
 

--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -24,22 +24,22 @@
 - name: ensure tgt service is running
   service: name=tgt state=started
 
-# TODO: allow for device-backed VGs in addition to file-backed VGs
-- name: cinder volume group
-  cinder_volume_group: file={{ cinder.volume_file }}
-                       size={{ cinder.volume_file_size }}
+- include: volume_group.yml
   when: cinder.fixed_key is not defined or (cinder.fixed_key is defined and "compute" not in group_names)
-  # a fixed_key cannot be used with a local cinder volume group on a compute
-  # node. This would be a security risk, DO NOT CHANGE.
 
 - name: iscsi start
   service: name=open-iscsi state=started
 
-- name: cinder encryption key
+- name: enable cinder encryption
   template: src=etc/cinder/cinder.encryption.conf dest=/etc/cinder/cinder.encryption.conf mode=0640
             owner=root group=cinder
   notify: restart cinder services
   when: cinder.fixed_key is defined
+
+- name: disable cinder encryption
+  file: dest=/etc/cinder/cinder.encryption.conf state=absent
+  notify: restart cinder services
+  when: cinder.fixed_key is not defined
 
 - name: install cinder-volume service
   upstart_service: name=cinder-volume user=cinder

--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -35,6 +35,12 @@
 - name: iscsi start
   service: name=open-iscsi state=started
 
+- name: cinder encryption key
+  template: src=etc/cinder/cinder.encryption.conf dest=/etc/cinder/cinder.encryption.conf mode=0640
+            owner=root group=cinder
+  notify: restart cinder services
+  when: cinder.fixed_key is defined
+
 - name: install cinder-volume service
   upstart_service: name=cinder-volume user=cinder
                    cmd=/usr/local/bin/cinder-volume

--- a/roles/cinder-data/tasks/volume_group.yml
+++ b/roles/cinder-data/tasks/volume_group.yml
@@ -1,0 +1,9 @@
+# TODO: allow for device-backed VGs in addition to file-backed VGs
+- name: file based cinder volume group
+  cinder_volume_group: file={{ cinder.volume_file }}
+                       size={{ cinder.volume_file_size }}
+  when: cinder.volume_type == "file"
+
+- name: device based cinder volume group
+  lvg:  vg=cinder-volumes pvs={{ cinder.volume_device }}
+  when: cinder.volume_type == "device"

--- a/roles/cinder-data/templates/etc/cinder/cinder.encryption.conf
+++ b/roles/cinder-data/templates/etc/cinder/cinder.encryption.conf
@@ -1,0 +1,4 @@
+[keymgr]
+# This line is needed, but we do not actually want
+# a real key saved on the cinder nodes, hence 'NOT_A_KEY'
+fixed_key = NOT_A_KEY

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -184,8 +184,3 @@ admin_url=https://{{ endpoints.main }}:35358/v2.0
 admin_tenant_name=service
 api_endpoint=https://{{ endpoints.main }}:6384/v1
 {% endif -%}
-
-{% if cinder.fixed_key is defined %}
-[keymgr]
-fixed_key = {{ cinder.fixed_key }}
-{% endif %}

--- a/roles/nova-data/tasks/main.yml
+++ b/roles/nova-data/tasks/main.yml
@@ -21,6 +21,12 @@
 
 - modprobe: name=nbd state=present
 
+- name: cinder encryption key
+  template: src=etc/nova/nova.cinder_encryption.conf dest=/etc/nova/nova.cinder_encryption.conf mode=0640
+            owner=root group=nova
+  notify: restart nova services
+  when: cinder.fixed_key is defined
+
 - name: install nova-compute service
   upstart_service: name=nova-compute user=nova cmd=/usr/local/bin/nova-compute
                    config_dirs=/etc/nova

--- a/roles/nova-data/tasks/main.yml
+++ b/roles/nova-data/tasks/main.yml
@@ -21,11 +21,16 @@
 
 - modprobe: name=nbd state=present
 
-- name: cinder encryption key
+- name: enable cinder encryption
   template: src=etc/nova/nova.cinder_encryption.conf dest=/etc/nova/nova.cinder_encryption.conf mode=0640
             owner=root group=nova
   notify: restart nova services
   when: cinder.fixed_key is defined
+
+- name: disable  cinder encryption
+  file: dest=/etc/nova/nova.cinder_encryption.conf state=absent
+  notify: restart nova services
+  when: cinder.fixed_key is not defined
 
 - name: install nova-compute service
   upstart_service: name=nova-compute user=nova cmd=/usr/local/bin/nova-compute

--- a/roles/nova-data/templates/etc/nova/nova.cinder_encryption.conf
+++ b/roles/nova-data/templates/etc/nova/nova.cinder_encryption.conf
@@ -1,0 +1,2 @@
+[keymgr]
+fixed_key = {{ cinder.fixed_key }}

--- a/roles/openstack-setup/tasks/cinder.yml
+++ b/roles/openstack-setup/tasks/cinder.yml
@@ -1,25 +1,21 @@
 ---
 - name: create cinder volume types
-  action: |
-    cinder_volume_type
-      volume_type={{ item }}
-      auth_url={{ endpoints.auth_uri }}
-      login_username=provider_admin
-      login_password={{ secrets.provider_admin_password }}
-      login_tenant_name=admin
+  cinder_volume_type: volume_type={{ item }}
+                      auth_url={{ endpoints.auth_uri }}
+                      login_username=provider_admin
+                      login_password={{ secrets.provider_admin_password }}
+                      login_tenant_name=admin
   with_items: cinder.volume_types
 
 - name: create cinder encryption volume types
-  action: |
-     cinder_volume_type
-      volume_type={{ item.volume_type }}
-      encryption_type=True
-      provider={{ item.provider }}
-      cipher={{ item.cipher }}
-      key_size={{ item.key_size }}
-      control_location={{ item.control_location }}
-      auth_url={{ endpoints.auth_uri }}
-      login_username=provider_admin
-      login_password={{ secrets.provider_admin_password }}
-      login_tenant_name=admin
+  cinder_volume_type: volume_type={{ item.volume_type }}
+                      encryption_type=True
+                      provider={{ item.provider }}
+                      cipher={{ item.cipher }}
+                      key_size={{ item.key_size }}
+                      control_location={{ item.control_location }}
+                      auth_url={{ endpoints.auth_uri }}
+                      login_username=provider_admin
+                      login_password={{ secrets.provider_admin_password }}
+                      login_tenant_name=admin
   with_items: cinder.encrypted_volume_types

--- a/roles/openstack-setup/tasks/main.yml
+++ b/roles/openstack-setup/tasks/main.yml
@@ -8,4 +8,7 @@
 - include: networks.yml
   when: openstack_setup.add_networks|bool or openstack_setup.add_networks is undefined
 
+- include: cinder.yml
+  tags: potato
+
 - include: flavors.yml

--- a/roles/openstack-setup/tasks/main.yml
+++ b/roles/openstack-setup/tasks/main.yml
@@ -9,6 +9,5 @@
   when: openstack_setup.add_networks|bool or openstack_setup.add_networks is undefined
 
 - include: cinder.yml
-  tags: potato
 
 - include: flavors.yml


### PR DESCRIPTION
allow use of device for cinder-volume

* move encryption key to own file so that we only write it on nodes that
  are involved in encryption

* allow for deviced backed volume group as well as file backed

* add cinder env for vagrant for easy testing

* fix cinder_volume_type library and create type if missing for encrypted type.

* style cleanup of cinder tasks in openstack-setup