### PR TITLE
Update the requirement on ursula-cli

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ tox
 pep8
 -e git://github.com/willthames/ansible-lint.git@9777f20aafd4be8706c9ce17005c981cb19a6a25#egg=ansible-lint
 https://github.com/blueboxgroup/ansible/archive/release1.7.2-bbg.tar.gz
--e git://github.com/blueboxgroup/ursula-cli.git@master#egg=ursula-cli
+-e git://github.com/blueboxgroup/ursula-cli.git@ursula-1.2.x#egg=ursula-cli


### PR DESCRIPTION
Point to a 1.2.x branch of ursula-cli so that master of ursula-cli can
move forward to working with Ansible 1.9.x