### PR TITLE
only do external network tasks when > 1 network

### DIFF
--- a/roles/openstack-network/tasks/main.yml
+++ b/roles/openstack-network/tasks/main.yml
@@ -7,17 +7,20 @@
                    login_password={{ secrets.provider_admin_password }}
   register: result
   run_once: true
+  failed_when: False
 
 - name: set neutron interface fact
   set_fact: neutron_external_interface=brq{{ result.id|truncate(length=11,killwords=true,end='') }}
+  when: result.id is defined
 
 - name: check for existing external interface config (which may contain additional routes)
   stat: path=/etc/network/interfaces.d/{{ neutron_external_interface }}.cfg
   register: neutron_external_ifcfg
+  when: result.id is defined
 
 - name: neutron external interface config
   template: src=neutron_external_interface.cfg
             dest=/etc/network/interfaces.d/{{ neutron_external_interface }}.cfg
             owner=root group=root mode=0644
-  when: not neutron_external_ifcfg.stat.exists
+  when: not neutron_external_ifcfg.stat.exists and result.id is defined
   notify: ifup neutron external interface


### PR DESCRIPTION
simple installs like allinone only has a single network
and therefore does not have an external network and thus
fails the tasks that try to set up the external network.