### PR TITLE
Setting dns_nameservers in the subnet block since the attribute set i…

### DIFF
--- a/envs/example/vagrant.yml
+++ b/envs/example/vagrant.yml
@@ -34,6 +34,7 @@ neutron:
       enable_dhcp: "true"
       gateway_ip: 172.16.255.100
       ip_version: 4
+      dns_nameservers: '8.8.8.8,8.8.4.4'
   routers: []
   router_interfaces: []
   logging:


### PR DESCRIPTION
Setting dns_nameservers in the subnet block in vagrant.yml since its value in default.yml gets overwritten.