### PR TITLE
Cinder volume needs qemu-img

### DIFF
--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -7,6 +7,7 @@
     - tgt
     - nbd-client
     - open-iscsi
+    - qemu-utils
 
 - name: iscsi target framework conf dir
   file: dest=/etc/tgt/conf.d state=directory


### PR DESCRIPTION
qemu-img, in the qemu-utils package, is used to convert qcow(2) images
to a cinder volume. Used when say making volumes from glance images.
With cinder-volume now potentially stand alone this package needs to be
explicitly added.