### PR TITLE
Backport 1.2.x: Provide path data to rootwrap

### DIFF
--- a/roles/cinder-common/templates/etc/cinder/rootwrap.conf
+++ b/roles/cinder-common/templates/etc/cinder/rootwrap.conf
@@ -10,7 +10,11 @@ filters_path=/etc/cinder/rootwrap.d,/usr/share/cinder/rootwrap
 # explicitely specify a full path (separated by ',')
 # If not specified, defaults to system PATH environment variable.
 # These directories MUST all be only writeable by root !
+{% if openstack_install_method == "package" -%}
+exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin,{{ 'cinder'|ursula_package_path(openstack_package_version) }}/bin
+{% else -%}
 exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin
+{% endif -%}
 
 # Enable logging to syslog
 # Default value is False

--- a/roles/ironic-common/templates/etc/ironic/rootwrap.conf
+++ b/roles/ironic-common/templates/etc/ironic/rootwrap.conf
@@ -10,7 +10,11 @@ filters_path=/etc/ironic/rootwrap.d,/usr/share/ironic/rootwrap
 # explicitely specify a full path (separated by ',')
 # If not specified, defaults to system PATH environment variable.
 # These directories MUST all be only writeable by root !
+{% if openstack_install_method == "package" -%}
+exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin,{{ 'ironic'|ursula_package_path(openstack_package_version) }}/bin
+{% else -%}
 exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin
+{% endif -%}
 
 # Enable logging to syslog
 # Default value is False

--- a/roles/neutron-common/templates/etc/neutron/rootwrap.conf
+++ b/roles/neutron-common/templates/etc/neutron/rootwrap.conf
@@ -1,4 +1,39 @@
 [DEFAULT]
+# Configuration for neutron-rootwrap
+# This file should be owned by (and only-writeable by) the root user
+
+[DEFAULT]
 # List of directories to load filter definitions from (separated by ',').
 # These directories MUST all be only writeable by root !
 filters_path=/etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap
+
+# List of directories to search executables in, in case filters do not
+# explicitely specify a full path (separated by ',')
+# If not specified, defaults to system PATH environment variable.
+# These directories MUST all be only writeable by root !
+{% if openstack_install_method == "package" -%}
+exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin,{{ 'neutron'|ursula_package_path(openstack_package_version) }}/bin
+{% else -%}
+exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin
+{% endif -%}
+
+# Enable logging to syslog
+# Default value is False
+use_syslog=False
+
+# Which syslog facility to use.
+# Valid values include auth, authpriv, syslog, local0, local1...
+# Default value is 'syslog'
+syslog_log_facility=syslog
+
+# Which messages to log.
+# INFO means log all usage
+# ERROR means only log unsuccessful attempts
+syslog_log_level=ERROR
+
+[xenapi]
+# XenAPI configuration is only required by the L2 agent if it is to
+# target a XenServer/XCP compute host's dom0.
+xenapi_connection_url=<None>
+xenapi_connection_username=root
+xenapi_connection_password=<None>

--- a/roles/nova-common/templates/etc/nova/rootwrap.conf
+++ b/roles/nova-common/templates/etc/nova/rootwrap.conf
@@ -10,7 +10,11 @@ filters_path=/etc/nova/rootwrap.d,/usr/share/nova/rootwrap
 # explicitely specify a full path (separated by ',')
 # If not specified, defaults to system PATH environment variable.
 # These directories MUST all be only writeable by root !
+{% if openstack_install_method == "package" -%}
+exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin,{{ 'nova'|ursula_package_path(openstack_package_version) }}/bin
+{% else -%}
 exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin
+{% endif -%}
 
 # Enable logging to syslog
 # Default value is False


### PR DESCRIPTION
Since our paths can be from virtualenvs we need to provide this path to
rootwrap config.

Also update neutron's rootwrap.conf from upstream.

(cherry picked from commit cf1f37718f6aee68d613a2357034317593f4b0c8)