### PR TITLE
VENOM for 1.2.x

### DIFF
--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -6,7 +6,7 @@ client:
     - python-glanceclient
     - python-novaclient==2.20.0
     - python-neutronclient
-    - python-cinderclient
+    - python-cinderclient==1.1.1
     - python-heatclient
     - python-ironicclient
     - python-swiftclient

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -21,14 +21,14 @@ nova:
   scheduler_default_filters: AvailabilityZoneFilter,RamFilter,ComputeFilter,CoreFilter
   libvirt_bin_version: 1.2.2-0ubuntu13.1.9~cloud0
   python_libvirt_version: 1.2.2-0ubuntu2~cloud0
-  qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.10~cloud0
+  qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.11~cloud0
   librdb1_version: 0.80.9-0ubuntu0.14.04.1~cloud0
   glance_endpoint: http://{{ endpoints.glance }}:9292
   reserved_host_disk_mb: 51200
   trusty:
     libvirt_bin_version: 1.2.2-0ubuntu13.1.10
     python_libvirt_version: 1.2.2-0ubuntu2
-    qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.9
+    qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.11
   driver:
     docker:
       rev: 2f23a09ba49bfafedc712b82613417da7147c5a3

--- a/roles/nova-data/tasks/libvirt.yml
+++ b/roles/nova-data/tasks/libvirt.yml
@@ -18,6 +18,7 @@
     - genisoimage
   notify: restart nova services
   when: ansible_distribution_version == "12.04"
+  tags: security
 
 - name: install nova-compute packages (trusty)
   apt: pkg={{ item }}
@@ -31,6 +32,7 @@
     - genisoimage
   notify: restart nova services
   when: ansible_distribution_version == "14.04"
+  tags: security
 
 # in the case of packaging, we want to be sure that libvirt python
 # modules are built against the libvirt running on the host, so build


### PR DESCRIPTION
This adds a security tagged task to update qemu-kvm package. It also backports a cinderclient fix to pass CI.