### PR TITLE
Neutron: Use HTTPS to connect to Nova metadata

### DIFF
--- a/roles/neutron-common/templates/etc/neutron/metadata_agent.ini
+++ b/roles/neutron-common/templates/etc/neutron/metadata_agent.ini
@@ -14,7 +14,12 @@ metadata_workers = {{ neutron.metadata_workers }}
 # Network service endpoint type to pull from the keystone catalog
 # endpoint_type = adminURL
 
-nova_metadata_ip = {{ endpoints.nova }}
+# Nova API returns HTTP 300 when these requests are made over HTTPS are run
+# through HA proxy, Send proxies meta-data requests to internal floating IP so
+# they are handled directly by nova-api on active controller.
+nova_metadata_ip = {{ undercloud_floating_ip }}
 nova_metadata_port = 8775
+nova_metadata_protocol = http
+
 
 metadata_proxy_shared_secret = {{ secrets.metadata_proxy_shared_secret }}


### PR DESCRIPTION
Avoids having to introduce an additional firewall rule for Neutron
metadata proxy to function.