### PR TITLE
testenv: enable IPv6 tenant networks

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -149,24 +149,38 @@ neutron:
       segmentation_id: ~
       provider_physical_network: ~
   subnets:
-    - name: internal
+    - name: internal_v4
       network_name: internal
+      ip_version: 4
       cidr: 172.16.255.0/24
       enable_dhcp: "true"
       gateway_ip: 172.16.255.1
-      ip_version: 4
+      dns_nameservers: '8.8.8.8,8.8.4.4'
+    - name: internal_v6
+      network_name: internal
+      ip_version: 6
+      cidr: 2db8:1::/64
+      enable_dhcp: "true"
+      gateway_ip: 2db8:1::1
+      ipv6_address_mode: dhcpv6-stateless
+      ipv6_ra_mode: dhcpv6-stateless
+      dns_nameservers: '2001:4860:4860::8888,2001:4860:4860::8844'
     - name: external
       network_name: external
+      ip_version: 4
       cidr: 192.168.255.0/24
       enable_dhcp: "false"
       gateway_ip: 192.168.255.1
-      ip_version: 4
+      dns_nameservers: '8.8.8.8,8.8.4.4'
   routers:
     - name: default
       tenant_name: admin
   router_interfaces:
     - router_name: default
-      subnet_name: internal
+      subnet_name: internal_v4
+      tenant_name: admin
+    - router_name: default
+      subnet_name: internal_v6
       tenant_name: admin
   service:
     envs:
@@ -194,7 +208,6 @@ keystone:
     - admin
     - service
     - demo
-
   users:
     - name: admin
       password: "{{ secrets.admin_password }}"
@@ -226,7 +239,6 @@ keystone:
     - name: "{{ monitoring.openstack.user.username }}"
       password: "{{ monitoring.openstack.user.password }}"
       tenant: "{{ monitoring.openstack.user.tenant }}"
-
   user_roles:
     - user: admin
       tenant: admin

--- a/library/neutron_floating_ip
+++ b/library/neutron_floating_ip
@@ -77,6 +77,11 @@ options:
         - The name of the instance to which the IP address should be assigned
      required: true
      default: None
