### PR TITLE
Switching false to none for preallocate_images

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -101,7 +101,7 @@ nova:
   metadata_api_workers: 1
   reserved_host_disk_mb: 50
   enable_ssh: true
-  preallocate_images: false
+  preallocate_images: none
   logging:
     debug: True
     verbose: True


### PR DESCRIPTION
The correct value as documented by Openstack is none