### PR TITLE
Set a default for openstack_package_version

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -5,7 +5,6 @@ country_code: US
 
 #openstack_install_method: 'source'
 openstack_install_method: 'package'
-openstack_package_version: '10.0-bbc62'
 
 primary_interface: 'ansible_eth0'
 primary_ip: "{{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}"

--- a/envs/vagrant/defaults.yml
+++ b/envs/vagrant/defaults.yml
@@ -8,7 +8,6 @@ country_code: US
 
 #openstack_install_method: 'source'
 openstack_install_method: 'package'
-openstack_package_version: '10.0-bbc64'
 
 fqdn: openstack.example.org
 undercloud_floating_ip: "{{ hostvars[groups['controller'][0]][primary_interface]['ipv4']['address'] }}"

--- a/roles/openstack-package/defaults/main.yml
+++ b/roles/openstack-package/defaults/main.yml
@@ -1,3 +1,4 @@
+openstack_package_version: 10.0-bbc64
 openstack_package:
   package_name: 'openstack-{{ project_name }}-{{ openstack_package_version }}'
   repo: 'deb http://repo.openstack.blueboxgrid.com/bbc precise main'


### PR DESCRIPTION
Sites can override the variable which will be used in the apt call to
install the packages. Keeps our versioning in a single place to update
as master moves along.