### PR TITLE
Fix rbd store user, add image direct url

### DIFF
--- a/roles/glance/templates/etc/glance/glance-api.conf
+++ b/roles/glance/templates/etc/glance/glance-api.conf
@@ -36,6 +36,10 @@ container_formats = {{ glance.container_formats }}
 
 show_multiple_locations = {{ glance.show_multiple_locations }}
 
+{% if glance.store_ceph|bool %}
+show_image_direct_url = True
+{% endif %}
+
 [glance_store]
 {% if glance.store_swift|bool %}
 stores = glance.store.swift.Store,
@@ -53,7 +57,7 @@ stores = glance.store.rbd.Store,
 rbd_store_ceph_conf = /etc/ceph/ceph.conf
 rbd_store_chunk_size = {{ glance.rbd_store_chunk_size }}
 rbd_store_pool = images
-rbd_store_user = service:glance
+rbd_store_user = glance
 
 {% else %}
 stores = glance.store.filesystem.Store,


### PR DESCRIPTION
During our last deploy, we identified a few bugs in `glance-api.conf`.
This PR is for ceph and corresponds to IDS epic 97391.