### PR TITLE
Setting preallocate_images in nova for vagrant

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -101,6 +101,7 @@ nova:
   metadata_api_workers: 1
   reserved_host_disk_mb: 50
   enable_ssh: true
+  preallocate_images: false
   logging:
     debug: True
     verbose: True


### PR DESCRIPTION
Preallocating images does not work for vagrant setup because of limited disk space. Need to set preallocate_images to false in order to boot instances