### PR TITLE
Add missing sysfsutils package to data nodes

### DIFF
--- a/roles/nova-data/tasks/main.yml
+++ b/roles/nova-data/tasks/main.yml
@@ -8,6 +8,9 @@
 - include: docker.yml
   when: nova.compute_driver == "novadocker.virt.docker.DockerDriver"
 
+- name: install nova data plan requirements
+  apt: pkg=sysfsutils
+
 - name: nova instances directory
   file: dest=/var/lib/nova/instances state=directory owner=nova
 


### PR DESCRIPTION
Ref: http://docs.openstack.org/admin-guide-cloud/content/section_ts_failed_attach_vol_no_sysfsutils.html and ticket C013EA - if this package is not installed, customers will get the error "systool is not installed" in their nova-compute.logs when trying to attach volumes to running instances.