### PR TITLE
Updating horizon role for kilo support

### DIFF
--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -2,7 +2,7 @@
 horizon:
   logo_url: https://s3.amazonaws.com/horizon-branding/bluebox-u1.1.x.png
   favicon_url: https://s3.amazonaws.com/horizon-branding/bluebox.ico
-  keystone_api_version: 2.0
+  keystone_api_version: 3
   virtualenv: /opt/stack/horizon/.venv
   session_timeout: 5400
   source:

--- a/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
+++ b/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
@@ -161,7 +161,8 @@ OPENSTACK_HYPERVISOR_FEATURES = {
 # services provided by quantum.  Currently only the load balancer service
 # is available.
 OPENSTACK_NEUTRON_NETWORK = {
-    'enable_lb': False
+    'enable_lb': False,
+    'enable_quotas': True
 }
 
 # OPENSTACK_ENDPOINT_TYPE specifies the endpoint type to use for the endpoints


### PR DESCRIPTION
Should set keystone_api_version default to __3__ for kilo. Enabling quotas for neutron also solves an issue we ran into earlier, though our patch won't break either way now. zrs233/horizon@b995cd4#diff-9582d630fda591281a820da973eaac94L114