### PR TITLE
feature flags added to allow a very minimal install

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -70,6 +70,7 @@ xtradb:
 # Currently, unable to test monitoring in a VM environment, without
 # changing the following to a valid sensu server.
 monitoring:
+  enabled: true
   sensu_package_version: 0.12.5-1
   rabbit:
     host: "{{ undercloud_floating_ip }}"
@@ -460,4 +461,7 @@ novadocker:
   enabled: False
 
 haproxy:
+  enabled: True
+
+logging:
   enabled: True

--- a/envs/example/jeofd/group_vars/all.yml
+++ b/envs/example/jeofd/group_vars/all.yml
@@ -1,0 +1,27 @@
+---
+stack_env: example_jeofd
+floating_ip: 172.16.0.100
+
+xtradb:
+  sst_auth_password: asdf
+
+cinder:
+  enabled: False
+
+heat:
+  enabled: False
+
+logging:
+  enabled: False
+
+monitoring:
+  enabled: False
+
+collectd:
+  enabled: False
+
+haproxy:
+  stats_group: root
+
+percona:
+  replication: False

--- a/envs/example/jeofd/hosts
+++ b/envs/example/jeofd/hosts
@@ -1,0 +1,14 @@
+[controller]
+allinone
+
+[network]
+allinone
+
+[db]
+allinone
+
+[compute]
+allinone
+
+[cinder_volume]
+allinone

--- a/envs/example/jeofd/playbooks
+++ b/envs/example/jeofd/playbooks
@@ -1,0 +1,1 @@
+../../../playbooks/vagrant

--- a/envs/example/jeofd/vagrant.yml
+++ b/envs/example/jeofd/vagrant.yml
@@ -1,0 +1,15 @@
+default:
+  memory: 512
+  cpus: 1
+
+vms:
+  allinone:
+    ip_address:
+      - 172.16.0.100
+      - 172.16.255.100
+      - 192.168.255.100
+    cpus: 2
+    memory: 6144
+    custom:
+       - '["modifyvm", :id, "--nicpromisc3", "allow-all"]'
+       - '["modifyvm", :id, "--nicpromisc4", "allow-all"]'

--- a/plugins/callbacks/timestamp.py
+++ b/plugins/callbacks/timestamp.py
@@ -62,6 +62,7 @@ class CallbackModule(object):
     def __init__(self):
         self.stats = {}
         self.current = None
+        self.count = 0
 
     def on_any(self, *args, **kwargs):
         pass
@@ -115,6 +116,7 @@ class CallbackModule(object):
         # Record the start time of the current task
         self.current = name
         self.stats[self.current] = time.time()
+        self.count += 1
 
         pass
 
@@ -138,6 +140,8 @@ class CallbackModule(object):
 
     def playbook_on_stats(self, stats):
         timestamp()
+        display(filled("", fchar="="))
+        print "Total tasks: %d" % ( self.count )
         display(filled("", fchar="="))
         print "Slowest 25 Tasks"
         display(filled("", fchar="="))

--- a/roles/cinder-control/tasks/main.yml
+++ b/roles/cinder-control/tasks/main.yml
@@ -35,3 +35,4 @@
   ufw: rule=allow to_port=8778 proto=tcp
 
 - include: monitoring.yml tags=monitoring,common
+  when: monitoring.enabled is not defined or monitoring.enabled|bool

--- a/roles/cinder-control/tasks/main.yml
+++ b/roles/cinder-control/tasks/main.yml
@@ -35,4 +35,4 @@
   ufw: rule=allow to_port=8778 proto=tcp
 
 - include: monitoring.yml tags=monitoring,common
-  when: monitoring.enabled is not defined or monitoring.enabled|bool
+  when: monitoring.enabled|default('True')|bool

--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -51,4 +51,4 @@
   service: name=cinder-volume state=started
 
 - include: monitoring.yml tags=monitoring,common
-  when: monitoring.enabled is not defined or monitoring.enabled|bool
+  when: monitoring.enabled|default('True')|bool

--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -51,3 +51,4 @@
   service: name=cinder-volume state=started
 
 - include: monitoring.yml tags=monitoring,common
+  when: monitoring.enabled is not defined or monitoring.enabled|bool

--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -12,3 +12,4 @@ dependencies:
   - role: docker
     when: docker.enabled is defined and docker.enabled|bool
   - role: monitoring-common
