### PR TITLE
cinderclient 1.2.1 causes issues with cinder behind haproxy

### DIFF
--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -6,7 +6,7 @@ client:
     - python-glanceclient
     - python-novaclient==2.20.0
     - python-neutronclient
-    - python-cinderclient
+    - python-cinderclient==1.1.1
     - python-heatclient
     - python-ironicclient
     - python-swiftclient


### PR DESCRIPTION
this has to do with openstack not understanding the x-forwarded-for
header and thus responding with a http link rather than a https.