### PR TITLE
Add the key type to the known_hosts file

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -101,7 +101,7 @@ nova:
   conductor_workers: 1
   metadata_api_workers: 1
   reserved_host_disk_mb: 50
-  enable_ssh: false
+  enable_ssh: true
   logging:
     debug: True
     verbose: True

--- a/roles/nova-data/templates/var/lib/nova/ssh/known_hosts
+++ b/roles/nova-data/templates/var/lib/nova/ssh/known_hosts
@@ -1,3 +1,3 @@
 {% for host in groups['compute'] %}
-{{ hostvars[host][primary_interface].ipv4.address }} {{ hostvars[host].ansible_ssh_host_key_rsa_public }}
+{{ hostvars[host][primary_interface].ipv4.address }} ssh-rsa {{ hostvars[host].ansible_ssh_host_key_rsa_public }}
 {% endfor %}


### PR DESCRIPTION
This is silly, but ssh refuses the key otherwise. Ansible fact doesn't
put this little header in place, we have to put it in manually.

Also turn ssh back on