+    when: monitoring.enabled is not defined or monitoring.enabled|bool

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -94,4 +94,4 @@
   lineinfile: dest=/etc/issue regexp="^{{ stack_env }} OpenStack Node" line="{{ stack_env }} OpenStack Node"
 
 - include: monitoring.yml tags=monitoring,common
-  when: monitoring.enabled is not defined or monitoring.enabled|bool
+  when: monitoring.enabled|default('True')|bool

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -94,3 +94,4 @@
   lineinfile: dest=/etc/issue regexp="^{{ stack_env }} OpenStack Node" line="{{ stack_env }} OpenStack Node"
 
 - include: monitoring.yml tags=monitoring,common
+  when: monitoring.enabled is not defined or monitoring.enabled|bool

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -74,10 +74,10 @@
   when: glance.sync.enabled
 
 - include: monitoring.yml tags=monitoring,common
-  when: monitoring.enabled is not defined or monitoring.enabled|bool
+  when: monitoring.enabled|default('True')|bool
 
 - include: logging.yml
   tags:
     - logrotate
     - logging
-  when: logging.enabled is not defined or logging.enabled|bool
+  when: logging.enabled|default('True')|bool

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -74,8 +74,10 @@
   when: glance.sync.enabled
 
 - include: monitoring.yml tags=monitoring,common
+  when: monitoring.enabled is not defined or monitoring.enabled|bool
 
 - include: logging.yml
   tags:
     - logrotate
     - logging
+  when: logging.enabled is not defined or logging.enabled|bool

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 haproxy:
   bufsize: 16384
+  stats_group: monitor

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -28,3 +28,4 @@
   service: name=haproxy state=started enabled=yes
 
 - include: monitoring.yml tags=monitoring,common
+  when: monitoring.enabled is not defined or monitoring.enabled|bool

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -28,4 +28,4 @@
   service: name=haproxy state=started enabled=yes
 
 - include: monitoring.yml tags=monitoring,common
-  when: monitoring.enabled is not defined or monitoring.enabled|bool
+  when: monitoring.enabled|default('True')|bool

--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -25,7 +25,7 @@ global
   daemon
   pidfile /var/run/haproxy/haproxy.pid
   tune.bufsize {{ haproxy.bufsize }}
-  stats socket /var/run/haproxy/stats.sock mode 770 group monitor
+  stats socket /var/run/haproxy/stats.sock mode 770 group {{ haproxy.stats_group }}
 
 defaults
   log global

--- a/roles/haproxy/templates/etc/haproxy/haproxy_swift.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_swift.cfg
@@ -5,7 +5,7 @@ global
    group nogroup
   daemon
   pidfile /var/run/haproxy.pid
-  stats socket /var/run/haproxy/stats.sock mode 770 group monitor
+  stats socket /var/run/haproxy/stats.sock mode 770 group {{ haproxy.stats_group }}
 
 defaults
   log global

--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -54,10 +54,10 @@
     - heat-engine
 
 - include: monitoring.yml tags=monitoring,common
-  when: monitoring.enabled is not defined or monitoring.enabled|bool
+  when: monitoring.enabled|default('True')|bool
 
 - include: logging.yml
   tags:
     - logrotate
     - logging
-  when: logging.enabled is not defined or logging.enabled|bool
+  when: logging.enabled|default('True')|bool

--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -54,8 +54,10 @@
     - heat-engine
 
 - include: monitoring.yml tags=monitoring,common
+  when: monitoring.enabled is not defined or monitoring.enabled|bool
 
 - include: logging.yml
   tags:
     - logrotate
     - logging
+  when: logging.enabled is not defined or logging.enabled|bool

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -115,3 +115,4 @@
   - 443
 
 - include: monitoring.yml tags=monitoring,common
+  when: monitoring.enabled is not defined or monitoring.enabled|bool

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -115,4 +115,4 @@
   - 443
 
 - include: monitoring.yml tags=monitoring,common
-  when: monitoring.enabled is not defined or monitoring.enabled|bool
+  when: monitoring.enabled|default('True')|bool

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -69,11 +69,11 @@
     state: absent
 
 - include: monitoring.yml tags=monitoring,common
-  when: monitoring.enabled is not defined or monitoring.enabled|bool
+  when: monitoring.enabled|default('True')|bool
 
 
 - include: logging.yml
   tags:
     - logrotate
     - logging
