### PR TITLE
Fixed README.md to include sourcing of mkvirtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ up a `virtualenv` for ursula.
 ```bash
 $ pip install virtualenvwrapper
 $ mkvirtualenv ursula
+$ source /usr/local/bin/virtualenvwrapper.sh
+```
+
+You will want to add `source /usr/local/bin/virtualenvwrapper.sh` to your shell startup file, changing the path to virtualenvwrapper.sh
+depending on where it was installed by pip.
+
+```bash
+echo " " >> .bash_profile (for OSX; .bashrc for various linux flavors)
+echo "#sourcing statement for virtualenvwrapper" >> .bash_profile
+echo "source /usr/local/bin/virtualenvwrapper.sh" >> .bash_profile
 ```
 
 From now on to work with ursula you can run `$ workon ursula` to

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -102,13 +102,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     workstation_config.vm.provider "libvirt" do |v|
       v.memory = 1024
     end
+     config.vm.provision :shell, path: "bootstrap.sh"
     if File.exist?("#{ENV['HOME']}/.stackrc")
       workstation_config.vm.provision "file", source: "~/.stackrc", destination: ".stackrc"
-    end
-    workstation_config.vm.provision "ansible" do |ansible|
-      ansible.playbook = "playbooks/vagrant/predeploy.yml"
-      ansible.sudo = true
-      ansible.groups = { "workstation" => ["workstation"] }
     end
   end
 


### PR DESCRIPTION
Added .bashrc or .bash_profile instructions for sourcing /usr/local/bin/virtualenvwrapper.sh in order to use the 
environment created by the mkvirtualenv command. This is necessary to enter the environment.