### PR TITLE
Updating horizon role for kilo support

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -3,8 +3,8 @@ stack_env: example
 
 country_code: US
 
-#openstack_install_method: 'source'
-openstack_install_method: 'package'
+openstack_install_method: 'source'
+#openstack_install_method: 'package'
 
 primary_interface: 'ansible_eth0'
 primary_ip: "{{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ tox
 pep8
 -e git://github.com/willthames/ansible-lint.git@9777f20aafd4be8706c9ce17005c981cb19a6a25#egg=ansible-lint
 -e git://github.com/blueboxgroup/ansible.git@stable-1.9-bb#egg=ansible
--e git://github.com/blueboxgroup/ursula-cli.git@ansible-1.9#egg=ursula-cli
+-e git://github.com/blueboxgroup/ursula-cli.git#egg=ursula-cli
 -e git://github.com/openstack-infra/shade.git@ab1c566cb8afbf477492180e2cc8257817a06893#egg=shade

--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -10,7 +10,7 @@ cinder:
   create_vg: true
 
   source:
-    rev: '7b1d7a31335bd8723551c9af5c270927ad830c3f'
+    rev: 'stable/kilo'
   package:
     console_scripts:
       - cinder-all

--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -17,7 +17,7 @@ glance:
   show_multiple_locations: True
 
   source:
-    rev: '0e355462833feeaa6f3124fda4bd5ff7064c8512'
+    rev: 'stable/kilo'
   package:
     console_scripts:
       - glance-api

--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -3,7 +3,7 @@ heat:
   enabled: False
 
   source:
-    rev: 'cbef40647e35cc065e36ee86b4ca1305676f4c1b'
+    rev: 'stable/kilo'
   package:
     console_scripts:
       - heat-api

--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -6,4 +6,4 @@ horizon:
   virtualenv: /opt/stack/horizon/.venv
   session_timeout: 5400
   source:
-    rev: 'stable/kilo'
+    rev: 'kilo-bbg'

--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -2,7 +2,7 @@
 horizon:
   logo_url: https://s3.amazonaws.com/horizon-branding/bluebox-u1.1.x.png
   favicon_url: https://s3.amazonaws.com/horizon-branding/bluebox.ico
-  keystone_api_version: 2.0
+  keystone_api_version: 3
   virtualenv: /opt/stack/horizon/.venv
   session_timeout: 5400
   source:

--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -6,4 +6,4 @@ horizon:
   virtualenv: /opt/stack/horizon/.venv
   session_timeout: 5400
   source:
-    rev: e5a9037d2ff5f2fbd5bde8e073e90b8d290994d3
+    rev: 'stable/kilo'

--- a/roles/horizon/meta/main.yml
+++ b/roles/horizon/meta/main.yml
@@ -3,7 +3,7 @@ dependencies:
   - role: monitoring-common
   - role: openstack-source
     project_name: horizon
-    git_mirror: "https://github.com/openstack"
+    git_mirror: "https://github.com/blueboxgroup"
     project_rev: "{{ horizon.source.rev }}"
     virtualenv: "{{ horizon.virtualenv }}"
     python_requirements:

--- a/roles/horizon/meta/main.yml
+++ b/roles/horizon/meta/main.yml
@@ -3,7 +3,7 @@ dependencies:
   - role: monitoring-common
   - role: openstack-source
     project_name: horizon
-    git_mirror: "https://github.com/blueboxgroup"
+    git_mirror: "https://github.com/openstack"
     project_rev: "{{ horizon.source.rev }}"
     virtualenv: "{{ horizon.virtualenv }}"
     python_requirements:

--- a/roles/horizon/meta/main.yml
+++ b/roles/horizon/meta/main.yml
@@ -7,7 +7,9 @@ dependencies:
     project_rev: "{{ horizon.source.rev }}"
     virtualenv: "{{ horizon.virtualenv }}"
     python_requirements:
+      - { name: functools32 }
       - { name: python-memcached, version: '1.48' }
+      - { name: stevedore, version: '1.5.0' }
     additional_handlers: [ "compress horizon assets" ]
     when: openstack_install_method == 'source'
   - role: openstack-package

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -104,7 +104,6 @@
     - "{{ horizon.virtualenv }}/bin/django-admin.py collectstatic --noinput"
     - "{{ horizon.virtualenv }}/bin/django-admin.py compress"
   when: openstack_install_method == 'source'
-  tags: FIXME
 
 - name: ensure apache started
   service: name=apache2 state=started

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -104,6 +104,7 @@
     - "{{ horizon.virtualenv }}/bin/django-admin.py collectstatic --noinput"
     - "{{ horizon.virtualenv }}/bin/django-admin.py compress"
   when: openstack_install_method == 'source'
