### PR TITLE
Add biosdevname=0 to kernel options

### DIFF
--- a/roles/common/tasks/kernel-tuning.yml
+++ b/roles/common/tasks/kernel-tuning.yml
@@ -35,11 +35,12 @@
 #  serial_console_cmdline   Enable kernel messages on ttyS0 and any IPMI SOL if present
 #  console=tty0     Enable default VGA console as /dev/console (must be last console)
 #                   See https://www.kernel.org/doc/Documentation/serial-console.txt
+#  biosdevname=0    Disable naming ethernet devices by bios names
 #
 - name: "Kernel boot parameters: disable console screen blanking, enabled serial console on IPMI serial over LAN"
   lineinfile: dest=/etc/default/grub
               regexp="^GRUB_CMDLINE_LINUX="
-              line="GRUB_CMDLINE_LINUX=\"consoleblank=0 crashkernel=256M nmi_watchdog=1 {{ serial_console_cmdline|default('') }} console=tty0\""
+              line="GRUB_CMDLINE_LINUX=\"consoleblank=0 crashkernel=256M nmi_watchdog=1 {{ serial_console_cmdline|default('') }} console=tty0 biosdevname=0\""
   notify: update grub config
 
 # This was removed in later distributions, but is in grub-common and if present


### PR DESCRIPTION
Avoids having our nics change names on trusty