### PR TITLE
update default filters

### DIFF
--- a/envs/example/allinone/group_vars/all.yml
+++ b/envs/example/allinone/group_vars/all.yml
@@ -8,8 +8,5 @@ xtradb:
 percona:
   replication: False
 
-nova:
-  scheduler_default_filters: AvailabilityZoneFilter,ComputeFilter
-
 heat:
  enabled: true

--- a/envs/example/vagrant.yml
+++ b/envs/example/vagrant.yml
@@ -12,6 +12,9 @@ monitoring:
     pass: rabbit
     vhost: /rabbit
 
+nova:
+  scheduler_default_filters: RetryFilter,AvailabilityZoneFilter,ComputeFilter,CoreFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter
+
 neutron:
   plugin: ml2
   bridge_mappings: physnet:eth2

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -18,7 +18,7 @@ nova:
   novnc_repo: https://github.com/kanaka/noVNC.git
   novnc_rev: 292f6a5d
   novnc_url: https://github.com/kanaka/noVNC/archive/v0.5.1.tar.gz
-  scheduler_default_filters: AvailabilityZoneFilter,RamFilter,ComputeFilter,CoreFilter
+  scheduler_default_filters: RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,CoreFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter
   libvirt_bin_version: 1.2.2-0ubuntu13.1.9~cloud0
   python_libvirt_version: 1.2.2-0ubuntu2~cloud0
   qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.11~cloud0


### PR DESCRIPTION
RetryFilter: Filters out hosts that have already been attempted for scheduling purposes. If the scheduler selects a host to respond to a service request, and the host fails to respond to the request, this filter prevents the scheduler from retrying that host for the service request.

AvailabilityZoneFilter: Filters hosts by availability zone. You must enable this filter for the scheduler to respect availability zones in requests.

RamFilter: Only schedules instances on hosts that have sufficient RAM available.

ComputeFilter: Passes all hosts that are operational and enabled.

CoreFilter: Only schedules instances on hosts if sufficient CPU cores are available.

ComputeCapabilitiesFilter: Matches properties defined in extra specs for an instance type against compute capabilities.

ImagePropertiesFilter: Filters hosts based on properties defined on the instance's image.

ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter: allow for affinty/antiaffinity based on server group membership.