-  when: logging.enabled is not defined or logging.enabled|bool
+  when: logging.enabled|default('True')|bool

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -69,8 +69,11 @@
     state: absent
 
 - include: monitoring.yml tags=monitoring,common
+  when: monitoring.enabled is not defined or monitoring.enabled|bool
+
 
 - include: logging.yml
   tags:
     - logrotate
     - logging
+  when: logging.enabled is not defined or logging.enabled|bool

--- a/roles/memcached/tasks/main.yml
+++ b/roles/memcached/tasks/main.yml
@@ -15,3 +15,4 @@
     - restart memcached
 
 - include: monitoring.yml tags=monitoring,common
+  when: monitoring.enabled is not defined or monitoring.enabled|bool

--- a/roles/memcached/tasks/main.yml
+++ b/roles/memcached/tasks/main.yml
@@ -15,4 +15,4 @@
     - restart memcached
 
 - include: monitoring.yml tags=monitoring,common
-  when: monitoring.enabled is not defined or monitoring.enabled|bool
+  when: monitoring.enabled|default('True')|bool

--- a/roles/neutron-control/tasks/main.yml
+++ b/roles/neutron-control/tasks/main.yml
@@ -41,4 +41,4 @@
   ufw: rule=allow to_port=9797 proto=tcp
 
 - include: monitoring.yml tags=monitoring,common
-  when: monitoring.enabled is not defined or monitoring.enabled|bool
+  when: monitoring.enabled|default('True')|bool

--- a/roles/neutron-control/tasks/main.yml
+++ b/roles/neutron-control/tasks/main.yml
@@ -41,3 +41,4 @@
   ufw: rule=allow to_port=9797 proto=tcp
 
 - include: monitoring.yml tags=monitoring,common
+  when: monitoring.enabled is not defined or monitoring.enabled|bool

--- a/roles/neutron-data-network/tasks/main.yml
+++ b/roles/neutron-data-network/tasks/main.yml
@@ -71,3 +71,4 @@
 - include: ipchanged.yml
 
 - include: monitoring.yml tags=monitoring,common
+  when: monitoring.enabled is not defined or monitoring.enabled|bool

--- a/roles/neutron-data-network/tasks/main.yml
+++ b/roles/neutron-data-network/tasks/main.yml
@@ -71,4 +71,4 @@
 - include: ipchanged.yml
 
 - include: monitoring.yml tags=monitoring,common
-  when: monitoring.enabled is not defined or monitoring.enabled|bool
+  when: monitoring.enabled|default('True')|bool

--- a/roles/neutron-data/tasks/main.yml
+++ b/roles/neutron-data/tasks/main.yml
@@ -51,3 +51,4 @@
             mode=0755 owner=root
 
 - include: monitoring.yml tags=monitoring,common
+  when: monitoring.enabled is not defined or monitoring.enabled|bool

--- a/roles/neutron-data/tasks/main.yml
+++ b/roles/neutron-data/tasks/main.yml
@@ -51,4 +51,4 @@
             mode=0755 owner=root
 
 - include: monitoring.yml tags=monitoring,common
-  when: monitoring.enabled is not defined or monitoring.enabled|bool
+  when: monitoring.enabled|default('True')|bool

--- a/roles/nova-common/tasks/main.yml
+++ b/roles/nova-common/tasks/main.yml
@@ -4,7 +4,7 @@
         createhome=yes generate_ssh_key=yes ssh_key_bits=4096
 
 - name: nova packages
-  apt: 
+  apt:
     pkg="{{ item }}"
   with_items: nova.install_packages
 
@@ -31,3 +31,4 @@
   tags:
     - logrotate
     - logging
+  when: logging.enabled is not defined or logging.enabled|bool

--- a/roles/nova-common/tasks/main.yml
+++ b/roles/nova-common/tasks/main.yml
@@ -31,4 +31,4 @@
   tags:
     - logrotate
     - logging
-  when: logging.enabled is not defined or logging.enabled|bool
+  when: logging.enabled|default('True')|bool

--- a/roles/nova-control/tasks/main.yml
+++ b/roles/nova-control/tasks/main.yml
@@ -51,3 +51,4 @@
 - include: novnc.yml tags=novnc
 
 - include: monitoring.yml tags=monitoring,common
+  when: monitoring.enabled is not defined or monitoring.enabled|bool

