### PR TITLE
Don't mark external as shared (1.3.x)

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -143,7 +143,7 @@ neutron:
       segmentation_id: 256
       provider_physical_network: ~
     - name: external
-      shared: true
+      shared: false
       external: true
       network_type: local
       segmentation_id: ~


### PR DESCRIPTION
This keeps the external network from showing up when building instances.

(cherry picked from commit 3c1c4d95e5c271bf409dbd352c9328ae6ec42ad2)