### PR TITLE
Added Ceilometer & MongoDB

### DIFF
--- a/envs/example/allinone/hosts
+++ b/envs/example/allinone/hosts
@@ -7,6 +7,9 @@ allinone
 [db]
 allinone
 
+[mongo_db]
+allinone
+
 [compute]
 allinone
 

--- a/envs/example/ci/group_vars/all.yml
+++ b/envs/example/ci/group_vars/all.yml
@@ -1,0 +1,21 @@
+---
+stack_env: example_ci
+floating_ip: 172.16.0.100
+
+xtradb:
+  sst_auth_password: asdf
+
+percona:
+  replication: False
+
+ceilometer:
+  enabled: True
+  logging:
+    debug: True
+    verbose: True
+
+heat:
+  enabled: True
+  logging:
+    debug: True
+    verbose: True

--- a/envs/example/ci/hosts
+++ b/envs/example/ci/hosts
@@ -5,6 +5,13 @@ db2.example.com
 [db_arbiter]
 bar.example.com
 
+[mongo_db]
+db.example.com
+db2.example.com
+
+[mongo_arbiter]
+bar.example.com
+
 [controller]
 foo.example.com
 

--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -12,6 +12,7 @@ undercloud_cidr: 10.230.7.0/24
 
 secrets:
   db_password:      asdf
+  mongodb_password: asdf
   service_password: asdf
   rabbit_password:  asdf
   admin_password:   asdf
@@ -21,6 +22,7 @@ secrets:
   horizon_secret_key:           asdf
   glance_sync:      ADQ64XUQLUWH75M634RVBLP55RKPGGOWG
   monitor_password: asdf
+  telemetry_secret: asdf
 
 fqdn: openstack.example.com
 swift_fqdn: "{{ fqdn }}"
@@ -36,6 +38,9 @@ rabbitmq:
   user: openstack
   cluster: false
 
+mongodb:
+  port: 27017
+
 memcached:
   memory: 64
   port: 11211
@@ -50,6 +55,7 @@ swift:
 endpoints:
   main:     "{{ fqdn }}"
   db:       "{{ undercloud_floating_ip }}"
+  mongodb:  "{{ undercloud_floating_ip }}"
   rabbit:   "{{ undercloud_floating_ip }}"
   keystone: "{{ fqdn }}"
   nova:     "{{ fqdn }}"
@@ -61,9 +67,10 @@ endpoints:
   cinderv2: "{{ fqdn }}"
   heat:     "{{ fqdn }}"
   heat-cfn: "{{ fqdn }}"
-  ironic: "{{ fqdn }}"
-  swift: "{{ swift.haproxy_vip }}"
-  magnum: "{{ fqdn }}"
+  ceilometer: "{{ fqdn }}"
+  ironic:   "{{ fqdn }}"
+  swift:    "{{ swift.haproxy_vip }}"
+  magnum:   "{{ fqdn }}"
   identity_uri: https://{{ fqdn }}:35358
   auth_uri: https://{{ fqdn }}:5001/v2.0
 
@@ -261,6 +268,9 @@ keystone:
     - name: heat
       password: "{{ secrets.service_password }}"
       tenant: service
+    - name: ceilometer
+      password: "{{ secrets.service_password }}"
+      tenant: service
     - name: ironic
       password: "{{ secrets.service_password }}"
       tenant: service
@@ -295,15 +305,21 @@ keystone:
     - user: neutron
       tenant: service
       role: service
-    - user: cinder
-      tenant: service
-      role: service
     - user: neutron
       tenant: service
       role: admin
+    - user: cinder
+      tenant: service
+      role: service
     - user: heat
       tenant: service
       role: service
+    - user: ceilometer
+      tenant: service
+      role: service
+    - user: ceilometer
+      tenant: service
+      role: admin
     - user: magnum
       tenant: service
       role: service
@@ -371,6 +387,12 @@ keystone:
       public_url: https://{{ endpoints.main }}:8001/v1
       internal_url: https://{{ endpoints.main }}:8001/v1
       admin_url: https://{{ endpoints.main }}:8001/v1
