### PR TITLE
Temporarly pin python-glanceclient

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 python-novaclient
 python-neutronclient
 python-keystoneclient
-python-glanceclient
+python-glanceclient<=0.19.0
 python-cinderclient
 oslo.utils
 tox


### PR DESCRIPTION
python-glanceclient just released 1.0.0 which changes some things
significantly, in a way that breaks tools like shade. Shade is working to
fix it, but until then we need to pin.

https://review.openstack.org/#/c/219005/