### PR TITLE
Add ceph-compute

### DIFF
--- a/roles/ceph-common/handlers/main.yml
+++ b/roles/ceph-common/handlers/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: restart ceph mons
   service: name=ceph-mon-all state=restarted
-  when: socket.rc == 0
+  when: ceph_socket.rc == 0
 
 - name: restart ceph osds
   service: name=ceph-osd-all state=restarted
-  when: socket.rc == 0
+  when: ceph_socket.rc == 0

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -20,11 +20,11 @@
   shell: "stat /var/run/ceph/*.asok > /dev/null 2>&1"
   changed_when: false
   failed_when: false
-  register: socket
+  register: ceph_socket
 
-# we're storing the fsid in a file on the first monitor node
+# generate uuid for ceph.conf
 # truncate is to get rid of the newline
-- name: generate fsid file if we don't have one
+- name: generate fsid file
   shell: uuidgen > /etc/ceph/fsid && truncate -s -1 /etc/ceph/fsid
          creates=/etc/ceph/fsid
   run_once: true
@@ -41,6 +41,26 @@
   copy:
     dest: "{{ fsid_file['source'] }}"
     content: "{{ fsid_file['content'] | b64decode }}"
+
+# generate uuid for cinder.conf and secret.xml
+# truncate is to get rid of the newline
+- name: generate cinder uuid
+  shell: uuidgen > /etc/ceph/cinder_uuid && truncate -s -1 /etc/ceph/cinder_uuid
+         creates=/etc/ceph/cinder_uuid
+  run_once: true
+  delegate_to:  "{{ groups[ceph.monitor_group_name][0] }}"
+
+- name: fetch contents of uuid file
+  slurp: path=/etc/ceph/cinder_uuid
+  run_once: true
+  delegate_to: "{{ groups[ceph.monitor_group_name][0] }}"
+  register: cinder_uuid_file
+
+# for redundancy, and if the hosts in mons get reordered
+- name: copy uuid to all hosts
+  copy:
+    dest: "{{ cinder_uuid_file['source'] }}"
+    content: "{{ cinder_uuid_file['content'] | b64decode }}"
 
 - name: generate ceph configuration file
   template: src=etc/ceph/ceph.conf

--- a/roles/ceph-compute/tasks/main.yml
+++ b/roles/ceph-compute/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+- name: create ceph directory
+  file:
+    path: /etc/ceph
+    state: directory
+
+- name: create client.cinder.key
+  shell: ceph auth get-key client.cinder > /etc/ceph/client.cinder.key
+         creates=/etc/ceph/client.cinder.key
+  run_once: true
+  delegate_to: "{{ groups[ceph.monitor_group_name][0] }}"
+
+- name: fetch client.cinder.key
+  slurp: path=/etc/ceph/client.cinder.key
+  run_once: true
+  delegate_to: "{{ groups[ceph.monitor_group_name][0] }}"
+  register: client_cinder_key
+
+- name: write client.cinder.key
+  copy:
+    dest: /etc/ceph/client.cinder.key
+    content: "{{ client_cinder_key['content'] | b64decode }}"
+
+# used in secret.xml
+- name: fetch contents of uuid file
+  slurp: path=/etc/ceph/cinder_uuid
+  run_once: true
+  delegate_to: "{{ groups[ceph.monitor_group_name][0] }}"
+  register: cinder_uuid_file
+
+- name: generate ceph secret xml file
+  template: src=etc/ceph/secret.xml
+            dest=/etc/ceph/secret.xml
+            owner=root
+            group=root
+            mode=0644
+
+- name: define virsh secret
+  shell: virsh secret-define --file /etc/ceph/secret.xml
+
+- name: set virsh secret
+  shell: "virsh secret-set-value --secret {{ cinder_uuid_file.content | b64decode }} --base64 $(cat /etc/ceph/client.cinder.key)"

--- a/roles/ceph-compute/templates/etc/ceph/secret.xml
+++ b/roles/ceph-compute/templates/etc/ceph/secret.xml
@@ -1,0 +1,6 @@
+<secret ephemeral='no' private='no'>
+  <uuid>{{ cinder_uuid_file.content | b64decode }}</uuid>
+  <usage type='ceph'>
+    <name>client.cinder secret</name>
+  </usage>
+</secret>


### PR DESCRIPTION
We are doing some tasks in `cinder-common` that really should be done
in a separate task. Namely, these `virsh` commands should only be run
on compute hosts.

#1140 shows how `site.yml` will make use of this role.