+    - name: ceilometer
+      type: metering
+      description: 'Telemetry Service'
+      public_url: https://{{ endpoints.main }}:8889
+      internal_url: https://{{ endpoints.main }}:8889
+      admin_url: https://{{ endpoints.main }}:8889
     - name: ironic
       type: baremetal
       description: 'Ironic bare metal provisioning service'
@@ -498,6 +520,12 @@ common:
 
 heat:
   enabled: False
+  logging:
+    debug: True
+    verbose: True
+
+ceilometer:
+  enabled: True
   logging:
     debug: True
     verbose: True

--- a/envs/example/standard/hosts
+++ b/envs/example/standard/hosts
@@ -10,7 +10,14 @@ controller2
 controller1
 controller2
 
+[mongo_db]
+controller1
+controller2
+
 [db_arbiter]
+compute1
+
+[mongo_arbiter]
 compute1
 
 [compute]

--- a/roles/apt-repos/defaults/main.yml
+++ b/roles/apt-repos/defaults/main.yml
@@ -36,3 +36,6 @@ apt_repos:
   ceph:
     repo: 'http://ceph.com/debian-'
     key_url: 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  mongodb:
+    repo: 'http://repo.mongodb.org/apt/ubuntu'
+    key_url: 'https://docs.mongodb.org/10gen-gpg-key.asc'

--- a/roles/ceilometer-common/defaults/main.yml
+++ b/roles/ceilometer-common/defaults/main.yml
@@ -1,0 +1,61 @@
+---
+ceilometer:
+  enabled: False
+  source:
+    rev: 'stable/kilo'
+    python_dependencies:
+      - { name: pymongo, version: '3.0.3' }
+      - { name: functools32 }
+      - { name: simplegeneric }
+  alternatives:
+    - ceilometer-api
+    - ceilometer-collector
+    - ceilometer-agent-notification
+    - ceilometer-agent-central
+    - ceilometer-alarm-evaluator
+    - ceilometer-alarm-notifier
+    - ceilometer-agent-compute
+  purge_frequency: 86400
+  mongodb_database: ceilometer
+  mongodb_user: ceilometer
+  mongodb_password: "{{ secrets.mongodb_password }}"
+  logs:
+    - paths:
+        - /var/log/ceilometer/api.log
+      fields:
+        type: openstack
+        tags: ceilometer,ceilometer-api
+    - paths:
+        - /var/log/ceilometer/agent-notification.log
+      fields:
+        type: openstack
+        tags: ceilometer,ceilometer-agent-notification
+    - paths:
+        - /var/log/ceilometer/alarm-evaluator.log
+      fields:
+        type: openstack
+        tags: ceilometer,ceilometer-alarm-evaluator
+    - paths:
+        - /var/log/ceilometer/alarm-notifier.log
+      fields:
+        type: openstack
+        tags: ceilometer,ceilometer-alarm-notifier
+    - paths:
+        - /var/log/ceilometer/central.log
+      fields:
+        type: openstack
+        tags: ceilometer,ceilometer-agent-central
+    - paths:
+        - /var/log/ceilometer/collector.log
+      fields:
+        type: openstack
+        tags: ceilometer,ceilometer-collector
+    - paths:
+        - /var/log/ceilometer/compute.log
+      fields:
+        type: openstack
+        tags: ceilometer,ceilometer-agent-compute
+  logging:
+    debug: False
+    verbose: True
+  cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"

--- a/roles/ceilometer-common/handlers/main.yml
+++ b/roles/ceilometer-common/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+- name: restart ceilometer services
+  service: name={{ item }} state=restarted must_exist=false
+  when: restart|default('True')
+  with_items:
+    - ceilometer-api
+    - ceilometer-collector
+    - ceilometer-agent-notification
+    - ceilometer-agent-central
+    - ceilometer-alarm-evaluator
+    - ceilometer-alarm-notifier
+    - ceiloemter-agent-compute