+  tags: FIXME
 
 - name: ensure apache started
   service: name=apache2 state=started

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -92,7 +92,7 @@
   shell: "{{ item }}"
   with_items:
     - "{{ 'horizon'|ursula_package_path(openstack_package_version) }}/bin/django-admin.py collectstatic --noinput"
-    - "{{ 'horizon'|ursula_package_path(openstack_package_version) }}/bin/django-admin.py compress"
+#    - "{{ 'horizon'|ursula_package_path(openstack_package_version) }}/bin/django-admin.py compress"
   when: openstack_install_method == 'package'
 
 - name: gather static assets from openstack source install

--- a/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
+++ b/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
@@ -161,7 +161,8 @@ OPENSTACK_HYPERVISOR_FEATURES = {
 # services provided by quantum.  Currently only the load balancer service
 # is available.
 OPENSTACK_NEUTRON_NETWORK = {
-    'enable_lb': False
+    'enable_lb': False,
+    'enable_quotas': True
 }
 
 # OPENSTACK_ENDPOINT_TYPE specifies the endpoint type to use for the endpoints

--- a/roles/ironic-common/defaults/main.yml
+++ b/roles/ironic-common/defaults/main.yml
@@ -18,7 +18,7 @@ ironic:
     - pxe_ipmitool
 
   source:
-    rev: '53171f75a64a26dcec91facbdec95b2ed7f74338'
+    rev: 'stable/kilo'
   package:
     console_scripts:
       - ironic-api

--- a/roles/keystone/defaults/main.yml
+++ b/roles/keystone/defaults/main.yml
@@ -6,7 +6,7 @@ keystone:
   public_workers: 5
 
   source:
-    rev: '8a7282bebd1ebfb92d9ccd87f85b8490a89da4e0'
+    rev: 'stable/kilo'
   package:
     console_scripts:
       - keystone-manage

--- a/roles/keystone/meta/main.yml
+++ b/roles/keystone/meta/main.yml
@@ -10,6 +10,7 @@ dependencies:
     # is this even required anymore with Juno?
     python_requirements:
       - { name: babel, version: "{{ keystone.babel_version }}" }
+      - { name: functools32 }
     when: openstack_install_method == 'source'
   - role: openstack-package
     project_name: keystone

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -21,7 +21,7 @@ neutron:
     envs: []
 
   source:
-    rev: '679246d7280e9fb374f8db0972b21b3653724c42'
+    rev: 'stable/kilo'
   package:
     console_scripts:
       - neutron-cisco-apic-host-agent

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -24,15 +24,15 @@ neutron:
     rev: '679246d7280e9fb374f8db0972b21b3653724c42'
   package:
     console_scripts:
-      - neutron-check-nsx-config
-      - neutron-cisco-cfg-agent
+      - neutron-cisco-apic-host-agent
+      - neutron-cisco-apic-service-agent
       - neutron-db-manage
       - neutron-debug
       - neutron-dhcp-agent
       - neutron-hyperv-agent
       - neutron-ibm-agent
+      - neutron-keepalived-state-change
       - neutron-l3-agent
-      - neutron-lbaas-agent
       - neutron-linuxbridge-agent
       - neutron-metadata-agent
       - neutron-metering-agent
@@ -40,31 +40,30 @@ neutron:
       - neutron-nec-agent
       - neutron-netns-cleanup
       - neutron-ns-metadata-proxy
-      - neutron-nsx-manage
       - neutron-nvsd-agent
-      - neutron-ofagent-agent
       - neutron-openvswitch-agent
       - neutron-ovs-cleanup
+      - neutron-ovsvapp-agent
+      - neutron-restproxy-agent
       - neutron-rootwrap
+      - neutron-rootwrap-daemon
       - neutron-rootwrap-xen-dom0
-      - neutron-ryu-agent
       - neutron-sanity-check
       - neutron-server
       - neutron-sriov-nic-agent
       - neutron-usage-audit
-      - neutron-vpn-agent
 
   package:
     console_scripts:
-      - neutron-check-nsx-config
-      - neutron-cisco-cfg-agent
+      - neutron-cisco-apic-host-agent
+      - neutron-cisco-apic-service-agent
       - neutron-db-manage
       - neutron-debug
       - neutron-dhcp-agent
       - neutron-hyperv-agent
       - neutron-ibm-agent
+      - neutron-keepalived-state-change
       - neutron-l3-agent
-      - neutron-lbaas-agent
       - neutron-linuxbridge-agent
       - neutron-metadata-agent
       - neutron-metering-agent
@@ -72,19 +71,18 @@ neutron:
       - neutron-nec-agent
       - neutron-netns-cleanup
       - neutron-ns-metadata-proxy
-      - neutron-nsx-manage
       - neutron-nvsd-agent
-      - neutron-ofagent-agent
       - neutron-openvswitch-agent
       - neutron-ovs-cleanup
+      - neutron-ovsvapp-agent
+      - neutron-restproxy-agent
       - neutron-rootwrap
+      - neutron-rootwrap-daemon
       - neutron-rootwrap-xen-dom0
-      - neutron-ryu-agent
       - neutron-sanity-check
       - neutron-server
       - neutron-sriov-nic-agent
       - neutron-usage-audit
-      - neutron-vpn-agent
 
   logs:
     - paths:

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -34,12 +34,12 @@ nova:
     - virt-top
   driver:
     docker:
-      rev: 2f23a09ba49bfafedc712b82613417da7147c5a3
+      rev: 'stable/kilo'
       git_mirror: https://github.com/stackforge/nova-docker.git
       dest: /opt/stack/novadocker
 
   source:
-    rev: 'd67ce79795feb2dcc8e1f90e50a17f866febff69'
+    rev: 'stable/kilo'
     git_mirror: https://github.com/blueboxgroup
   package:
     console_scripts:

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -48,8 +48,6 @@ nova:
       - nova-api-ec2
       - nova-api-metadata
       - nova-api-os-compute
-      - nova-baremetal-deploy-helper
-      - nova-baremetal-manage
       - nova-cells
       - nova-cert
       - nova-compute
@@ -75,8 +73,6 @@ nova:
       - nova-api-ec2
       - nova-api-metadata
       - nova-api-os-compute
-      - nova-baremetal-deploy-helper
-      - nova-baremetal-manage
       - nova-cells
       - nova-cert
       - nova-compute

--- a/roles/openstack-package/defaults/main.yml
+++ b/roles/openstack-package/defaults/main.yml
@@ -1,4 +1,4 @@
-openstack_package_version: 10.0-bbc72
+openstack_package_version: 11.0-bbc73
 openstack_package:
   package_name: 'openstack-{{ project_name }}-{{ openstack_package_version }}'
   rootwrap: "{{ rootwrap|default(False)|bool }}"

--- a/roles/openstack-source/handlers/main.yml
+++ b/roles/openstack-source/handlers/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: "python requirements for {{ project_name }}"
+  pip:
+    name: "{{ item.name }}"
+    version: "{{ item.version|default(omit) }}"
+    virtualenv: "{{ virtualenv|default(omit) }}"
+    extra_args: "-i {{ openstack_source.pypi_mirror }}"
+  with_items: python_requirements
+  when: python_requirements is defined
+
 - name: "pip install {{ project_name }}"
   pip:
     name: "/opt/stack/{{ project_name }}"
@@ -10,7 +19,6 @@
   delay: 10
   notify:
     - update ca-certs
-  when: virtualenv is not defined
 
 - name: update ca-certs
   command: "update-ca-certificates"

--- a/roles/openstack-source/tasks/main.yml
+++ b/roles/openstack-source/tasks/main.yml
@@ -8,6 +8,7 @@
   until: git_result|success
   retries: 3
   notify:
+    - "python requirements for {{ project_name }}"
     - "pip install {{ project_name }}"
     - "ensure project config directory exists"
     - "stat rootwrap.d"
@@ -15,16 +16,5 @@
     - "setup {{ project_name }} rootwrap"
     - "restart {{ project_name }} services"
     - "additional handlers"
-
-# This happens after the git clone as one may locate the virtualenv
-# in the same directory as the git clone path. In this scenario, git will
-# not clone into a non-empty directory.
-- name: "python requirements for {{ project_name }}"
-  pip:
-    name: "{{ item.name }}"
-    version: "{{ item.version|default(omit) }}"
-    virtualenv: "{{ virtualenv|default(omit) }}"
-  with_items: python_requirements
-  when: python_requirements is defined
 
 - meta: flush_handlers

--- a/roles/openstack-source/tasks/main.yml
+++ b/roles/openstack-source/tasks/main.yml
@@ -22,7 +22,7 @@
 - name: "python requirements for {{ project_name }}"
   pip:
     name: "{{ item.name }}"
-    version: "{{ item.version }}"
+    version: "{{ item.version|default(omit) }}"
     virtualenv: "{{ virtualenv|default(omit) }}"
   with_items: python_requirements
   when: python_requirements is defined

--- a/roles/swift-common/defaults/main.yml
+++ b/roles/swift-common/defaults/main.yml
@@ -6,7 +6,7 @@ swift:
   allow_versions: False
 
   source:
-    rev: '4765537cba6a6970110953f11f4e1b419d0730d3'
+    rev: 'stable/kilo'
   package:
     console_scripts:
       - swift-account-audit


### PR DESCRIPTION
Should set keystone_api_version default to __3__ for kilo. Enabling quotas for neutron also solves an issue we ran into earlier, though our patch won't break either way now. https://github.com/zrs233/horizon/commit/b995cd4964b6a498cb35d55951d53be5bea0c111#diff-9582d630fda591281a820da973eaac94L114