### PR TITLE
Hard set hypervisor ssh access IP

### DIFF
--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -82,6 +82,10 @@ firewall_driver=nova.virt.firewall.NoopFirewallDriver
 dhcpbridge_flagfile = /etc/nova/nova.conf
 dhcpbridge=/usr/local/bin/nova-dhcpbridge
 
+# Set my_ip so that we explicitly define the IP we can be reached
+# at by other hypervisors
+my_ip = {{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}
+
 # Workers #
 osapi_compute_workers={{ nova.api_workers }}
 metadata_workers={{ nova.metadata_api_workers }}


### PR DESCRIPTION
We want to set this so that resize/migration activities know which IP
address to use to connect to a given hypervisor. Without this set some
socket work is done which many actually pick the external floating IP
address by mistake, which will break migrations.