### PR TITLE
Make sure VNC listens on primary_ip

### DIFF
--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -56,7 +56,7 @@ novnc_enabled=false
 novncproxy_base_url=https://{{ endpoints.vnc }}:6081/vnc_auto.html
 novncproxy_port=6080
 vncserver_proxyclient_address={{ primary_ip }}
-vncserver_listen=0.0.0.0
+vncserver_listen={{ primary_ip }}
 
 # Consoleauth tokens in memcached
 memcached_servers={{ hostvars|ursula_memcache_hosts(groups, memcached.port) }}


### PR DESCRIPTION
As there is no need for VNC to listen on all interfaces, we should
restrict VNC to the primary_ip for nova-vncproxy access.