### PR TITLE
update pinned libvirt version

### DIFF
--- a/library/neutron_floating_ip
+++ b/library/neutron_floating_ip
@@ -77,6 +77,11 @@ options:
         - The name of the instance to which the IP address should be assigned
      required: true
      default: None
+   fixed_ip:
+     description:
+        - IP address on the instance's port. Useful when the port has more than one IP
+     required: false
+     default: None
 requirements: ["novaclient", "neutronclient", "keystoneclient"]
 '''
 
@@ -136,7 +141,7 @@ def _get_server_state(module, nova):
     except Exception as e:
         module.fail_json(msg = "Error in getting the server list: %s" % e.message)
     return server_info, server
-                                 
+
 def _get_port_info(neutron, module, instance_id):
     if module.params['port_network_name'] is None:
       kwargs = {
@@ -158,7 +163,7 @@ def _get_port_info(neutron, module, instance_id):
     if not ports['ports']:
         return None, None
     return ports['ports'][0]['fixed_ips'][0]['ip_address'], ports['ports'][0]['id']
-        
+
 def _get_floating_ip(module, neutron, fixed_ip_address):
     kwargs = {
             'fixed_ip_address': fixed_ip_address
@@ -192,6 +197,8 @@ def _create_floating_ip(neutron, module, port_id, net_id):
             'port_id': port_id,
             'floating_network_id': net_id
     }
+    if 'fixed_ip' in module.params:
+        kwargs['fixed_ip_address'] = module.params['fixed_ip']
     try:
         result = neutron.create_floatingip({'floatingip': kwargs})
     except Exception as e:
@@ -222,7 +229,7 @@ def _update_floating_ip(neutron, module, port_id, floating_ip_id):
 
 
 def main():
-    
+
     module = AnsibleModule(
         argument_spec = dict(
             login_username = dict(default='admin'),
@@ -233,17 +240,18 @@ def main():
             network_name = dict(required=True),
             instance_name = dict(required=True),
             port_network_name = dict(default=None),
+            fixed_ip = dict(default=None),
             state = dict(default='present', choices=['absent', 'present'])
         ),
     )
-        
+
     try:
         nova = nova_client.Client(module.params['login_username'], module.params['login_password'],
             module.params['login_tenant_name'], module.params['auth_url'], service_type='compute')
         neutron = _get_neutron_client(module, module.params)
     except Exception as e:
         module.fail_json(msg="Error in authenticating to nova: %s" % e.message)
-        
+
     server_info, server_obj = _get_server_state(module, nova)
     if not server_info:
         module.fail_json(msg="The instance name provided cannot be found")

--- a/library/nova_compute
+++ b/library/nova_compute
@@ -194,7 +194,7 @@ def _create_server(module, nova):
             if server.status == 'ACTIVE':
                 private = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'fixed']
                 public  = [ x['addr'] for x in getattr(server, 'addresses').itervalues().next() if 'OS-EXT-IPS:type' in x and x['OS-EXT-IPS:type'] == 'floating']
-                module.exit_json(changed = True, id = server.id, private_ip=''.join(private), public_ip=''.join(public), status = server.status, info = server._info)
+                module.exit_json(changed = True, id = server.id, private_ip=''.join(private), private_ips=private, public_ip=''.join(public), public_ips=public, status = server.status, info = server._info)
             if server.status == 'ERROR':
                 module.fail_json(msg = "Error in creating the server, please check logs")
             time.sleep(2)

--- a/library/nova_group
+++ b/library/nova_group
@@ -21,11 +21,9 @@ import os
 import six
 
 try:
-    from novaclient.openstack.common import uuidutils
-    try:
-        from nova.openstack.common import strutils
-    except ImportError:
-        from novaclient.openstack.common import strutils
+    from oslo_utils import uuidutils
+    from oslo_utils import strutils
+    from oslo_utils import encodeutils
     from novaclient.v1_1 import client
     from novaclient.v1_1 import security_groups
     from novaclient.v1_1 import security_group_rules
@@ -134,7 +132,7 @@ class NovaGroup(object):
     # Taken from novaclient/v1_1/shell.py.
     def _get_secgroup(self, secgroup):
         # Check secgroup is an UUID
-        if uuidutils.is_uuid_like(strutils.safe_encode(secgroup)):
+        if uuidutils.is_uuid_like(encodeutils.safe_encode(secgroup)):
             try:
                 sg = self._sg.get(secgroup)
                 return sg

--- a/playbooks/tests/tasks/integration.yml
+++ b/playbooks/tests/tasks/integration.yml
@@ -4,21 +4,61 @@
   tasks:
   - name: generate ssh key for root
     user: name=root generate_ssh_key=yes
+    register: rootuser
 
-  - name: generate nova key-pair
-    shell: . /root/stackrc; nova keypair-add turtle-key --pub-key
-           /root/.ssh/id_rsa.pub
 
-  - name: generate test security group
-    shell: . /root/stackrc; neutron security-group-create turtle-sec &&
-           neutron security-group-rule-create turtle-sec --remote-ip-prefix
-           0.0.0.0/0
+  - name: add ssh-key
+    nova_keypair: state=present
+                  auth_url={{ endpoints.auth_uri }}
+                  login_tenant_name=admin
+                  login_username=provider_admin
+                  login_password={{ secrets.provider_admin_password }}
+                  name="turtle-key"
+                  public_key="{{ rootuser.ssh_public_key }}"
+
+  - name: add security group
+    nova_group:
+      name: turtle-sec
+      state: present
+      auth_url: "{{ endpoints.auth_uri }}"
+      login_username: provider_admin
+      login_password: "{{ secrets.provider_admin_password }}"
+      login_tenant_name: admin
+      description: an example nova group
+      rules:
+        - ip_protocol: tcp
+          from_port: 22
+          to_port: 22
+          cidr: 0.0.0.0/0
+        - ip_protocol: icmp
+          from_port: -1
+          to_port: -1
+          cidr: 0.0.0.0/0
+
+  - name: collect neutron network info
+    neutron_network: name=internal state=present
+                     auth_url={{ endpoints.auth_uri }}
+                     login_tenant_name=admin
+                     login_username=provider_admin
+                     login_password={{ secrets.provider_admin_password }}
+    register: turtle_network
 
   - name: nova can boot an instance
-    shell: . /root/stackrc; INTERNAL_NET=$( nova net-list | awk
-           '/ internal / {print $2}' ); nova boot --flavor m1.tiny --image
-           cirros --nic net-id=${INTERNAL_NET} --key-name
-           turtle-key --security-groups turtle-sec --poll turtle-stack
+    nova_compute:
+      state: present
+      auth_url: "{{ endpoints.auth_uri }}"
+      login_username: provider_admin
+      login_password: "{{ secrets.provider_admin_password }}"
+      login_tenant_name: admin
+      name: turtle-stack
+      image_name: cirros
+      key_name: turtle-key
+      security_groups: turtle-sec
+      wait_for: 200
+      flavor_id: 1
+      nics:
+        - net-id: "{{ turtle_network.id }}"
+    register: turtle_stack
 
   - name: neutron can associate floating IP with test instance
     neutron_floating_ip: auth_url={{ endpoints.auth_uri }}
@@ -26,8 +66,8 @@
                          login_username=provider_admin
                          login_password={{ secrets.provider_admin_password }}
                          network_name=external
-                         instance_name=turtle-stack
-                         fixed_ip={{ turtle_stack.private_ips|ipv4|first }}
+                         instance_name="turtle-stack"
+                         fixed_ip={{ turtle_stack.private_ip }}
     register: floating_ip
 
   - name: nova can create a volume via cinder
@@ -41,12 +81,22 @@
     shell: . /root/stackrc; nova volume-attach
            turtle-stack {{ turtle_vol.stdout }} auto
 
+  - name: give nova instance some time to become available
+    wait_for: delay=60
+
   - name: can ping instance
     shell: ping -c 5 {{ floating_ip.public_ip }}
+    register: result
+    until: result.rc == 0
+    retries: 6
+    delay: 10
 
 # (due to 1450 MTU on VXLAN this doesn't work with recent version of SSH)
   - name: test instance can ping Google
-    shell: . /root/stackrc; ssh -o
-           UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+    shell: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
            cirros@{{ floating_ip.public_ip }} ping -c 5 www.google.com
+    register: result
+    until: result.rc == 0
+    retries: 6
+    delay: 10
     when: ansible_distribution_version == "12.04"

--- a/playbooks/tests/tasks/integration.yml
+++ b/playbooks/tests/tasks/integration.yml
@@ -10,7 +10,7 @@
            /root/.ssh/id_rsa.pub
 
   - name: generate test security group
-    shell: . /root/stackrc; neutron security-group-create turtle-sec && 
+    shell: . /root/stackrc; neutron security-group-create turtle-sec &&
            neutron security-group-rule-create turtle-sec --remote-ip-prefix
            0.0.0.0/0
 
@@ -20,10 +20,15 @@
            cirros --nic net-id=${INTERNAL_NET} --key-name
            turtle-key --security-groups turtle-sec --poll turtle-stack
 
-  - name: nova can associate floating IP with test instance
-    shell: . /root/stackrc; FLOATING_IP=$( nova floating-ip-create
-           external | awk '/ external / {print $2}' ); nova add-floating-ip
-           turtle-stack ${FLOATING_IP}; sleep 60
+  - name: neutron can associate floating IP with test instance
+    neutron_floating_ip: auth_url={{ endpoints.auth_uri }}
+                         login_tenant_name=admin
+                         login_username=provider_admin
+                         login_password={{ secrets.provider_admin_password }}
+                         network_name=external
+                         instance_name=turtle-stack
+                         fixed_ip={{ turtle_stack.private_ips|ipv4|first }}
+    register: floating_ip
 
   - name: nova can create a volume via cinder
     shell: . /root/stackrc; nova volume-create --display-name=turtle-vol 2
@@ -37,13 +42,11 @@
            turtle-stack {{ turtle_vol.stdout }} auto
 
   - name: can ping instance
-    shell: . /root/stackrc; TURTLE_IP=$( nova list | awk
-           '/turtle-stack/ {print $13}' ); ping -c 5 ${TURTLE_IP}
+    shell: ping -c 5 {{ floating_ip.public_ip }}
 
 # (due to 1450 MTU on VXLAN this doesn't work with recent version of SSH)
   - name: test instance can ping Google
-    shell: . /root/stackrc; TURTLE_IP=$( nova list | awk
-           '/turtle-stack/ {print $13}' ); ssh -o
+    shell: . /root/stackrc; ssh -o
            UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
-           cirros@${TURTLE_IP} ping -c 5 www.google.com
+           cirros@{{ floating_ip.public_ip }} ping -c 5 www.google.com
     when: ansible_distribution_version == "12.04"

--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -4,9 +4,9 @@ client:
   names:
     - python-keystoneclient
     - python-glanceclient
-    - python-novaclient==2.20.0
+    - python-novaclient
     - python-neutronclient
-    - python-cinderclient==1.1.1
+    - python-cinderclient
     - python-heatclient
     - python-ironicclient
     - python-swiftclient

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -21,7 +21,7 @@ nova:
   scheduler_default_filters: AvailabilityZoneFilter,RamFilter,ComputeFilter,CoreFilter
   libvirt_bin_version: 1.2.2-0ubuntu13.1.9~cloud0
   python_libvirt_version: 1.2.2-0ubuntu2~cloud0
-  qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.11~cloud0
+  qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.16~cloud0
   librdb1_version: 0.80.9-0ubuntu0.14.04.2~cloud0
   glance_endpoint: http://{{ endpoints.glance }}:9292
   reserved_host_disk_mb: 51200

--- a/test/common
+++ b/test/common
@@ -21,7 +21,7 @@ export NET_ID=${NET_ID:=ba0fdd03-72b5-41eb-bb67-fef437fd6cb4}
 if [[ $(git rev-parse --abbrev-ref HEAD) == 'HEAD' ]]; then
   export testenv_instance_prefix=$(git rev-parse --short HEAD)
 else
-  export testenv_instance_prefix=$(git rev-parse --abbrev-ref HEAD)
+  export testenv_instance_prefix=$(git rev-parse --abbrev-ref HEAD | sed 's/\./_/g' | cut -c 1-20)
 fi
 
 VMS="${testenv_instance_prefix}-controller-0 ${testenv_instance_prefix}-controller-1 ${testenv_instance_prefix}-compute-0"


### PR DESCRIPTION
Updated `qemu_kvm_version` however there were some other problems going on with CI which I also fix here:

1. CI was using nova command and awk to try and test for floating_ip etc and it was failing due to awk positionals.   I changed them to use the ansible modules instead.

2. the older nova client pinned version was having dependency issues with one or more of the newer clients and not working.   removed the pinnings.