### PR TITLE
Get juno working again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 python-novaclient
 python-neutronclient
 python-keystoneclient
-python-glanceclient
+python-glanceclient<=0.19.0
 python-cinderclient
 oslo.utils
 tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-python-novaclient
-python-neutronclient
+python-novaclient<2.27.0
+python-neutronclient==2.6.0
 python-keystoneclient
 python-glanceclient<=0.19.0
 python-cinderclient

--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -3,8 +3,8 @@ client:
   self_signed_cert: false
   names:
     - python-keystoneclient
-    - python-glanceclient
-    - python-novaclient
+    - python-glanceclient<1.0.0
+    - python-novaclient<2.27.0
     - python-neutronclient
     - python-cinderclient==1.1.1
     - python-heatclient

--- a/roles/openstack-package/defaults/main.yml
+++ b/roles/openstack-package/defaults/main.yml
@@ -1,4 +1,4 @@
-openstack_package_version: 10.0-bbc72
+openstack_package_version: 10.0-bbc110
 openstack_package:
   package_name: 'openstack-{{ project_name }}-{{ openstack_package_version }}'
   rootwrap: "{{ rootwrap|default(False)|bool }}"


### PR DESCRIPTION
This tries to pull in a new package to get nimble working, but in order to do that it has to deal with some other changes that have happened in pip requirements since the last time we built, so this requires pinning some versions.