### PR TITLE
Set a default volume type for cinder (1.2.x)

### DIFF
--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -5,6 +5,7 @@ cinder:
   default_backend:
   backends: []
   api_workers: 5
+  volume_type: file
   volume_group: cinder-volumes
   create_vg: true
 


### PR DESCRIPTION
We were relying on an env setting for this, but we really should have a
default in the role. File is the safe default.

(cherry picked from commit a7060d71da926d9afb44fd9fadf6fa46a75f0f1f)