### PR TITLE
Dump various openstack dbs on upgrade (1.2.x)

### DIFF
--- a/upgrade.yml
+++ b/upgrade.yml
@@ -111,7 +111,7 @@
       mysql_db:
         name: glance
         state: dump
-        target: /var/lib/mysql/glance-preupgrade.sql
+        target: /backup/glance-preupgrade.sql
       run_once: True
       tags: dbdump
 
@@ -150,7 +150,7 @@
       mysql_db:
         name: cinder
         state: dump
-        target: /var/lib/mysql/cinder-preupgrade.sql
+        target: /backup/cinder-preupgrade.sql
       run_once: True
       tags: dbdump
 
@@ -226,7 +226,7 @@
       mysql_db:
         name: nova
         state: dump
-        target: /var/lib/mysql/nova-preupgrade.sql
+        target: /backup/nova-preupgrade.sql
       run_once: True
       tags: dbdump
 
@@ -311,7 +311,7 @@
       mysql_db:
         name: neutron
         state: dump
-        target: /var/lib/mysql/neutron-preupgrade.sql
+        target: /backup/neutron-preupgrade.sql
       run_once: True
       tags: dbdump
 
@@ -407,7 +407,7 @@
       mysql_db:
         name: keystone
         state: dump
-        target: /var/lib/mysql/keystone-preupgrade.sql
+        target: /backup/keystone-preupgrade.sql
       run_once: True
       tags: dbdump
 

--- a/upgrade.yml
+++ b/upgrade.yml
@@ -106,6 +106,15 @@
   max_fail_percentage: 1
   tags: glance
 
+  pre_tasks:
+    - name: dump glance db
+      mysql_db:
+        name: glance
+        state: dump
+        target: /var/lib/mysql/glance-preupgrade.sql
+      run_once: True
+      tags: dbdump
+
   roles:
     - role: glance
       force_sync: true
@@ -135,6 +144,15 @@
   tags:
     - cinder
     - cinder-control
+
+  pre_tasks:
+    - name: dump cinder db
+      mysql_db:
+        name: cinder
+        state: dump
+        target: /var/lib/mysql/cinder-preupgrade.sql
+      run_once: True
+      tags: dbdump
 
   roles:
     - role: cinder-control
@@ -202,6 +220,15 @@
   tags:
     - nova
     - nova-control
+
+  pre_tasks:
+    - name: dump nova db
+      mysql_db:
+        name: nova
+        state: dump
+        target: /var/lib/mysql/nova-preupgrade.sql
+      run_once: True
+      tags: dbdump
 
   roles:
     - role: nova-control
@@ -280,6 +307,14 @@
     - neutron-control
 
   pre_tasks:
+    - name: dump neutron db
+      mysql_db:
+        name: neutron
+        state: dump
+        target: /var/lib/mysql/neutron-preupgrade.sql
+      run_once: True
+      tags: dbdump
+
     - name: check db version
       command: neutron-db-manage --config-file /etc/neutron/neutron.conf
                --config-file /etc/neutron/plugins/ml2/ml2_plugin.ini
@@ -366,6 +401,15 @@
   hosts: controller
   max_fail_percentage: 1
   tags: keystone
+
+  pre_tasks:
+    - name: dump keystone db
+      mysql_db:
+        name: keystone
+        state: dump
+        target: /var/lib/mysql/keystone-preupgrade.sql
+      run_once: True
+      tags: dbdump
 
   roles:
     - role: keystone


### PR DESCRIPTION
Tiny window while some service is still running but gives us a good
going back spot.

(cherry picked from commit ec27daee0d958e37c9fd6b80d9c71ff38635a48c)