--- a/roles/ceilometer-common/meta/main.yml
+++ b/roles/ceilometer-common/meta/main.yml
@@ -1,0 +1,16 @@
+---
+dependencies:
+  - role: monitoring-common
+  - role: logging-config
+    service: ceilometer
+    logdata: "{{ ceilometer.logs }}"
+  - role: openstack-source
+    project_name: ceilometer
+    project_rev: "{{ ceilometer.source.rev }}"
+    alternatives: "{{ ceilometer.alternatives }}"
+    python_dependencies: "{{ ceilometer.source.python_dependencies }}"
+    when: openstack_install_method == 'source'
+  - role: openstack-package
+    project_name: ceilometer
+    alternatives: "{{ ceilometer.alternatives }}"
+    when: openstack_install_method == 'package'

--- a/roles/ceilometer-common/tasks/logging.yml
+++ b/roles/ceilometer-common/tasks/logging.yml
@@ -1,0 +1,9 @@
+---
+- name: set up log rotation for ceilometer
+  logrotate: name=ceilometer path=/var/log/ceilometer/*.log
+  args:
+    options:
+      - daily
+      - missingok
+      - rotate 7
+      - compress

--- a/roles/ceilometer-common/tasks/main.yml
+++ b/roles/ceilometer-common/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: create ceilometer user
+  user: name=ceilometer comment=ceilometer shell=/bin/false system=yes home=/nonexistent
+        createhome=no
+
+- name: create ceilometer environment.d directory
+  file: dest=/etc/ceilometer/environment.d state=directory
+
+- name: create ceilometer log directory
+  file: dest=/var/log/ceilometer state=directory mode=0755 owner=ceilometer
+
+- name: create ceilometer cache dir
+  file: dest=/var/cache/ceilometer state=directory mode=0700
+        owner=ceilometer group=ceilometer
+
+- name: ceilometer config
+  template: src=etc/ceilometer/{{ item }} dest=/etc/ceilometer/{{ item }} mode=0644
+  with_items:
+    - ceilometer.conf
+    - policy.json
+    - api_paste.ini
+    - event_definitions.yaml
+    - event_pipeline.yaml
+    - pipeline.yaml
+
+- include: logging.yml
+  tags:
+    - logrotate
+    - logging
+  when: logging.enabled|default('True')|bool

--- a/roles/ceilometer-common/templates/etc/ceilometer/api_paste.ini
+++ b/roles/ceilometer-common/templates/etc/ceilometer/api_paste.ini
@@ -1,0 +1,14 @@
+# Ceilometer API WSGI Pipeline
+# Define the filters that make up the pipeline for processing WSGI requests
+# Note: This pipeline is PasteDeploy's term rather than Ceilometer's pipeline
+# used for processing samples
+
+# Remove authtoken from the pipeline if you don't want to use keystone authentication
+[pipeline:main]
+pipeline = authtoken api-server
+
+[app:api-server]
+paste.app_factory = ceilometer.api.app:app_factory
+
+[filter:authtoken]
+paste.filter_factory = keystonemiddleware.auth_token:filter_factory

--- a/roles/ceilometer-common/templates/etc/ceilometer/ceilometer.conf
+++ b/roles/ceilometer-common/templates/etc/ceilometer/ceilometer.conf
@@ -1,0 +1,72 @@
+[DEFAULT]
+debug = {{ ceilometer.logging.debug }}
+verbose = {{ ceilometer.logging.verbose }}
+log_dir = /var/log/ceilometer
+policy_file = /etc/ceilometer/policy.json
+rpc_backend = ceilometer.openstack.common.rpc.impl_kombu
+
+[oslo_messaging_rabbit]
+{% macro rabbitmq_hosts() -%}
+{% for host in groups['controller'] -%}
+   {% if loop.last -%}
+{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }}
+   {%- else -%}
+{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }},
+   {%- endif -%}
+{% endfor -%}
+{% endmacro -%}
+
+{% if rabbitmq.cluster -%}
+rabbit_hosts = {{ rabbitmq_hosts() }}
+{% else -%}
+rabbit_host = {{ endpoints.rabbit }}
+rabbit_port = 5672
+{% endif -%}
+rabbit_userid = {{ rabbitmq.user }}
+rabbit_password = {{ secrets.rabbit_password }}
+
+[database]
+{% macro ceilometer_hosts() -%}
+{% for host in groups['controller'] -%}
+   {% if loop.last -%}
+{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ mongodb.port }}
+   {%- else -%}
+{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ mongodb.port }},
+   {%- endif -%}
+{% endfor -%}
+{% endmacro -%}
+
+connection=mongodb://ceilometer:{{ secrets.mongodb_password }}@{{ ceilometer_hosts() }}/ceilometer?replicaSet=mongoreplica
+metering_time_to_live={{ ceilometer.purge_frequency }}
+
+# If mongodb_replica_set is set, MongoReplicaSetClient will be used instead of MongoClient
+mongodb_replica_set=mongoreplica
+
+[api]
+host = 0.0.0.0
+port = 8888
+
+[keystone_authtoken]
+identity_uri = {{ endpoints.identity_uri }}
+auth_uri = {{ endpoints.auth_uri }}
+admin_tenant_name = service
+admin_user = ceilometer
+admin_password = {{ secrets.service_password }}
+cafile = {{ ceilometer.cafile }}
+signing_dir = /var/cache/ceilometer/api
+
+[clients]
+ca_file = {{ ceilometer.cafile }}
+
+[publisher]
+# Secret value for signing messages. Set value empty if signing is not required to avoid computational overhead.
+telemetry_secret = {{ secrets.telemetry_secret }}
+
+[service_credentials]
+os_auth_url = {{ endpoints.auth_uri }}
+os_username = ceilometer
+os_tenant_name = service
+os_password = {{ secrets.service_password }}
+os_endpoint_type = internalURL
+os_region_name = RegionOne
+os_cacert = {{ ceilometer.cafile }}

--- a/roles/ceilometer-common/templates/etc/ceilometer/event_definitions.yaml
+++ b/roles/ceilometer-common/templates/etc/ceilometer/event_definitions.yaml
@@ -1,0 +1,62 @@
+---
+- event_type: compute.instance.*
+  traits: &instance_traits
+    tenant_id:
+      fields: payload.tenant_id
+    user_id:
+      fields: payload.user_id
+    instance_id:
+      fields: payload.instance_id
+    host:
+      fields: publisher_id
+      plugin:
+        name: split
+        parameters:
+          segment: 1
+          max_split: 1
+    service:
+      fields: publisher_id
+      plugin: split
+    memory_mb:
+      type: int
+      fields: payload.memory_mb
+    disk_gb:
+      type: int
+      fields: payload.disk_gb
+    root_gb:
+      type: int
+      fields: payload.root_gb
+    ephemeral_gb:
+      type: int
+      fields: payload.ephemeral_gb
+    vcpus:
+      type: int
+      fields: payload.vcpus
+    instance_type_id:
+      type: int
+      fields: payload.instance_type_id
+    instance_type:
+      fields: payload.instance_type
+    state:
+      fields: payload.state
+    os_architecture:
+      fields: payload.image_meta.'org.openstack__1__architecture'
+    os_version:
+      fields: payload.image_meta.'org.openstack__1__os_version'
+    os_distro:
+      fields: payload.image_meta.'org.openstack__1__os_distro'
+    launched_at:
+      type: datetime
+      fields: payload.launched_at
+    deleted_at:
+      type: datetime
+      fields: payload.deleted_at
+- event_type: compute.instance.exists
+  traits:
+    <<: *instance_traits
+    audit_period_beginning:
+      type: datetime
+      fields: payload.audit_period_beginning
+    audit_period_ending:
+      type: datetime
+      fields: payload.audit_period_ending

--- a/roles/ceilometer-common/templates/etc/ceilometer/event_pipeline.yaml
+++ b/roles/ceilometer-common/templates/etc/ceilometer/event_pipeline.yaml
@@ -1,0 +1,13 @@
+---
+sources:
+    - name: event_source
+      events:
+          - "*"
+      sinks:
+          - event_sink
+sinks:
+    - name: event_sink
+      transformers:
+      triggers:
+      publishers:
+          - notifier://

--- a/roles/ceilometer-common/templates/etc/ceilometer/pipeline.yaml
+++ b/roles/ceilometer-common/templates/etc/ceilometer/pipeline.yaml
@@ -1,0 +1,30 @@
+---
+sources:
+    - name: meter_source
+      interval: 60
+      meters:
+          - "cpu"
+      sinks:
+          - meter_sink
+    - name: cpu_source
+      interval: 60
+      meters:
+          - "cpu"
+      sinks:
+          - cpu_sink
+sinks:
+    - name: meter_sink
+      transformers:
+      publishers:
+          - notifier://
+    - name: cpu_sink
+      transformers:
+          - name: "rate_of_change"
+            parameters:
+                target:
+                    name: "cpu_util"
+                    unit: "%"
+                    type: "gauge"
+                    scale: "100.0 / (10**9 * (resource_metadata.cpu_number or 1))"
+      publishers:
+          - notifier://

--- a/roles/ceilometer-common/templates/etc/ceilometer/policy.json
+++ b/roles/ceilometer-common/templates/etc/ceilometer/policy.json
@@ -1,0 +1,3 @@
+{
+    "context_is_admin":  [["role:admin"]]
+}

--- a/roles/ceilometer-control/meta/main.yml
+++ b/roles/ceilometer-control/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: ceilometer-common

--- a/roles/ceilometer-control/tasks/main.yml
+++ b/roles/ceilometer-control/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+- name: permit access to ceilometer
+  ufw: rule=allow to_port=8889 proto=tcp
+
+- name: install ceilometer controller services
+  upstart_service: name={{ item }}
+                   user=ceilometer
+                   cmd=/usr/local/bin/{{ item }}
+  with_items:
+    - ceilometer-api
+    - ceilometer-collector
+    - ceilometer-agent-notification
+    - ceilometer-agent-central
+    - ceilometer-alarm-evaluator
+    - ceilometer-alarm-notifier
+  notify: restart ceilometer services
+
+- name: create ceilometer user in mongodb
+  mongodb_user: database={{ ceilometer.mongodb_database }} name={{ ceilometer.mongodb_user }} password={{ ceilometer.mongodb_password }} roles='readWrite,dbAdmin' state=present
+  when: inventory_hostname in groups['controller'][0]
+
+- meta: flush_handlers
+
+- name: start ceilometer services
+  service: name={{ item }} state=started
+  with_items:
+    - ceilometer-api
+    - ceilometer-collector
+    - ceilometer-agent-notification
+    - ceilometer-agent-central
+    - ceilometer-alarm-evaluator
+    - ceilometer-alarm-notifier
+
+- include: monitoring.yml
+  tags:
+    - monitoring
+    - common
+  when: monitoring.enabled|default('True')|bool

--- a/roles/ceilometer-control/tasks/monitoring.yml
+++ b/roles/ceilometer-control/tasks/monitoring.yml
@@ -1,0 +1,21 @@
+---
+- name: ceilometer-api check
+  sensu_check: name=check-ceilometer-api plugin=check-os-api.rb
+               args="--service ceilometer"
+  notify: restart sensu-client
+
+- name: ceilometer sla metrics
+  sensu_metrics_check: name=ceilometer-sla-metrics plugin=metrics-os-api.py
+                      args='-S ceilometer --scheme {{ monitoring.graphite.host_prefix }}'
+  notify: restart sensu-client
+
+- name: ceilometer process check
+  sensu_process_check: service={{ item }}
+  with_items:
+    - ceilometer-api
+    - ceilometer-collector
+    - ceilometer-agent-notification
+    - ceilometer-agent-central
+    - ceilometer-alarm-evaluator
+    - ceilometer-alarm-notifier
+  notify: restart sensu-client

--- a/roles/ceilometer-data/meta/main.yml
+++ b/roles/ceilometer-data/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: ceilometer-common

--- a/roles/ceilometer-data/tasks/main.yml
+++ b/roles/ceilometer-data/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: install ceilometer compute service
+  upstart_service: name=ceilometer-agent-compute
+                   user=ceilometer
+                   cmd=/usr/local/bin/ceilometer-agent-compute
+  notify: restart ceilometer services
+
+- name: install libvirt-python in package venv
+  command: "{{ 'ceilometer'|ursula_package_path(openstack_package_version) }}/bin/pip install libvirt-python"
+  notify: restart ceilometer services
+  when: openstack_install_method == 'package'
+
+- name: install libvirt-python in source venv
+  command: "{{ openstack_source.virtualenv_base }}/ceilometer/bin/pip install libvirt-python"
+  notify: restart ceilometer services
+  when: openstack_install_method == 'source'
+
+- meta: flush_handlers
+
+- name: start ceilometer-compute service
+  service: name=ceilometer-agent-compute state=started
+
+- include: monitoring.yml
+  tags:
+    - monitoring
+    - common
+  when: monitoring.enabled|default('True')|bool

--- a/roles/ceilometer-data/tasks/monitoring.yml
+++ b/roles/ceilometer-data/tasks/monitoring.yml
@@ -1,0 +1,4 @@
+---
+- name: ceilometer-agent-compute process check
+  sensu_process_check: service=ceilometer-agent-compute
+  notify: restart sensu-client

--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -8,6 +8,7 @@ client:
     - python-neutronclient
     - python-cinderclient
     - python-heatclient
+    - python-ceilometerclient
     - python-ironicclient
     - python-swiftclient
     - python-magnumclient

--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -14,14 +14,16 @@
     {% set _ = haproxy_services.append(['heat', 8004, 8005, false]) %}
     {% set _ = haproxy_services.append(['heat-cfn', 8000, 8001, false]) %}
 {% endif -%}
-
+{% if ceilometer.enabled|default('True')|bool -%}
+    {% set _ = haproxy_services.append(['ceilometer', 8888, 8889, false]) %}
+{% endif -%}
 {% if magnum.enabled|default('False')|bool -%}
     {% set _ = haproxy_services.append(['magnum', 9512, 9511, false]) %}
 {% endif -%}
-
 {% if ironic.enabled|default('False')|bool -%}
     {% set _ = haproxy_services.append(['ironic', 6385, 6384, false]) %}
 {% endif -%}
+
 global
   log /dev/log local0
   maxconn 256
@@ -69,6 +71,8 @@ backend {{ name }}
   option httpchk GET /vnc_auto.html
   {% elif name == "ironic" -%}
   option httpchk GET /v1
+  {% elif name == "ceilometer" -%}
+  option tcp-check /
   {% elif name == "magnum" -%}
   # option httpchk /
   {% else -%}

--- a/roles/mongodb-arbiter/meta/main.yml
+++ b/roles/mongodb-arbiter/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: mongodb-common

--- a/roles/mongodb-arbiter/tasks/main.yml
+++ b/roles/mongodb-arbiter/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: add mongodb arbiter to replica set
+  command: mongo --host {{ endpoints.mongodb }} --eval rs.addArb(\"{{ primary_ip ~ ":" ~ mongodb.port | string}}\")
+  when: inventory_hostname in groups['mongo_arbiter']

--- a/roles/mongodb-common/defaults/main.yml
+++ b/roles/mongodb-common/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+mongodb:
+  version: 3.0.6
+  replica_name: mongoreplica
+  db_password: "{{ secrets.mongodb_password }}"
+  bind_ip: 0.0.0.0
+  port: 27017
+  logging:
+    debug: False
+    verbose: True
+  cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"

--- a/roles/mongodb-common/handlers/main.yml
+++ b/roles/mongodb-common/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart mongodb service
+  service: name=mongod state=restarted

--- a/roles/mongodb-common/meta/main.yml
+++ b/roles/mongodb-common/meta/main.yml
@@ -1,0 +1,9 @@
+---
+dependencies:
+  - role: monitoring-common
+  - role: apt-repos
+    repos:
+      - repo: 'deb {{ apt_repos.mongodb.repo }} {{ ansible_distribution_release }}/mongodb-org/3.0 multiverse'
+        key_url: '{{ apt_repos.mongodb.key_url }}'
+        key_id: '7F0CEB10'
+        validate_certs: no

--- a/roles/mongodb-common/tasks/logging.yml
+++ b/roles/mongodb-common/tasks/logging.yml
@@ -1,0 +1,9 @@
+---
+- name: set up log rotation for mongodb
+  logrotate: name=mongodb path=/var/log/mongodb/*.log
+  args:
+    options:
+      - daily
+      - missingok
+      - rotate 7
+      - compress

--- a/roles/mongodb-common/tasks/main.yml
+++ b/roles/mongodb-common/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: install mongodb packages
+  apt: pkg={{ item }} state=installed
+  with_items:
+    - mongodb-org-server={{ mongodb.version }}
+    - mongodb-org-shell={{ mongodb.version }}
+
+- name: install mongodb config files
+  template: src=etc/mongodb/mongod.conf dest=/etc/mongod.conf mode=0644
+  notify: restart mongodb service
+
+- meta: flush_handlers
+
+- name: start mongodb service
+  service: name=mongod state=started
+
+- include: monitoring.yml
+  tags:
+    - monitoring
+    - common
+  when: monitoring.enabled|default('True')|bool
+
+- include: logging.yml
+  tags:
+    - logrotate
+    - logging
+  when: logging.enabled|default('True')|bool

--- a/roles/mongodb-common/tasks/monitoring.yml
+++ b/roles/mongodb-common/tasks/monitoring.yml
@@ -1,0 +1,3 @@
+---
+- name: mongod process check
+  sensu_process_check: service=mongod

--- a/roles/mongodb-common/templates/etc/mongodb/mongod.conf
+++ b/roles/mongodb-common/templates/etc/mongodb/mongod.conf
@@ -1,0 +1,81 @@
+# mongod.conf
+
+# Where to store the data.
+# Note: if you run mongodb as a non-root user (recommended) you may
+# need to create and set permissions for this directory manually,
+# e.g., if the parent directory isn't mutable by the mongodb user.
+dbpath=/var/lib/mongodb
+
+#where to log
+logpath=/var/log/mongodb/mongod.log
+logappend=true
+
+pidfilepath = /var/run/mongodb.pid
+fork = false
+
+# Listen to local interface only. Comment out to listen on all interfaces.
+bind_ip = {{ mongodb.bind_ip }}
+port = {{ mongodb.port }}
+
+# Disables write-ahead journaling
+{% if primary_ip in groups['mongo_arbiter'] -%}
+  nojournal = true
+{% else -%}
+  nojournal = false
+{% endif -%}
+
+smallfiles = true
+
+# Enables periodic logging of CPU utilization and I/O wait
+#cpu = false
+
+# Turn on/off security.  Off is currently the default
+noauth = true
+#auth = true
+
+# Inspect all client data for validity on receipt (useful for
+# developing drivers)
+#objcheck = true
+
+# Enable db quota management
+#quota = true
+
+# Set oplogging level where n is
+#   0=off (default)
+#   1=W
+#   2=R
+#   3=both
+#   7=W+some reads
+#diaglog = 0
+
+# Ignore query hints
+#nohints = true
+
+# Enable the HTTP interface (Defaults to port 28017).
+httpinterface = false
+
+# Enable the REST interface
+rest = false
+
+# Turns off server-side scripting.  This will result in greatly limited
+# functionality
+#noscripting = true
+
+# Turns off table scans.  Any query that would do a table scan fails.
+#notablescan = true
+
+# Disable data file preallocation.
+#noprealloc = true
+
+# Specify .ns file size for new databases.
+# nssize = <size>
+
+# Replication Options
+
+# in replicated mongo databases, specify the replica set name here
+replSet={{ mongodb.replica_name }}
+# maximum size in megabytes for replication operation log
+oplogSize=4096
+# path to a key file storing authentication info for connections
+# between replica set members
+#keyFile=/path/to/keyfile

--- a/roles/mongodb-server/meta/main.yml
+++ b/roles/mongodb-server/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: mongodb-common

--- a/roles/mongodb-server/tasks/main.yml
+++ b/roles/mongodb-server/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- include: primary.yml
+  when: inventory_hostname in groups['mongo_db'][0]
+
+- name: add mongodb secondary servers to replica set
+  command: mongo --host {{ endpoints.mongodb }} --eval rs.add(\"{{ primary_ip ~ ":" ~ mongodb.port | string}}\")
+  when: inventory_hostname not in groups['mongo_db'][0] and inventory_hostname in groups['mongo_db']

--- a/roles/mongodb-server/tasks/primary.yml
+++ b/roles/mongodb-server/tasks/primary.yml
@@ -1,0 +1,15 @@
+---
+- name: initiate replica set
+  command: mongo --host {{ endpoints.mongodb }} --eval 'rs.initiate()'
+
+- name: wait for replica set init to complete
+  pause: seconds=20
+
+- name: rename primary replica member
+  command: mongo --host {{ endpoints.mongodb }} --eval 'cfg=rs.conf(); cfg.members[0].host="{{ primary_ip }}:{{ mongodb.port }}"; rs.reconfig(cfg)'
+
+- name: install pymongo for mongodb_user module
+  pip: name=pymongo state=present
+
+- name: create admin user
+  mongodb_user: database=admin name=admin password={{ mongodb.db_password }} roles='userAdminAnyDatabase' state=present

--- a/roles/nova-data/tasks/libvirt.yml
+++ b/roles/nova-data/tasks/libvirt.yml
@@ -47,7 +47,7 @@
   notify: restart nova services
   when: openstack_install_method == 'package'
 
-- name: install libvirt-python in package venv
+- name: install libvirt-python in source venv
   command: "{{ openstack_source.virtualenv_base }}/nova/bin/pip install libvirt-python"
   register: lvpout
   changed_when: lvpout.stdout|search("Successfully installed")

--- a/site.yml
+++ b/site.yml
@@ -78,6 +78,22 @@
     - role: percona-backup
       tags: ['infra', 'percona']
 
+- name: install mongodb server
+  gather_facts: force
+  hosts: mongo_db
+  roles:
+    - role: mongodb-server
+      tags: ['mongodb', 'mongodb-server']
+      when: ceilometer.enabled|bool
+
+- name: install mongodb arbiter
+  gather_facts: force
+  hosts: mongo_arbiter
+  roles:
+    - role: mongodb-arbiter
+      tags: ['mongodb', 'mongodb-arbiter']
+      when: ceilometer.enabled|bool
+
 - name: memcached for keystone and horizon
   gather_facts: force
   hosts: controller
@@ -258,6 +274,22 @@
     - role: heat
       tags: ['openstack', 'heat', 'control']
       when: heat.enabled|bool
+
+- name: ceilometer control plane
+  gather_facts: force
+  hosts: controller
+  roles:
+    - role: ceilometer-control
+      tags: ['openstack', 'ceilometer', 'control']
+      when: ceilometer.enabled|bool
+
+- name: ceilometer data plane
+  gather_facts: force
+  hosts: compute
+  roles:
+    - role: ceilometer-data
+      tags: ['openstack', 'ceilometer', 'data']
+      when: ceilometer.enabled|bool
 
 - name: magnum code and config
   gather_facts: force

--- a/test/setup
+++ b/test/setup
@@ -76,6 +76,13 @@ $(public_ip "${testenv_instance_prefix}-controller-1")
 [db_arbiter]
 $(public_ip "${testenv_instance_prefix}-compute-0")
 
+[mongo_db]
+$(public_ip "${testenv_instance_prefix}-controller-0")
+$(public_ip "${testenv_instance_prefix}-controller-1")
+
+[mongo_arbiter]
+$(public_ip "${testenv_instance_prefix}-compute-0")
+
 [controller]
 $(public_ip "${testenv_instance_prefix}-controller-0")
 $(public_ip "${testenv_instance_prefix}-controller-1")
@@ -99,6 +106,9 @@ else
 $(public_ip "${testenv_instance_prefix}-allinone")
 
 [db_arbiter]
+$(public_ip "${testenv_instance_prefix}-allinone")
+
+[mongo_db]
 $(public_ip "${testenv_instance_prefix}-allinone")
 
 [controller]


### PR DESCRIPTION
Added 3 Ceilometer roles: ceilometer-common/control/data
Ceilometer is currently trimmed down to minimal offering
Ceilometer pipeline.yml only allows cpu & cpu_utils meters
Added Ceilometer with tcp rule to haproxy

Added 1 MongoDB role with tasks split into main.yml & primary.yml
MongoDB is scalable to add additional controllers to replica set
MongoDB will deploy with one arbiter on compute1
MongoDB init script is idempotent to rerun ursula without failure
MongoDB only installs mongod daemon service and mongo-shell
Added MongoDB repo with key for future authentication
MongoDB currently has collectd template, but is untested