--- a/roles/nova-control/tasks/main.yml
+++ b/roles/nova-control/tasks/main.yml
@@ -51,4 +51,4 @@
 - include: novnc.yml tags=novnc
 
 - include: monitoring.yml tags=monitoring,common
-  when: monitoring.enabled is not defined or monitoring.enabled|bool
+  when: monitoring.enabled|default('True')|bool

--- a/roles/nova-data/tasks/main.yml
+++ b/roles/nova-data/tasks/main.yml
@@ -46,5 +46,5 @@
   ufw: rule=allow port=5900:6100 proto=tcp
 
 - include: monitoring.yml tags=monitoring,common
-
+  when: monitoring.enabled is not defined or monitoring.enabled|bool
 

--- a/roles/nova-data/tasks/main.yml
+++ b/roles/nova-data/tasks/main.yml
@@ -46,5 +46,5 @@
   ufw: rule=allow port=5900:6100 proto=tcp
 
 - include: monitoring.yml tags=monitoring,common
-  when: monitoring.enabled is not defined or monitoring.enabled|bool
+  when: monitoring.enabled|default('True')|bool
 

--- a/roles/openstack-setup/tasks/main.yml
+++ b/roles/openstack-setup/tasks/main.yml
@@ -9,6 +9,6 @@
   when: openstack_setup.add_networks|bool or openstack_setup.add_networks is undefined
 
 - include: cinder.yml
-  when: cinder.enabled is not defined or cinder.enabled|bool
+  when: cinder.enabled|default('True')|bool
 
 - include: flavors.yml

--- a/roles/openstack-setup/tasks/main.yml
+++ b/roles/openstack-setup/tasks/main.yml
@@ -9,5 +9,6 @@
   when: openstack_setup.add_networks|bool or openstack_setup.add_networks is undefined
 
 - include: cinder.yml
+  when: cinder.enabled is not defined or cinder.enabled|bool
 
 - include: flavors.yml

--- a/roles/percona-server/tasks/main.yml
+++ b/roles/percona-server/tasks/main.yml
@@ -109,4 +109,4 @@
     - "{{ ansible_hostname }}"
 
 - include: monitoring.yml tags=monitoring,common
-  when: monitoring.enabled is not defined or monitoring.enabled|bool
+  when: monitoring.enabled|default('True')|bool

--- a/roles/percona-server/tasks/main.yml
+++ b/roles/percona-server/tasks/main.yml
@@ -109,3 +109,4 @@
     - "{{ ansible_hostname }}"
 
 - include: monitoring.yml tags=monitoring,common
+  when: monitoring.enabled is not defined or monitoring.enabled|bool

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -45,4 +45,4 @@
   file: group=root owner=root mode=0755 path=/usr/local/bin/rabbitmqadmin
 
 - include: monitoring.yml tags=monitoring,common
-  when: monitoring.enabled is not defined or monitoring.enabled|bool
+  when: monitoring.enabled|default('True')|bool

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -45,3 +45,4 @@
   file: group=root owner=root mode=0755 path=/usr/local/bin/rabbitmqadmin
 
 - include: monitoring.yml tags=monitoring,common
+  when: monitoring.enabled is not defined or monitoring.enabled|bool

--- a/roles/swift-common/tasks/main.yml
+++ b/roles/swift-common/tasks/main.yml
@@ -4,28 +4,28 @@
 
 # swiftops requires a shell and a home in order to build/distribute rings
 - name: create swiftops user
-  user: name=swiftops comment=swiftops shell=/bin/bash system=yes 
+  user: name=swiftops comment=swiftops shell=/bin/bash system=yes
         home=/home/swiftops
 
 - name: create swiftops .ssh directory
-  file: dest=/home/swiftops/.ssh state=directory owner=swiftops 
+  file: dest=/home/swiftops/.ssh state=directory owner=swiftops
         group=swiftops mode=0755
 
 - name: drop a swiftops public key
-  template: src=home/swiftops/.ssh/id_rsa dest=/home/swiftops/.ssh/id_rsa 
+  template: src=home/swiftops/.ssh/id_rsa dest=/home/swiftops/.ssh/id_rsa
             owner=swiftops group=swiftops mode=0600
 
 - name: drop a swiftops private key
