### PR TITLE
Revert "initial support for storcli"

### DIFF
--- a/roles/apt-repos/defaults/main.yml
+++ b/roles/apt-repos/defaults/main.yml
@@ -12,9 +12,6 @@ apt_repos:
   hwraid:
     repo: 'http://hwraid.le-vert.net/ubuntu'
     key_url: 'http://hwraid.le-vert.net/debian/hwraid.le-vert.net.gpg.key'
-  tkraid:
-    repo: 'http://archive.thomas-krenn.com/packages'
-    key_url: 'http://archive.thomas-krenn.com/tk-archive.gpg.pub'
   sensu:
     repo: 'http://repos.sensuapp.org/apt'
     key_url: 'http://repos.sensuapp.org/apt/pubkey.gpg'

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -3,10 +3,8 @@ common:
   bbg_openstack_repo: 'deb http://apt.openstack.blueboxgrid.com/ubuntu/ precise main'
   hwraid:
     enabled: True
-    add_clients:
+    clients:
       - tw-cli
-      - storcli
-    remove_clients:
       - megacli
   ipmi:
     enabled: True

--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -6,8 +6,6 @@ dependencies:
         key_url: '{{ apt_repos.bbg_ubuntu.key_url }}'
       - repo: 'deb {{ apt_repos.hwraid.repo }} precise main'
         key_url: '{{ apt_repos.hwraid.key_url }}'
-      - repo: 'deb {{ apt_repos.tkraid.repo }} precise optional'
-        key_url: '{{ apt_repos.tkraid.key_url }}'
       - repo: 'deb {{ apt_repos.sensu.repo }} sensu main'
         key_url: '{{ apt_repos.sensu.key_url }}'
   - role: docker

--- a/roles/common/tasks/hwraid.yml
+++ b/roles/common/tasks/hwraid.yml
@@ -1,8 +1,4 @@
 ---
 - name: install raid utilities
   apt: pkg={{ item }}
-  with_items: common.hwraid.add_clients
-
-- name: install raid utilities
-  apt: pkg={{ item }} state=absent
-  with_items: common.hwraid.remove_clients
+  with_items: common.hwraid.clients


### PR DESCRIPTION
This reverts commit 44d9e2bd3fa7490ad4aa585abfc2dd1ffe37adb5.

We're running into problems with conflicting storcli packages that need
to be worked out before making this change. Reverting to a previous
working configuration.

(cherry picked from commit 57e3f5da9af4283b4f7013b6b71fd41e269fb3e4)