### PR TITLE
Remove any hard-coded kernel default (1.2.x)

### DIFF
--- a/roles/common/tasks/kernel-tuning.yml
+++ b/roles/common/tasks/kernel-tuning.yml
@@ -55,3 +55,9 @@
   lineinfile: dest=/etc/default/grub
               line="GRUB_DISABLE_OS_PROBER=true"
   notify: update grub config
+
+- name: Remove any forced boot kernel
+  lineinfile:
+    dest: /etc/default/grub
+    regexp: "^GRUB_DEFAULT=" #
+    state: absent


### PR DESCRIPTION
This was done on some hosts for a time, but as part of the upgrade we
want the new kernel.

(cherry picked from commit 5df0a05cad12efde9b2d7d596acbf4880867e9e1)