### PR TITLE
Bump package for python-swiftclient in swift venv

### DIFF
--- a/roles/openstack-package/defaults/main.yml
+++ b/roles/openstack-package/defaults/main.yml
@@ -1,4 +1,4 @@
-openstack_package_version: 10.0-bbc66
+openstack_package_version: 10.0-bbc68
 openstack_package:
   package_name: 'openstack-{{ project_name }}-{{ openstack_package_version }}'
   repo: 'deb http://repo.openstack.blueboxgrid.com/bbc precise main'


### PR DESCRIPTION
This build of the package just gets python-swiftclient into swift's venv
so that dispersion works once more.