### PR TITLE
fixed installers

### DIFF
--- a/bin/install-osx
+++ b/bin/install-osx
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -ex 
+
+BINDIR=$(dirname $0)
+
 install_pip() {
   which brew >/dev/null || \
     die "This installation script requires a homebrew installation to proceed. Please see: http://mxcl.github.io/homebrew/"
@@ -20,6 +24,6 @@ uname | grep Darwin || die "This is not an OS X system... Aborting."
 
 which pip >/dev/null || install_pip
 
-pip install -r -U $BINDIR/../requirements.txt
+pip install -U -r $BINDIR/../requirements.txt
 
 echo -e "\nInstallation complete!\n"

--- a/bin/install-ubuntu
+++ b/bin/install-ubuntu
@@ -13,6 +13,6 @@ apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install --yes python-pip python-dev libxml2-dev libxslt-dev libffi-dev
 apt-get remove --yes ansible || echo "ok"
 
-pip install -r -U $BINDIR/../requirements.txt
+pip install -U -r $BINDIR/../requirements.txt
 
 echo -e "\nInstallation complete!\n"


### PR DESCRIPTION
The osx installer was missing a $BINDIR definition, and both had "pip -r -U <file>" instead of "pip -U -r <file>".  Verified osx installer works now, didn't test ubuntu but it should work fine.