### PR TITLE
Don't mark external as shared

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -150,7 +150,7 @@ neutron:
       segmentation_id: 256
       provider_physical_network: ~
     - name: external
-      shared: true
+      shared: false
       external: true
       network_type: local
       segmentation_id: ~


### PR DESCRIPTION
This keeps the external network from showing up when building instances.