### PR TITLE
Turn on keystone token checking

### DIFF
--- a/roles/keystone/tasks/monitoring.yml
+++ b/roles/keystone/tasks/monitoring.yml
@@ -8,6 +8,14 @@
                args="--service keystone"
   notify: restart sensu-client
 
+- name: keystone token buildup check
+  sensu_check:
+    name: check-keystone-expired-tokens
+    plugin: check-keystone-expired-tokens.py
+    interval: 10
+    use_sudo: true
+  notify: restart sensu-client
+
 - name: keystone metrics
   template: src=etc/collectd/plugins/keystone.conf dest=/etc/collectd/plugins/keystone.conf
   notify: restart collectd


### PR DESCRIPTION
This check comes from ursula-monitoring and will exit non-zero if the
expired token count goes above the high watermark (1K).

Sudo is required to run it so that logging can be written out should
something go wrong with the script.

Requires https://github.com/blueboxgroup/ursula-monitoring/pull/21