### PR TITLE
Backport 1.2: Neutron L2 population for VXLAN over unicast

### DIFF
--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 neutron:
+  l2_population: False
   api_workers: 3
   metadata_workers: 3
   agent_down_time: 20

--- a/roles/neutron-common/templates/etc/neutron/plugins/ml2/ml2_plugin.ini
+++ b/roles/neutron-common/templates/etc/neutron/plugins/ml2/ml2_plugin.ini
@@ -26,7 +26,11 @@ tenant_network_types = {{ neutron.tenant_network_type }}
 # to be loaded from the neutron.ml2.mechanism_drivers namespace.
 # Example: mechanism_drivers = arista
 # Example: mechanism_drivers = cisco,logger
-mechanism_drivers = linuxbridge
+{% set mechanism_drivers = ['linuxbridge'] %}
+{% if neutron.l2_population %}
+{% set _ = mechanism_drivers.append('l2population') %}
+{% endif %}
+mechanism_drivers = {{ mechanism_drivers|join(',') }}
 
 [ml2_type_vlan]
 # (ListOpt) List of <physical_network>[:<vlan_min>:<vlan_max>] tuples
@@ -65,7 +69,7 @@ vxlan_group = 239.1.1.1
 [vxlan]
 # LinuxBridge agent VXLAN config: should match ML2 config
 enable_vxlan = {{ neutron.enable_tunneling and "vxlan" in neutron.tunnel_types }}
-l2_population = False
+l2_population = {{ neutron.l2_population }}
 
 [database]
 sql_connection = mysql://neutron:{{ secrets.db_password }}@{{ endpoints.db }}/neutron?charset=utf8

--- a/roles/neutron-data/defaults/main.yml
+++ b/roles/neutron-data/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+neutron:
+  l2_population: False

--- a/roles/neutron-data/templates/etc/neutron/plugins/ml2/ml2_plugin_dataplane.ini
+++ b/roles/neutron-data/templates/etc/neutron/plugins/ml2/ml2_plugin_dataplane.ini
@@ -1,8 +1,10 @@
 [vxlan]
 local_ip = {{ hostvars[inventory_hostname][neutron.vxlan_interface|default(primary_interface)]['ipv4']['address'] }}
+{% if not neutron.l2_population %}
 # Set TTL on VXLAN datagrams to 1 to confine to local broadcast domain
 ttl = 1
 vxlan_group = 239.1.1.1
+{% endif %}
 
 [linux_bridge]
 physical_interface_mappings = {{ neutron.bridge_mappings }}

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -22,7 +22,7 @@ nova:
   libvirt_bin_version: 1.2.2-0ubuntu13.1.9~cloud0
   python_libvirt_version: 1.2.2-0ubuntu2~cloud0
   qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.11~cloud0
-  librdb1_version: 0.80.9-0ubuntu0.14.04.1~cloud0
+  librdb1_version: 0.80.9-0ubuntu0.14.04.2~cloud0
   glance_endpoint: http://{{ endpoints.glance }}:9292
   reserved_host_disk_mb: 51200
   trusty:


### PR DESCRIPTION
To support non-multicast environment enabled L2 population and VXLAN
over unicast. Note that this significantly reduces interoperability
with other VXLAN enabled devices, since Neutron itself provides the L2
learning mechanism rather than traditional flooding of unknown unicast
frames. Any additional devices participating the VXLAN virtual network
must coordinate with Neutron to populate their L2 addresses and VTEPs.

Additionally HA configurations utilizing a shared/floating MAC address
may not work, unless they also coordinate with Neutron when the MAC
address moves between active interfaces.

Linux 3.11 is recommended for proper replication of broadcast and
multicast frames egressing VXLAN interface.