### PR TITLE
Port Standardization for Glance, Nova, NoVNC, Cinder and Neutron

### DIFF
--- a/doc/endpoints.md
+++ b/doc/endpoints.md
@@ -40,17 +40,17 @@ request.
 | Keystone-admin | haproxy  | HTTP     | 35357 | controller internal IP |
 | Keystone-admin | internal | HTTPS    | 35358 | external floating IP   |
 | Keystone-admin | public   | HTTPS    | 35358 | external floating IP   |
-| Nova           | haproxy  | HTTP     | 8774  | controller internal IP |
-| Nova           | internal | HTTPS    | 8777  | external floating IP   |
-| Nova           | public   | HTTPS    | 8777  | external floating IP   |
-| Nova - noVNC   | internal | HTTP     | 6080  | controller internal IP |
-| Nova - noVNC   | public   | HTTPS    | 6081  | external floating IP   |
-| Neutron        | haproxy  | HTTP     | 9696  | controller internal IP |
-| Neutron        | internal | HTTPS    | 9797  | external floating IP   |
-| Neutron        | public   | HTTPS    | 9797  | external floating IP   |
-| Glance         | haproxy  | HTTP     | 9292  | controller internal IP |
-| Glance         | internal | HTTPS    | 9393  | external floating IP   |
-| Glance         | public   | HTTPS    | 9393  | external floating IP   |
+| Nova           | haproxy  | HTTP     | 8777  | controller internal IP |
+| Nova           | internal | HTTPS    | 8774  | external floating IP   |
+| Nova           | public   | HTTPS    | 8774  | external floating IP   |
+| Nova - noVNC   | internal | HTTP     | 6081  | controller internal IP |
+| Nova - noVNC   | public   | HTTPS    | 6080  | external floating IP   |
+| Neutron        | haproxy  | HTTP     | 9797  | controller internal IP |
+| Neutron        | internal | HTTPS    | 9696  | external floating IP   |
+| Neutron        | public   | HTTPS    | 9696  | external floating IP   |
+| Glance         | haproxy  | HTTP     | 9393  | controller internal IP |
+| Glance         | internal | HTTPS    | 9292  | external floating IP   |
+| Glance         | public   | HTTPS    | 9292  | external floating IP   |
 | Heat           | haproxy  | HTTP     | 8004  | controller internal IP |
 | Heat           | internal | HTTPS    | 8005  | external floating IP   |
 | Heat           | public   | HTTPS    | 8005  | external floating IP   |

--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -292,33 +292,33 @@ keystone:
     - name: nova
       type: compute
       description: 'Compute Service'
-      public_url: https://{{ endpoints.main }}:8777/v2/%(tenant_id)s
-      internal_url: https://{{ endpoints.main }}:8777/v2/%(tenant_id)s
-      admin_url: https://{{ endpoints.main }}:8777/v2/%(tenant_id)s
+      public_url: https://{{ endpoints.main }}:8774/v2/%(tenant_id)s
+      internal_url: https://{{ endpoints.main }}:8774/v2/%(tenant_id)s
+      admin_url: https://{{ endpoints.main }}:8774/v2/%(tenant_id)s
     - name: glance
       type: image
       description: 'Image Service'
-      public_url: https://{{ endpoints.main }}:9393
-      internal_url: https://{{ endpoints.main }}:9393
-      admin_url: https://{{ endpoints.main }}:9393
+      public_url: https://{{ endpoints.main }}:9292
+      internal_url: https://{{ endpoints.main }}:9292
+      admin_url: https://{{ endpoints.main }}:9292
     - name: neutron
       type: network
       description: 'Network Service'
-      public_url: https://{{ endpoints.main }}:9797
-      internal_url: https://{{ endpoints.main }}:9797
-      admin_url: https://{{ endpoints.main }}:9797
+      public_url: https://{{ endpoints.main }}:9696
+      internal_url: https://{{ endpoints.main }}:9696
+      admin_url: https://{{ endpoints.main }}:9696
     - name: cinder
       type: volume
       description: 'Volume Service'
