### PR TITLE
Add cpu pinning for AMD nodes

### DIFF
--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -30,7 +30,7 @@ cpu_allocation_ratio={{ nova.cpu_allocation_ratio }}
 ram_allocation_ratio={{ nova.ram_allocation_ratio }}
 {% endif -%}
 
-{% if ansible_processor|search('AMD') & inventory_hostname in groups['controller'] -%}
+{% if ansible_processor|search('AMD') and inventory_hostname in groups['controller'] -%}
 vcpu_pin_set = "2-15,18-31"
 {% elif ansible_processor|search('AMD') -%}
 vcpu_pin_set = "1-31"

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -30,9 +30,9 @@ cpu_allocation_ratio={{ nova.cpu_allocation_ratio }}
 ram_allocation_ratio={{ nova.ram_allocation_ratio }}
 {% endif -%}
 
-{% if ansible_processor[0]|search('AMD') and inventory_hostname in groups['controller'] -%}
+{% if ansible_product_name == 'H8DGU' and ansible_processor_vcpus == 32 and inventory_hostname in groups['controller'] -%}
 vcpu_pin_set = "2-15,18-31"
-{% elif ansible_processor[0]|search('AMD') -%}
+{% elif ansible_product_name == 'H8DGU' and ansible_processor_vcpus == 32 -%}
 vcpu_pin_set = "1-31"
 {% endif -%}
 

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -30,6 +30,12 @@ cpu_allocation_ratio={{ nova.cpu_allocation_ratio }}
 ram_allocation_ratio={{ nova.ram_allocation_ratio }}
 {% endif -%}
 
+{% if ansible_processor|search('AMD') & inventory_hostname in groups['controller'] -%}
+vcpu_pin_set = "2-15,18-31"
+{% elif ansible_processor|search('AMD') -%}
+vcpu_pin_set = "1-31"
+{% endif -%}
+
 # Services offered #
 s3_host={{ endpoints.keystone }}
 ec2_host={{ endpoints.keystone }}

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -30,9 +30,9 @@ cpu_allocation_ratio={{ nova.cpu_allocation_ratio }}
 ram_allocation_ratio={{ nova.ram_allocation_ratio }}
 {% endif -%}
 
-{% if ansible_processor|search('AMD') and inventory_hostname in groups['controller'] -%}
+{% if ansible_processor[0]|search('AMD') and inventory_hostname in groups['controller'] -%}
 vcpu_pin_set = "2-15,18-31"
-{% elif ansible_processor|search('AMD') -%}
+{% elif ansible_processor[0]|search('AMD') -%}
 vcpu_pin_set = "1-31"
 {% endif -%}
 


### PR DESCRIPTION
Add pinning of CPU for nodes with AMD processors.  4 CPUS will be reserved on compute/controller nodes, and 1 will be reserved on compute-only nodes.