### PR TITLE
fix typo to enable garbd start on boot (1.2.x)

### DIFF
--- a/roles/percona-arbiter/tasks/main.yml
+++ b/roles/percona-arbiter/tasks/main.yml
@@ -16,4 +16,4 @@
   template: src=etc/default/garbd dest=/etc/default/garbd mode=0644
 
 - name: ensure garbd running
-  service: name=garbd state=started enabled=on pattern=/usr/bin/garbd
+  service: name=garbd state=started enabled=yes pattern=/usr/bin/garbd


### PR DESCRIPTION
(cherry picked from commit 531bc60fe1b84579fa678805fee418ec26cf04f9)