-      public_url: https://{{ endpoints.main }}:8778/v1/%(tenant_id)s
-      internal_url: https://{{ endpoints.main }}:8778/v1/%(tenant_id)s
-      admin_url: https://{{ endpoints.main }}:8778/v1/%(tenant_id)s
+      public_url: https://{{ endpoints.main }}:8776/v1/%(tenant_id)s
+      internal_url: https://{{ endpoints.main }}:8776/v1/%(tenant_id)s
+      admin_url: https://{{ endpoints.main }}:8776/v1/%(tenant_id)s
     - name: cinderv2
       type: volumev2
       description: 'Volume Service v2'
-      public_url: https://{{ endpoints.main }}:8778/v2/%(tenant_id)s
-      internal_url: https://{{ endpoints.main }}:8778/v2/%(tenant_id)s
-      admin_url: https://{{ endpoints.main }}:8778/v2/%(tenant_id)s
+      public_url: https://{{ endpoints.main }}:8776/v2/%(tenant_id)s
+      internal_url: https://{{ endpoints.main }}:8776/v2/%(tenant_id)s
+      admin_url: https://{{ endpoints.main }}:8776/v2/%(tenant_id)s
     - name: heat
       type: orchestration
       description: 'Heat Orchestration API'

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -3,6 +3,7 @@ debug = {{ cinder.logging.debug }}
 verbose = {{ cinder.logging.verbose }}
 
 osapi_volume_workers = {{ cinder.api_workers }}
+osapi_volume_listen_port=8778
 
 # Logging #
 log_dir = /var/log/cinder

--- a/roles/cinder-control/tasks/main.yml
+++ b/roles/cinder-control/tasks/main.yml
@@ -32,7 +32,7 @@
     - cinder-scheduler
 
 - name: Permit access to Cinder
-  ufw: rule=allow to_port=8778 proto=tcp
+  ufw: rule=allow to_port=8776 proto=tcp
 
 - include: monitoring.yml tags=monitoring,common
   when: monitoring.enabled|default('True')|bool

--- a/roles/glance/templates/etc/glance/glance-api.conf
+++ b/roles/glance/templates/etc/glance/glance-api.conf
@@ -11,7 +11,7 @@ default_store = file
 {% endif %}
 
 bind_host = 0.0.0.0
-bind_port = 9292
+bind_port = 9393
 
 sql_connection=mysql://glance:{{ secrets.db_password }}@{{ endpoints.db }}/glance?charset=utf8
 

--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -3,11 +3,11 @@
     [ 'horizon', 8080, 443, false ],
     [ 'keystone', 5000, 5001, false ],
     [ 'keystone-admin', 35357, 35358, false ],
-    [ 'nova', 8774, 8777, false ],
-    [ 'novnc', 6080, 6081, true ],
-    [ 'glance', 9292, 9393, true ],
-    [ 'neutron', 9696, 9797, false ],
-    [ 'cinder', 8776, 8778, false ],
+    [ 'nova', 8777, 8774, false ],
+    [ 'novnc', 6081, 6080, true ],
+    [ 'glance', 9393, 9292, true ],
+    [ 'neutron', 9797, 9696, false ],
+    [ 'cinder', 8778, 8776, false ],
   ]
 -%}
 {% if heat.enabled -%}

--- a/roles/ironic-common/templates/etc/ironic/ironic.conf
+++ b/roles/ironic-common/templates/etc/ironic/ironic.conf
@@ -41,7 +41,7 @@ admin_password = {{ secrets.service_password }}
 cafile = {{ ironic.cafile }}
 
 [neutron]
-url=https://{{ endpoints.main }}:9797
+url=https://{{ endpoints.main }}:9696
 
 [glance]
 glance_host={{ endpoints.main }}

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -42,7 +42,7 @@ rabbit_password = {{ secrets.rabbit_password }}
 rpc_backend = neutron.openstack.common.rpc.impl_kombu
 
 bind_host = 0.0.0.0
-bind_port = 9696
+bind_port = 9797
 
 api_paste_config = api-paste.ini
 
@@ -57,7 +57,7 @@ lock_path = $state_path/lock
 # ======== neutron nova interactions ==========
 notify_nova_on_port_data_changes = True
 notify_nova_on_port_status_changes = True
