### PR TITLE
rabbitmq-numqueues check timeout can be 2 seconds

### DIFF
--- a/roles/rabbitmq/tasks/monitoring.yml
+++ b/roles/rabbitmq/tasks/monitoring.yml
@@ -20,7 +20,8 @@
 - name: rabbit queue num check
   sensu_check: name=rabbitmq-numqueues plugin=check-rabbitmq-queues.rb
                args="-t number -w {{ cluster_node_count|int * 50 }}
-                     -c {{ cluster_node_count|int * 100 }}"
+                     -c {{ cluster_node_count|int * 100 }}
+                     --timeout 2"
                use_sudo=true
   notify: restart sensu-client
 


### PR DESCRIPTION
I've been observing this check error out at times if there is load upon the controller.
By setting this to 2 sec (instead of the default 1 sec) we will be getting less noise and will actually be allowing the check to run like it was intended to.