### PR TITLE
Do not open VNC ports by default

### DIFF
--- a/roles/nova-data/tasks/main.yml
+++ b/roles/nova-data/tasks/main.yml
@@ -28,9 +28,6 @@
 - name: start nova-compute
   service: name=nova-compute state=started
 
-- name: allow vnc access for console
-  ufw: rule=allow port=5900:6100 proto=tcp
-
 - include: monitoring.yml tags=monitoring,common
 
 


### PR DESCRIPTION
This code had been added for use on a firewalled stack, but it is not
appropraite for general consumption of Ursula stacks.