### PR TITLE
Update swift keystoneauth options (1.2.x)

### DIFF
--- a/roles/swift-proxy/templates/etc/swift/proxy-server.conf
+++ b/roles/swift-proxy/templates/etc/swift/proxy-server.conf
@@ -50,7 +50,7 @@ use = egg:swift#name_check
 use = egg:swift#list_endpoints
 
 [filter:keystoneauth]
-operator_roles = Member,admin
+operator_roles = Member,_member_,admin
 reseller_prefix =
 use = egg:swift#keystoneauth
 
@@ -85,13 +85,12 @@ use = egg:swift#dlo
 
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+identity_uri = https://{{ endpoints.keystone }}:35358/
 auth_uri = https://{{ endpoints.keystone }}:5001/
-auth_host = {{ endpoints.keystone }}
-auth_port = 5001
 admin_password = {{ secrets.service_password }}
-auth_protocol = https
 admin_tenant_name = service
 admin_user = swift
 cache = swift.cache
 include_service_catalog = False
-cafile = "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"
+delay_auth_decision = true
+cafile = {{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}


### PR DESCRIPTION
In our previous releases, we were not using keystoneauth to validate
user role, so anybody with a valid token was allowed to use Swift. Now
we'll allow _member_ in, to match that functionality.

Also update the authtoken config to remove the old format of urls.

Remove the quotes on the cert file, as this seems to trip up requests.

(cherry picked from commit c8b8197a8ce29ee5c7ac99d64608cd4dcaf9bc76)