### PR TITLE
Ensure mysql is running after reboot

### DIFF
--- a/playbooks/reboot_cluster.yml
+++ b/playbooks/reboot_cluster.yml
@@ -39,3 +39,8 @@
 
   - name: Ensure Galera is up before rebooting next node
     wait_for: port=4567
+
+  - name: Ensure mysql is running
+    service:
+      name: mysql
+      state: started


### PR DESCRIPTION
Otherwise we could break the cluster. The service module should be able
to wait until the mysql daemon fully joins the cluster.