### PR TITLE
glance: configure show_multiple_locations

### DIFF
--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -12,6 +12,7 @@ glance:
     device_name: image-cache
     dir: /var/lib/glance/images
   store_swift: False
+  show_multiple_locations: True
 
   source:
     rev: '0e355462833feeaa6f3124fda4bd5ff7064c8512'

--- a/roles/glance/templates/etc/glance/glance-api.conf
+++ b/roles/glance/templates/etc/glance/glance-api.conf
@@ -32,6 +32,8 @@ notifier_strategy = noop
 container_formats = {{ glance.container_formats }}
 {% endif %}
 
+show_multiple_locations = {{ glance.show_multiple_locations }}
+
 [glance_store]
 {% if glance.store_swift %}
 stores = glance.store.swift.Store,


### PR DESCRIPTION
This is necessary to add support for https://github.com/blueboxgroup/ursula-monitoring/pull/11 and fix the current sensu glance image issue.