### PR TITLE
Update git references to our forked Horizon

### DIFF
--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -6,4 +6,4 @@ horizon:
   virtualenv: /opt/stack/horizon/.venv
   session_timeout: 5400
   source:
-    rev: 'stable/kilo'
+    rev: 'kilo-bbg'

--- a/roles/horizon/meta/main.yml
+++ b/roles/horizon/meta/main.yml
@@ -3,7 +3,7 @@ dependencies:
   - role: monitoring-common
   - role: openstack-source
     project_name: horizon
-    git_mirror: "https://github.com/openstack"
+    git_mirror: "https://github.com/blueboxgroup"
     project_rev: "{{ horizon.source.rev }}"
     virtualenv: "{{ horizon.virtualenv }}"
     python_requirements:

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -104,7 +104,6 @@
     - "{{ horizon.virtualenv }}/bin/django-admin.py collectstatic --noinput"
     - "{{ horizon.virtualenv }}/bin/django-admin.py compress"
   when: openstack_install_method == 'source'
-  tags: FIXME
 
 - name: ensure apache started
   service: name=apache2 state=started


### PR DESCRIPTION
Updates to kilo-bbg Horizon branch to support a working dashboard have been merged. We can now enable them here in the kilo ursula branch.