-  template: src=home/swiftops/.ssh/id_rsa.pub 
-            dest=/home/swiftops/.ssh/id_rsa.pub owner=swiftops 
+  template: src=home/swiftops/.ssh/id_rsa.pub
+            dest=/home/swiftops/.ssh/id_rsa.pub owner=swiftops
             group=swiftops mode=0600
 
 - name: setup swiftops authorized hosts
-  file: src=/home/swiftops/.ssh/id_rsa.pub 
+  file: src=/home/swiftops/.ssh/id_rsa.pub
         dest=/home/swiftops/.ssh/authorized_keys state=link
 
 - name: setup swiftops sudoers
-  template: src=etc/sudoers.d/swiftops dest=/etc/sudoers.d/swiftops 
+  template: src=etc/sudoers.d/swiftops dest=/etc/sudoers.d/swiftops
             owner=root group=root mode=0440
 
 - name: get swifttool repo
@@ -38,15 +38,15 @@
     - pip install swifttool
 
 - name: create swift configuration diectory
-  file: dest=/etc/swift state=directory owner=swiftops 
+  file: dest=/etc/swift state=directory owner=swiftops
         group=swiftops mode=0755
 
 - name: configure swift
-  template: src=etc/swift/swift.conf dest=/etc/swift/swift.conf 
+  template: src=etc/swift/swift.conf dest=/etc/swift/swift.conf
             owner=root group=root mode=0644
 
 - name: create swift cache directory
-  file: dest=/var/cache/swift state=directory owner=swift 
+  file: dest=/var/cache/swift state=directory owner=swift
         group=swift mode=0755
 
 - name: create swift node directory
@@ -55,7 +55,7 @@
 - name: install rsync
   apt: pkg=rsync
 
-- template: src=etc/rsyncd.conf dest=/etc/rsyncd.conf owner=root 
+- template: src=etc/rsyncd.conf dest=/etc/rsyncd.conf owner=root
             group=root mode=0644
   notify: restart rsync
 
@@ -64,15 +64,17 @@
   notify: restart rsync
 
 - name: configure dispersion tools
-  template: src=etc/swift/dispersion.conf dest=/etc/swift/dispersion.conf 
+  template: src=etc/swift/dispersion.conf dest=/etc/swift/dispersion.conf
             owner=root group=root mode=0644
 
 - include: monitoring.yml tags=monitoring,common
+  when: monitoring.enabled is not defined or monitoring.enabled|bool
 
 - include: logging.yml
   tags:
     - logrotate
     - logging
+  when: logging.enabled is not defined or logging.enabled|bool
 
 - name: include swift warning in message of the day
   lineinfile: dest=/etc/motd.tail

--- a/roles/swift-common/tasks/main.yml
+++ b/roles/swift-common/tasks/main.yml
@@ -68,13 +68,13 @@
             owner=root group=root mode=0644
 
 - include: monitoring.yml tags=monitoring,common
-  when: monitoring.enabled is not defined or monitoring.enabled|bool
+  when: monitoring.enabled|default('True')|bool
 
 - include: logging.yml
   tags:
     - logrotate
     - logging
-  when: logging.enabled is not defined or logging.enabled|bool
+  when: logging.enabled|default('True')|bool
 
 - name: include swift warning in message of the day
   lineinfile: dest=/etc/motd.tail

--- a/site.yml
+++ b/site.yml
@@ -20,6 +20,7 @@
   roles:
     - role: logging
       tags: ['common', 'logging']
+      when: logging.enabled|bool or logging.enabled is not defined
 
 - name: setup IPv6 router advertisements
   gather_facts: force

--- a/site.yml
+++ b/site.yml
@@ -7,7 +7,7 @@
       tags: ['common','common-base']
     - role: collectd-client
       tags: ['collectd-client','collectd']
-      when: collectd is defined and collectd.enabled|bool
+      when: collectd.enabled|default('False')|bool
 
 - name: security and errata
   hosts: all
@@ -20,7 +20,7 @@
   roles:
     - role: logging
       tags: ['common', 'logging']
-      when: logging.enabled|bool or logging.enabled is not defined
+      when: logging.enabled|default('True')|bool
 
 - name: setup IPv6 router advertisements
   gather_facts: force


### PR DESCRIPTION
* feature flags to allow disabling of logging/monitoring
* ensure feature flags for cinder etc work as expected

* example of using those flags in envs/example/jeofd to install
  a minimal openstack footprint.

(jeofd = just enough openstack for docker)