### PR TITLE
Add a 2 second timeout to the other rabbit check

### DIFF
--- a/roles/rabbitmq/tasks/monitoring.yml
+++ b/roles/rabbitmq/tasks/monitoring.yml
@@ -11,6 +11,7 @@
 
 - name: rabbit queues check
   sensu_check: name=rabbitmq-queues plugin=check-rabbitmq-queues.rb
+               args="--timeout 2"
                use_sudo=true
   notify: restart sensu-client
 


### PR DESCRIPTION
We added a 2 second timeout for checking number of queues, but didn't
add one for the general queue check. This adds it to keep things
consistent and to keep sensu/pager duty quiet.