### PR TITLE
ensure sensu PATH contains /usr/local/bin for keystone &c

### DIFF
--- a/roles/common/tasks/monitoring.yml
+++ b/roles/common/tasks/monitoring.yml
@@ -41,6 +41,11 @@
               line=EMBEDDED_RUBY=true
   notify: restart sensu-client
 
+- name: ensure PATH contains /usr/local/bin (OpenStack clients)
+  lineinfile: dest=/etc/default/sensu regexp=^PATH
+              line="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+  notify: restart sensu-client
+
 - name: sensu client config
   template: src=monitoring/config.json dest=/etc/sensu/config.json owner=root
             group=root


### PR DESCRIPTION
When launched through upstart at boot, the PATH doesn't contain /usr/local folders, which is where OpenStack clients reside, causing check-os-api to fail.