### PR TITLE
Remove client pins and ensure latest pbr

### DIFF
--- a/playbooks/tests/tasks/integration.yml
+++ b/playbooks/tests/tasks/integration.yml
@@ -10,7 +10,7 @@
            /root/.ssh/id_rsa.pub
 
   - name: generate test security group
-    shell: . /root/stackrc; neutron security-group-create turtle-sec && 
+    shell: . /root/stackrc; neutron security-group-create turtle-sec &&
            neutron security-group-rule-create turtle-sec --remote-ip-prefix
            0.0.0.0/0
 
@@ -25,6 +25,10 @@
            external | awk '/ external / {print $2}' ); nova add-floating-ip
            turtle-stack ${FLOATING_IP}; sleep 60
 
+  - name: get floating IP
+    shell: . /root/stackrc; nova show turtle-stack | grep 'internal network' | awk '{ print $5 }'
+    register: turtle_ip
+
   - name: nova can create a volume via cinder
     shell: . /root/stackrc; nova volume-create --display-name=turtle-vol 2
 
@@ -37,13 +41,11 @@
            turtle-stack {{ turtle_vol.stdout }} auto
 
   - name: can ping instance
-    shell: . /root/stackrc; TURTLE_IP=$( nova list | awk
-           '/turtle-stack/ {print $13}' ); ping -c 5 ${TURTLE_IP}
+    shell: . /root/stackrc; TURTLE_IP={{ turtle_ip.stdout }}; ping -c 5 ${TURTLE_IP}
 
 # (due to 1450 MTU on VXLAN this doesn't work with recent version of SSH)
   - name: test instance can ping Google
-    shell: . /root/stackrc; TURTLE_IP=$( nova list | awk
-           '/turtle-stack/ {print $13}' ); ssh -o
+    shell: . /root/stackrc; TURTLE_IP={{ turtle_ip.stdout }}; ssh -o
            UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
            cirros@${TURTLE_IP} ping -c 5 www.google.com
     when: ansible_distribution_version == "12.04"

--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -4,9 +4,9 @@ client:
   names:
     - python-keystoneclient
     - python-glanceclient
-    - python-novaclient==2.20.0
+    - python-novaclient
     - python-neutronclient
-    - python-cinderclient==1.1.1
+    - python-cinderclient
     - python-heatclient
     - python-ironicclient
     - python-swiftclient


### PR DESCRIPTION
This fixes client installs

cinderclient was pinned due to version discovery code being added that
broke, which has since been reverted.

Novaclient was pinned due to a volume-attach bug, but a new enough
release of novaclient is in pip that doesn't have this issue.

To ensure we get the right ones we express that we need newer/equal to
the versions that have our fixes in them.