### PR TITLE
Adding functionality for ceph backend in glance

### DIFF
--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 glance:
   api_workers: 5
+  rbd_store_chunk_size: 8
   registry_workers: 5
   sync:
     enabled: true
@@ -12,6 +13,7 @@ glance:
     device_name: image-cache
     dir: /var/lib/glance/images
   store_swift: False
+  store_ceph: False
   show_multiple_locations: True
 
   source:

--- a/roles/glance/templates/etc/glance/glance-api.conf
+++ b/roles/glance/templates/etc/glance/glance-api.conf
@@ -2,9 +2,9 @@
 debug = {{ glance.logging.debug }}
 verbose = {{ glance.logging.verbose }}
 
-{% if glance.store_swift %}
+{% if glance.store_swift|bool %}
 default_store = swift
-{% elif glance.store_ceph %}
+{% elif glance.store_ceph|bool %}
 default_store = rbd
 {% else %}
 default_store = file
@@ -37,7 +37,7 @@ container_formats = {{ glance.container_formats }}
 show_multiple_locations = {{ glance.show_multiple_locations }}
 
 [glance_store]
-{% if glance.store_swift %}
+{% if glance.store_swift|bool %}
 stores = glance.store.swift.Store,
          glance.store.http.Store
 
@@ -46,7 +46,7 @@ swift_store_user = service:glance
 swift_store_key {{ secrets.service_password }}
 swift_store_create_container_on_put = True
 
-{% elif glance.store_ceph %}
+{% elif glance.store_ceph|bool %}
 stores = glance.store.rbd.Store,
          glance.store.http.Store
 

--- a/roles/glance/templates/etc/glance/glance-api.conf
+++ b/roles/glance/templates/etc/glance/glance-api.conf
@@ -4,6 +4,8 @@ verbose = {{ glance.logging.verbose }}
 
 {% if glance.store_swift %}
 default_store = swift
+{% elif glance.store_ceph %}
+default_store = rbd
 {% else %}
 default_store = file
 {% endif %}
@@ -43,6 +45,15 @@ swift_store_auth_address = https://{{ endpoints.main }}:35358/v2.0
 swift_store_user = service:glance
 swift_store_key {{ secrets.service_password }}
 swift_store_create_container_on_put = True
+
+{% elif glance.store_ceph %}
+stores = glance.store.rbd.Store,
+         glance.store.http.Store
+
+rbd_store_ceph_conf = /etc/ceph/ceph.conf
+rbd_store_chunk_size = {{ glance.rbd_store_chunk_size }}
+rbd_store_pool = images
+rbd_store_user = service:glance
 
 {% else %}
 stores = glance.store.filesystem.Store,


### PR DESCRIPTION
Enhance glance Ursula so that it leverages swift when present, ceph when present (but not swift), or default local file system when neither swift nor ceph are enabled. To enable ceph, set glance.store_ceph to True.