### PR TITLE
Pin oslo.utils to stay compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ python-neutronclient==2.3.6
 python-keystoneclient
 python-glanceclient
 python-cinderclient
-oslo.utils
+oslo.utils==1.9.0
 tox
 pep8
 -e git://github.com/willthames/ansible-lint.git@9777f20aafd4be8706c9ce17005c981cb19a6a25#egg=ansible-lint


### PR DESCRIPTION
We pin novaclient and neutronclient to keep working with the ansible
modules we've got housed here in 1.2.x, and oslo.utils bumped upstream
into an incompatible version. So pin oslo.utils to the last version that
works for us in this dead end tree of code.