### PR TITLE
Add a true SSL context for python clients/requests

### DIFF
--- a/roles/security_errata/tasks/main.yml
+++ b/roles/security_errata/tasks/main.yml
@@ -9,5 +9,12 @@
   - openssl
   notify: reload haproxy
 
+- name: update python modules for true ssl context
+  pip: name={{ item }} state=latest
+  with_items:
+    - pyopenssl 
+    - pyasn1 
+    - ndg-httpsclient
+
 - include: CVE-2015-0235.yml
   tags: CVE-2015-0235


### PR DESCRIPTION
Anything that uses requests > 2.5.3 will complain if there is no true
SSL context capability on the host. Add these 3 python modules for
making such a context available.