### PR TITLE
Backport the cluster reboot playbook

### DIFF
--- a/playbooks/reboot_cluster.yml
+++ b/playbooks/reboot_cluster.yml
@@ -1,0 +1,46 @@
+---
+- hosts: all:!db
+  tasks:
+  - name: Reboot
+    command: shutdown -r now
+    async: 0
+    poll: 0
+    ignore_errors: true
+
+  - name: Wait for SSH to come back
+    wait_for: host={{ ansible_default_ipv4.address }}
+              port={{ ansible_ssh_port|default(22) }}
+              delay=15
+    delegate_to: "{{ groups['controller']|first }}"
+
+- hosts: db_arbiter
+  tasks:
+  - name: Ensure Garbd is up before rebooting database servers
+    wait_for: host={{ ansible_default_ipv4.address }}
+              port=4567
+              delay=15
+    delegate_to: "{{ groups['controller']|first }}"
+
+- hosts: db
+  serial: 1
+  tasks:
+  - name: Reboot
+    command: shutdown -r now
+    async: 0
+    poll: 0
+    ignore_errors: true
+
+  - name: Wait for SSH to come back
+    local_action:
+      module: wait_for
+        host={{ ansible_default_ipv4.address }}
+        port={{ ansible_ssh_port|default(22) }}
+        delay=15
+
+  - name: Ensure Galera is up before rebooting next node
+    wait_for: port=4567
+
+  - name: Ensure mysql is running
+    service:
+      name: mysql
+      state: started


### PR DESCRIPTION
This should be on 1.2.x for rebooting 1.2.x and earlier clusters. Master
is moving beyond what is appropriate to push to <1.2.x clusters.