### PR TITLE
Making change of ipmi state easier

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -442,6 +442,7 @@ percona:
 common:
   ipmi:
     enabled: false
+    state: probe
 
 heat:
   enabled: False

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -8,6 +8,8 @@ common:
   ipmi:
     enabled: True
     serial_console: ttyS1
+    state: probe
+    baud_rate: 115200
   python_extra_packages: []
   ssh_private_keys: []
   ssh:

--- a/roles/common/tasks/ipmi.yml
+++ b/roles/common/tasks/ipmi.yml
@@ -6,9 +6,9 @@
   apt: pkg=ipmitool
 
 - name: load kernel ipmi modules
-  modprobe: name={{ item }} state=probe
+  modprobe: name={{ item }} state={{ common.ipmi.state }}
   with_items:
     - ipmi_devintf
     - ipmi_si
 
-- include: serial-console.yml tty={{ common.ipmi.serial_console }} baud_rate=115200
+- include: serial-console.yml tty={{ common.ipmi.serial_console }} baud_rate={{ common.ipmi.baud_rate }}


### PR DESCRIPTION
Softlayer builds fail when ipmi state is __probe__ so we always change to __absent__ before deploy. This makes it easier to set in defaults without having to edit code and worrying about committing it :smile: 
Also threw ___baud_rate___ in to the role defaults since it looked lonely by itself in the task