### PR TITLE
Use ansible modules for integration test

### DIFF
--- a/playbooks/tests/tasks/integration.yml
+++ b/playbooks/tests/tasks/integration.yml
@@ -4,26 +4,51 @@
   tasks:
   - name: generate ssh key for root
     user: name=root generate_ssh_key=yes
+    register: rootuser
 
   - name: generate nova key-pair
-    shell: . /root/stackrc; nova keypair-add turtle-key --pub-key
-           /root/.ssh/id_rsa.pub
+    nova_keypair: name=turtle-key
+                  auth_url={{ endpoints.auth_uri }}
+                  login_tenant_name=admin
+                  login_username=provider_admin
+                  login_password={{ secrets.provider_admin_password }}
+                  public_key="{{ rootuser.ssh_public_key }}"
 
   - name: generate test security group
-    shell: . /root/stackrc; neutron security-group-create turtle-sec && 
+    shell: . /root/stackrc; neutron security-group-create turtle-sec &&
            neutron security-group-rule-create turtle-sec --remote-ip-prefix
            0.0.0.0/0
 
+  - name: determine Neutron internal interface ID
+    neutron_network: name=internal
+                     auth_url={{ endpoints.auth_uri }}
+                     login_tenant_name=admin
+                     login_username=provider_admin
+                     login_password={{ secrets.provider_admin_password }}
+    register: internal_net
+
   - name: nova can boot an instance
-    shell: . /root/stackrc; INTERNAL_NET=$( nova net-list | awk
-           '/ internal / {print $2}' ); nova boot --flavor m1.tiny --image
-           cirros --nic net-id=${INTERNAL_NET} --key-name
-           turtle-key --security-groups turtle-sec --poll turtle-stack
+    nova_compute:
+        name: turtle-stack
+        auth_url: "{{ endpoints.auth_uri }}"
+        login_tenant_name: admin
+        login_username: provider_admin
+        login_password: "{{ secrets.provider_admin_password }}"
+        image_name: cirros
+        security_groups: turtle-sec
+        key_name: turtle-key
+        nics:
+        - net-id: "{{ internal_net.id }}"
+    register: turtle_stack
 
   - name: nova can associate floating IP with test instance
-    shell: . /root/stackrc; FLOATING_IP=$( nova floating-ip-create
-           external | awk '/ external / {print $4}' ); nova add-floating-ip
-           turtle-stack ${FLOATING_IP}; sleep 60
+    neutron_floating_ip: auth_url={{ endpoints.auth_uri }}
+                         login_tenant_name=admin
+                         login_username=provider_admin
+                         login_password={{ secrets.provider_admin_password }}
+                         network_name=external
+                         instance_name=turtle-stack
+    register: floating_ip
 
   - name: nova can create a volume via cinder
     shell: . /root/stackrc; nova volume-create --display-name=turtle-vol 2
@@ -36,14 +61,14 @@
     shell: . /root/stackrc; nova volume-attach
            turtle-stack {{ turtle_vol.stdout }} auto
 
-  - name: can ping instance
-    shell: . /root/stackrc; TURTLE_IP=$( nova list | awk
-           '/turtle-stack/ {print $13}' ); ping -c 5 ${TURTLE_IP}
+  - name: wait for instance to boot
+    wait_for: host={{ floating_ip.public_ip }}
+              port=22
+              timeout=180
 
 # (due to 1450 MTU on VXLAN this doesn't work with recent version of SSH)
   - name: test instance can ping Google
-    shell: . /root/stackrc; TURTLE_IP=$( nova list | awk
-           '/turtle-stack/ {print $13}' ); ssh -o
-           UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
-           cirros@${TURTLE_IP} ping -c 5 www.google.com
+    command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+             -i /root/.ssh/id_rsa cirros@{{ floating_ip.public_ip }}
+             ping -c 5 www.google.com
     when: ansible_distribution_version == "12.04"


### PR DESCRIPTION
Ansible modules allow more robust extraction of instance floating IP and
network ID.