-nova_url = https://{{ endpoints.nova }}:8777/v2
+nova_url = https://{{ endpoints.nova }}:8774/v2
 nova_region_name = RegionOne
 nova_admin_username = neutron
 nova_admin_tenant_id = {{ service_tenant.id }}

--- a/roles/neutron-control/tasks/main.yml
+++ b/roles/neutron-control/tasks/main.yml
@@ -38,7 +38,7 @@
   service: name=neutron-server state=started
 
 - name: Permit access to Neutron
-  ufw: rule=allow to_port=9797 proto=tcp
+  ufw: rule=allow to_port=9696 proto=tcp
 
 - include: monitoring.yml tags=monitoring,common
   when: monitoring.enabled|default('True')|bool

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -23,7 +23,7 @@ nova:
   python_libvirt_version: 1.2.2-0ubuntu2~cloud0
   qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.11~cloud0
   librdb1_version: 0.80.9-0ubuntu0.14.04.2~cloud0
-  glance_endpoint: http://{{ endpoints.glance }}:9292
+  glance_endpoint: http://{{ endpoints.glance }}:9393
   reserved_host_disk_mb: 51200
   preallocate_images: space
   floating_pool: external

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -2,6 +2,7 @@
 debug = {{ nova.logging.debug }}
 verbose = {{ nova.logging.verbose }}
 
+osapi_compute_listen_port=8777
 # Policy #
 allow_resize_to_same_host = True
 
@@ -42,7 +43,7 @@ ec2_host={{ endpoints.keystone }}
 ec2_dmz_host={{ endpoints.keystone }}
 ec2_url=http://{{ endpoints.nova }}:8773/services/Cloud
 cc_host={{ endpoints.keystone }}
-nova_url=http://{{ endpoints.nova }}:8774/v1.1/
+nova_url=http://{{ endpoints.nova }}:8777/v1.1/
 
 # Paths to important items #
 state_path=/var/lib/nova
@@ -59,8 +60,8 @@ keystone_ec2_url=https://{{ endpoints.keystone }}:5001/v2.0/ec2tokens
 
 # Vnc configuration
 novnc_enabled=false
-novncproxy_base_url=https://{{ endpoints.vnc }}:6081/vnc_auto.html
-novncproxy_port=6080
+novncproxy_base_url=https://{{ endpoints.vnc }}:6080/vnc_auto.html
+novncproxy_port=6081
 vncserver_proxyclient_address={{ primary_ip }}
 vncserver_listen={{ primary_ip }}
 
@@ -172,7 +173,7 @@ signing_dir = /var/cache/nova/api
 cafile = {{ nova.cafile }}
 
 [neutron]
-url=https://{{ endpoints.neutron }}:9797
+url=https://{{ endpoints.neutron }}:9696
 auth_strategy=keystone
 admin_tenant_name=service
 admin_username=neutron

--- a/roles/nova-control/tasks/main.yml
+++ b/roles/nova-control/tasks/main.yml
@@ -46,7 +46,7 @@
     - nova-scheduler
 
 - name: permit access to nova api
-  ufw: rule=allow to_port=8777 proto=tcp
+  ufw: rule=allow to_port=8774 proto=tcp
 
 - include: novnc.yml tags=novnc
 

--- a/roles/nova-control/tasks/novnc.yml
+++ b/roles/nova-control/tasks/novnc.yml
@@ -31,4 +31,4 @@
   service: name=nova-novncproxy state=started
 
 - name: Permit access to NoVNC
-  ufw: rule=allow to_port=6081 proto=tcp
+  ufw: rule=allow to_port=6080 proto=tcp

--- a/roles/novnc/tasks/main.yml
+++ b/roles/novnc/tasks/main.yml
@@ -19,4 +19,4 @@
 - service: name=nova-novncproxy state=started
 
 - name: Permit access to NoVNC
-  ufw: rule=allow to_port=6081 proto=tcp
+  ufw: rule=allow to_port=6080 proto=tcp


### PR DESCRIPTION
Port Standardization for Glance, Nova, novnc, Cinder and Neutron. Next pull request will include Keystone, Heat etc. Changed the customer facing ports to use openstack standard ports. 