+   fixed_ip:
+     description:
+        - IP address on the instance's port. Useful when the port has more than one IP
+     required: false
+     default: None
 requirements: ["novaclient", "neutronclient", "keystoneclient"]
 '''
 
@@ -136,7 +141,7 @@ def _get_server_state(module, nova):
     except Exception as e:
         module.fail_json(msg = "Error in getting the server list: %s" % e.message)
     return server_info, server
-                                 
+
 def _get_port_info(neutron, module, instance_id):
     if module.params['port_network_name'] is None:
       kwargs = {
@@ -158,7 +163,7 @@ def _get_port_info(neutron, module, instance_id):
     if not ports['ports']:
         return None, None
     return ports['ports'][0]['fixed_ips'][0]['ip_address'], ports['ports'][0]['id']
-        
+
 def _get_floating_ip(module, neutron, fixed_ip_address):
     kwargs = {
             'fixed_ip_address': fixed_ip_address
@@ -192,6 +197,8 @@ def _create_floating_ip(neutron, module, port_id, net_id):
             'port_id': port_id,
             'floating_network_id': net_id
     }
+    if 'fixed_ip' in module.params:
+        kwargs['fixed_ip_address'] = module.params['fixed_ip']
     try:
         result = neutron.create_floatingip({'floatingip': kwargs})
     except Exception as e:
@@ -222,7 +229,7 @@ def _update_floating_ip(neutron, module, port_id, floating_ip_id):
 
 
 def main():
-    
+
     module = AnsibleModule(
         argument_spec = dict(
             login_username = dict(default='admin'),
@@ -233,17 +240,18 @@ def main():
             network_name = dict(required=True),
             instance_name = dict(required=True),
             port_network_name = dict(default=None),
+            fixed_ip = dict(default=None),
             state = dict(default='present', choices=['absent', 'present'])
         ),
     )
-        
+
     try:
         nova = nova_client.Client(module.params['login_username'], module.params['login_password'],
             module.params['login_tenant_name'], module.params['auth_url'], service_type='compute')
         neutron = _get_neutron_client(module, module.params)
     except Exception as e:
         module.fail_json(msg="Error in authenticating to nova: %s" % e.message)
-        
+
     server_info, server_obj = _get_server_state(module, nova)
     if not server_info:
         module.fail_json(msg="The instance name provided cannot be found")

--- a/library/neutron_subnet
+++ b/library/neutron_subnet
@@ -85,6 +85,11 @@ options:
         - Whether DHCP should be enabled for this subnet.
      required: false
      default: true
+   no_gateway:
+     description:
+        - If "true", no gateway will be created for this subnet
+     required: false
+     default: false
    gateway_ip:
      description:
         - The ip that would be assigned to the gateway for this subnet
@@ -105,6 +110,16 @@ options:
         - From the subnet pool the last IP that should be assigned to the virtual machines
      required: false
      default: None
+   ipv6-ra-mode:
+     description:
+        - IPv6 router advertisement mode: dhcpv6-stateful,dhcpv6-stateless,slaac
+     required: false
+     default: none
+   ipv6-address-mode:
+     description:
+        - IPv6 address mode: dhcpv6-stateful,dhcpv6-stateless,slaac
+     required: false
+     default: none
    host_routes:
      description:
         - Host routes for this subnet, list of dictionaries, e.g. [{destination: 0.0.0.0/0, nexthop: 123.456.78.9}, {destination: 192.168.0.0/24, nexthop: 192.168.0.1}]
@@ -126,16 +141,18 @@ _os_network_id = None
 
 def _get_ksclient(module, kwargs):
     try:
-        kclient = ksclient.Client(username=kwargs.get('login_username'),
-                                 password=kwargs.get('login_password'),
-                                 tenant_name=kwargs.get('login_tenant_name'),
-                                 auth_url=kwargs.get('auth_url'))
+        kclient = ksclient.Client(
+            username=module.params.get('login_username'),
+            password=module.params.get('login_password'),
+            tenant_name=module.params.get('login_tenant_name'),
+            auth_url=module.params.get('auth_url'),
+            region_name=module.params.get('region_name'))
     except Exception as e:
         module.fail_json(msg = "Error authenticating to the keystone: %s" %e.message)
     global _os_keystone
     _os_keystone = kclient
     return kclient
- 
+
 
 def _get_endpoint(module, ksclient):
     try:
@@ -160,17 +177,20 @@ def _get_neutron_client(module, kwargs):
 
 def _set_tenant_id(module):
     global _os_tenant_id
-    if not module.params['tenant_name']:
-        tenant_name = module.params['login_tenant_name']
-    else:
+    if module.params['tenant_name']:
+        # We need admin power in order retrieve the tenant_id of a given
+        # tenant name and to create/delete networks for a tenant that is not
+        # the one used to authenticate the user.
         tenant_name = module.params['tenant_name']
+        for tenant in _os_keystone.tenants.list():
+            if tenant.name == tenant_name:
+                _os_tenant_id = tenant.id
+                break
+    else:
+        _os_tenant_id = _os_keystone.tenant_id
 
-    for tenant in _os_keystone.tenants.list():
-        if tenant.name == tenant_name:
-            _os_tenant_id = tenant.id
-            break
     if not _os_tenant_id:
-            module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
+        module.fail_json(msg = "The tenant id cannot be found, please check the paramters")
 
 def _get_net_id(neutron, module):
     kwargs = {
@@ -180,7 +200,7 @@ def _get_net_id(neutron, module):
     try:
         networks = neutron.list_networks(**kwargs)
     except Exception as e:
-        module.fail_json("Error in listing Neutron networks: %s" % e.message)
+        module.fail_json(msg = "Error in listing Neutron networks: %s" % e.message)
     if not networks['networks']:
             return None
     return networks['networks'][0]['id']
@@ -226,31 +246,40 @@ def _create_subnet(module, neutron):
             }
         ]
         subnet.update({'allocation_pools': allocation_pools})
-    if not module.params['gateway_ip']:
-        subnet.pop('gateway_ip')
+    # "subnet['gateway_ip'] = None" means: "no gateway"
+    # no gateway_ip in body means: "automatic gateway"
+    if module.params['no_gateway']:
+        subnet['gateway_ip'] = None
+    elif module.params['gateway_ip'] is not None:
+        subnet['gateway_ip'] = module.params['gateway_ip']
     if module.params['dns_nameservers']:
         subnet['dns_nameservers'] = module.params['dns_nameservers'].split(',')
     else:
         subnet.pop('dns_nameservers')
     if not module.params['host_routes']:
         subnet.pop('host_routes')
+    if module.params['ipv6_ra_mode'] and int(module.params['ip_version']) == 6:
+        subnet.update({'ipv6_ra_mode': module.params['ipv6_ra_mode']})
+    if module.params['ipv6_address_mode'] and int(module.params['ip_version']) == 6:
+        subnet.update({'ipv6_address_mode': module.params['ipv6_address_mode']})
     try:
         new_subnet = neutron.create_subnet(dict(subnet=subnet))
     except Exception, e:
         module.fail_json(msg = "Failure in creating subnet: %s" % e.message)
     return new_subnet['subnet']['id']
-        
-                
+
+
 def _delete_subnet(module, neutron, subnet_id):
     try:
         neutron.delete_subnet(subnet_id)
     except Exception as e:
         module.fail_json( msg = "Error in deleting subnet: %s" % e.message)
     return True
-        
-                
+
+
 def main():
-    
+
+    ipv6_mode_choices = ['dhcpv6-stateful', 'dhcpv6-stateless', 'slaac']
     module = AnsibleModule(
         argument_spec = dict(
             login_username = dict(default='admin'),
@@ -264,11 +293,14 @@ def main():
             tenant_name = dict(default=None),
             state = dict(default='present', choices=['absent', 'present']),
             ip_version = dict(default='4', choices=['4', '6']),
-            enable_dhcp = dict(default='true', choices=BOOLEANS),
+            enable_dhcp = dict(default=True, type='bool'),
+            no_gateway = dict(default=False, type='bool'),
             gateway_ip = dict(default=None),
             dns_nameservers = dict(default=None),
             allocation_pool_start = dict(default=None),
             allocation_pool_end = dict(default=None),
+            ipv6_ra_mode = dict(default=None, choices=ipv6_mode_choices),
+            ipv6_address_mode = dict(default=None, choices=ipv6_mode_choices),
             host_routes = dict(default=None),
         ),
     )
@@ -288,7 +320,7 @@ def main():
         else:
             _delete_subnet(module, neutron, subnet_id)
             module.exit_json(changed = True, result = "deleted")
-                
+
 # this is magic, see lib/ansible/module.params['common.py
 from ansible.module_utils.basic import *
 main()

--- a/library/nova_compute
+++ b/library/nova_compute
@@ -194,7 +194,7 @@ def _create_server(module, nova):
             if server.status == 'ACTIVE':
                 private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'fixed']
                 public  = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'floating']
-                module.exit_json(changed = True, id = server.id, private_ip=''.join(private), public_ip=''.join(public), status = server.status, info = server._info)
+                module.exit_json(changed = True, id = server.id, private_ip=''.join(private), private_ips=private, public_ip=''.join(public), public_ips=public, status = server.status, info = server._info)
             if server.status == 'ERROR':
                 module.fail_json(msg = "Error in creating the server, please check logs")
             time.sleep(2)

--- a/playbooks/tests/tasks/integration.yml
+++ b/playbooks/tests/tasks/integration.yml
@@ -48,6 +48,7 @@
                          login_password={{ secrets.provider_admin_password }}
                          network_name=external
                          instance_name=turtle-stack
+                         fixed_ip={{ turtle_stack.private_ips|ipv4|first }}
     register: floating_ip
 
   - name: nova can create a volume via cinder

--- a/playbooks/tests/tasks/network.yml
+++ b/playbooks/tests/tasks/network.yml
@@ -24,27 +24,27 @@
     shell: . /root/stackrc; neutron net-show internal | grep
            router:external | grep False
 
-  - name: neutron has a network with internal_subnet
-    shell: . /root/stackrc; neutron net-list | grep internal | grep
-           172.16.255.0/24
-
   - name: neutron has the internal subnet
-    shell: . /root/stackrc; neutron subnet-list | grep internal
+    shell: . /root/stackrc; neutron subnet-list | grep internal_v4
 
   - name: neutron has the internal subnet with cidr
-    shell: . /root/stackrc; neutron subnet-show internal | grep cidr | grep
+    shell: . /root/stackrc; neutron subnet-show internal_v4 | grep cidr | grep
            172.16.255.0/24
 
+  - name: neutron has the internal subnet with cidr
+    shell: . /root/stackrc; neutron subnet-show internal_v6 | grep cidr | grep
+           2db8:1::/64
+
   - name: neutron has the internal_subnet with cidr start/end addresses
-    shell: . /root/stackrc; neutron subnet-show internal | grep
+    shell: . /root/stackrc; neutron subnet-show internal_v4 | grep
            allocation_pools | egrep '172.16.255.2.*172.16.255.254'
 
   - name: neutron has the internal_subnet with enable_dhcp True
-    shell: . /root/stackrc; neutron subnet-show internal | grep
+    shell: . /root/stackrc; neutron subnet-show internal_v4 | grep
            enable_dhcp | grep True
 
   - name: neutron has the internal_subnet with gateway_ip
-    shell: . /root/stackrc; neutron subnet-show internal | grep
+    shell: . /root/stackrc; neutron subnet-show internal_v4 | grep
            gateway | grep gateway_ip
 
   - name: neutron has the default router

--- a/roles/openstack-setup/tasks/networks.yml
+++ b/roles/openstack-setup/tasks/networks.yml
@@ -14,6 +14,8 @@
   with_items: neutron.networks
   run_once: true
 
+# FIXME with Ansible 1.9 we can use |default(omit) instead of duplicate tasks with
+# when guards
 - name: neutron subnets
   neutron_subnet: name={{ item.name }}
                   network_name={{ item.network_name }}
@@ -21,13 +23,33 @@
                   enable_dhcp={{ item.enable_dhcp }}
                   gateway_ip={{ item.gateway_ip }}
                   ip_version={{ item.ip_version }}
-                  dns_nameservers={{ neutron.tenant_nameservers|join(',') }}
+                  dns_nameservers={{ item.dns_nameservers }}
                   state=present
                   auth_url={{ endpoints.auth_uri }}
                   login_tenant_name=admin
                   login_username=provider_admin
                   login_password={{ secrets.provider_admin_password }}
   with_items: neutron.subnets
+  when: "'ipv6_address_mode' not in item and 'ipv6_ra_mode' not in item"
+  run_once: true
+
+- name: neutron subnets
+  neutron_subnet: name={{ item.name }}
+                  network_name={{ item.network_name }}
+                  cidr={{ item.cidr }}
+                  enable_dhcp={{ item.enable_dhcp }}
+                  gateway_ip={{ item.gateway_ip }}
+                  ip_version={{ item.ip_version }}
+                  dns_nameservers={{ item.dns_nameservers }}
+                  ipv6_address_mode={{ item.ipv6_address_mode }}
+                  ipv6_ra_mode={{ item.ipv6_ra_mode }}
+                  state=present
+                  auth_url={{ endpoints.auth_uri }}
+                  login_tenant_name=admin
+                  login_username=provider_admin
+                  login_password={{ secrets.provider_admin_password }}
+  with_items: neutron.subnets
+  when: "'ipv6_address_mode' in item and 'ipv6_ra_mode' in item"
   run_once: true
 
 - name: neutron routers


### PR DESCRIPTION
Configure a dual stack tenant network in testenv. Update neutron_subnet
module to support IPv6 addressing options (changes accepted upstream).