### PR TITLE
Cleanup neutron interface logs

### DIFF
--- a/roles/neutron-data/tasks/main.yml
+++ b/roles/neutron-data/tasks/main.yml
@@ -42,4 +42,9 @@
   service: name=neutron-linuxbridge-agent state=started
   when: neutron.plugin == 'ml2'
 
+- name: cleanup interface logs
+  template: src=etc/cron.daily/cleanup-neutron-interfaces
+            dest=/etc/cron.daily/cleanup-neutron-interfaces
+            mode=0755 owner=root
+
 - include: monitoring.yml tags=monitoring,common

--- a/roles/neutron-data/templates/etc/cron.daily/cleanup-neutron-interfaces
+++ b/roles/neutron-data/templates/etc/cron.daily/cleanup-neutron-interfaces
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Remove logs for Neutron TAP interfaces
+find /var/log/upstart/ -name network-interface-tap\*.log -mtime +1 -delete


### PR DESCRIPTION
Upstart logs state changes when each tap interface comes up, since a
running cluster could have a very large number of instances created and
destroy purge these files daily.