### PR TITLE
Fix deprecated location for default_store

### DIFF
--- a/roles/glance/templates/etc/glance/glance-api.conf
+++ b/roles/glance/templates/etc/glance/glance-api.conf
@@ -2,14 +2,6 @@
 debug = {{ glance.logging.debug }}
 verbose = {{ glance.logging.verbose }}
 
-{% if glance.store_swift|bool %}
-default_store = swift
-{% elif glance.store_ceph|bool %}
-default_store = rbd
-{% else %}
-default_store = file
-{% endif %}
-
 bind_host = 0.0.0.0
 bind_port = 9292
 
@@ -50,6 +42,7 @@ swift_store_user = service:glance
 swift_store_key {{ secrets.service_password }}
 swift_store_create_container_on_put = True
 
+default_store = swift
 {% elif glance.store_ceph|bool %}
 stores = glance.store.rbd.Store,
          glance.store.http.Store
@@ -59,11 +52,14 @@ rbd_store_chunk_size = {{ glance.rbd_store_chunk_size }}
 rbd_store_pool = images
 rbd_store_user = glance
 
+default_store = rbd
 {% else %}
 stores = glance.store.filesystem.Store,
          glance.store.http.Store
 
 filesystem_store_datadir = /var/lib/glance/images/
+
+default_store = file
 {% endif %}
 
 [keystone_authtoken]


### PR DESCRIPTION
Putting default_store in the [DEFAULT] section has been deprecated since Juno. We verified this was causing failures in starting the glance service with ceph or swift enabled. Moved to the correct location under [glance_store].