### PR TITLE
Set a default volume type for cinder

### DIFF
--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -5,6 +5,7 @@ cinder:
   default_backend:
   backends: []
   api_workers: 5
+  volume_type: file
   volume_group: cinder-volumes
   create_vg: true
 


### PR DESCRIPTION
We were relying on an env setting for this, but we really should have a
default in the role. File is the safe default.