### PR TITLE
Don't pin requests, it breaks clients (1.2.x)

### DIFF
--- a/roles/common/tasks/ssl.yml
+++ b/roles/common/tasks/ssl.yml
@@ -21,7 +21,7 @@
   when: ansible_distribution_version == "12.04"
 
 - name: pip install requests - precise
-  pip: name=requests version=1.2.3
+  pip: name=requests state=latest
   when: ansible_distribution_version == "12.04"
 
 - name: force our ssl cert for python libs on precise


### PR DESCRIPTION
With the pinning, clients aren't able to auth to keystone. Just grab the
latest one.

(cherry picked from commit 6299c8850dace0a24b3edd752fd62335467e6350)