### PR TITLE
Flush keystone tokens every 5 minutes

### DIFF
--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -55,15 +55,18 @@
     - 35358
 
 - name: add cron job to clean up expired tokens
-  template: src=etc/cron.hourly/drop-expired-keystone-tokens
-            dest=/etc/cron.hourly/drop-expired-keystone-tokens
-            owner=root group=root mode=0755
+  template:
+    src: etc/cron.d/drop-expired-keystone-tokens
+    dest: /etc/cron.d/drop-expired-keystone-tokens
+    owner: root
+    group: root
+    mode: 0640
   run_once: true
 
-- name: ensure only one token flush cron job
-  file: path=/etc/cron.hourly/drop-expired-keystone-tokens
-        state=absent
-  when: inventory_hostname != play_hosts[0]
+- name: delete old token flush job
+  file:
+    path: /etc/cron.hourly/drop-expired-keystone-tokens
+    state: absent
 
 - include: monitoring.yml tags=monitoring,common
 

--- a/roles/keystone/templates/etc/cron.d/drop-expired-keystone-tokens
+++ b/roles/keystone/templates/etc/cron.d/drop-expired-keystone-tokens
@@ -1,0 +1,4 @@
+PATH=/usr/local/bin/
+
+# Drop the tokens every 5 minutes
+*/5 * * * * root keystone-manage token_flush

--- a/roles/keystone/templates/etc/cron.hourly/drop-expired-keystone-tokens
+++ b/roles/keystone/templates/etc/cron.hourly/drop-expired-keystone-tokens
@@ -1,6 +1,0 @@
-#!/bin/bash
-# This script drops all expired entries from the keystone.token table.
-# This is necessary, because otherwise the number of tokens would grow without bound.
-# Intended to be run periodically by cron.
-
-keystone-manage token_flush


### PR DESCRIPTION
Once an hour isn't enough, too big of a batch. Every 5 minutes will lead
to smaller batches and a more flushed system. A happy system is a
flushed system.