### PR TITLE
Explicitly remove package symlink on upgrade

### DIFF
--- a/upgrade.yml
+++ b/upgrade.yml
@@ -4,6 +4,16 @@
 #
 # Assumes ml2 networking
 ---
+- name: Remove existing package symlink
+  hosts: all
+  max_fail_percentage: 0
+
+  tasks:
+    - file:
+        dest: /opt/openstack/current
+        state: absent
+      when: openstack_install_method == 'package'
+
 - name: Upgrade kernel to supported HWE
   hosts: all
   max_fail_percentage: 1


### PR DESCRIPTION
The package role will not update the symlink if it already exists. For
upgrades that's no good, we want a new symlink. This removal will force
the symlink to be re-created.

Also use the new suggested task format since it's required for some of
our tasks. max_fail_percentage is set to 0 because that was more
appropriate than 1.