### PR TITLE
Backport 1.2.x: lock down physical host access via IPv6

### DIFF
--- a/roles/common/files/etc/sysctl.d/10-disable-ipv6-default.conf
+++ b/roles/common/files/etc/sysctl.d/10-disable-ipv6-default.conf
@@ -1,0 +1,5 @@
+# Disable IPv6 on all interfaces
+net.ipv6.conf.all.disable_ipv6 = 1
+net.ipv6.conf.default.disable_ipv6 = 1
+# Enable on loopback
+net.ipv6.conf.lo.disable_ipv6 = 0

--- a/roles/common/tasks/networking.yml
+++ b/roles/common/tasks/networking.yml
@@ -45,6 +45,13 @@
       regex: '^net\.ipv6\.conf\.default\.use_tempaddr'
       line: "net.ipv6.conf.default.use_tempaddr = 0"
 
+- name: Disable IPv6 on all interfaces by default
+  copy: src=etc/sysctl.d/10-disable-ipv6-default.conf
+        dest=/etc/sysctl.d/10-disable-ipv6-default.conf
+        owner=root group=root mode=0644
+  notify:
+  - apply-sysctl
+
 - name: conntrack module
   template: src=etc/modprobe.d/conntrack.conf
             dest=/etc/modprobe.d/conntrack.conf owner=root group=root mode=0644


### PR DESCRIPTION
By default IPv6 assigns link-local addresses to all up interfaces
including bridge, tun and veth interfaces thus exposing the host IPv6
services to the tenant networks. Resolve this by disabling IPv6 on all
interfaces by default, and explicitly enabling it on specific
interfaces. This brings IPv6 in to parity with IPv4 so the protocol is
only active on interfaces that have been explicitly configured. To
configure IPv6 on an additional interface `sysctl
net.ipv6.conf.$IFACE.disable_ipv6=0`.