### PR TITLE
Cinder backup to swift

### DIFF
--- a/envs/example/swift/group_vars/all.yml
+++ b/envs/example/swift/group_vars/all.yml
@@ -14,6 +14,7 @@ percona:
   replication: False
 
 swift:
+  enabled: True
   disks:
     - sdb
   enabled: True

--- a/roles/cinder-common/handlers/main.yml
+++ b/roles/cinder-common/handlers/main.yml
@@ -6,3 +6,7 @@
     - cinder-api
     - cinder-scheduler
     - cinder-volume
+
+- name: restart cinder backup service
+  service: name=cinder-backup state=restarted must_exist=false
+  when: restart|default('True') and swift.enabled|default('False')

--- a/roles/cinder-common/tasks/main.yml
+++ b/roles/cinder-common/tasks/main.yml
@@ -33,7 +33,9 @@
 - name: cinder config
   template: src={{ item }} dest=/etc/cinder mode=0644
   with_fileglob: ../templates/etc/cinder/*
-  notify: restart cinder services
+  notify:
+    - restart cinder services
+    - restart cinder backup service
 
 - name: cinder sudoer
   template: src=etc/sudoers.d/cinder dest=/etc/sudoers.d/cinder owner=root

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -54,6 +54,10 @@ enabled_backends = {{ cinder.enabled_backends }}
 default_backend = {{ cinder.default_backend }}
 {% endif %}
 
+{% if swift.enabled|bool -%}
+backup_driver = cinder.backup.drivers.swift
+{% endif -%}
+
 {% for backend in cinder.backends %}
 [{{ backend.name }}]
 volume_driver = {{ backend.volume_driver }}

--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -50,5 +50,16 @@
 - name: start cinder-volume
   service: name=cinder-volume state=started
 
+- name: install cinder backup service
+  upstart_service: name=cinder-backup
+                   user=cinder
+                   cmd=/usr/local/bin/cinder-backup
+                   config_dirs=/etc/cinder
+  when: swift.enabled|default("false")|bool
+
+- name: start cinder backup
+  service: name=cinder-backup state=started
+  when: swift.enabled|default("false")|bool
+
 - include: monitoring.yml tags=monitoring,common
   when: monitoring.enabled|default('True')|bool

--- a/roles/cinder-data/tasks/monitoring.yml
+++ b/roles/cinder-data/tasks/monitoring.yml
@@ -13,3 +13,8 @@
                        args='-v cinder-volumes --scheme {{ monitoring.graphite.host_prefix }}'
   notify: restart sensu-client
   when: cinder.fixed_key is not defined or (cinder.fixed_key is defined and "compute" not in group_names)
+
+- name: cinder-backup process check
+  sensu_process_check: service=cinder-backup
+  notify: restart sensu-client
+


### PR DESCRIPTION
if swift.enabled is true, the cinder-common and cinder-control roles will now setup cinder backup with swift as the backend.