### PR TITLE
Add ignore_errors on partition check

### DIFF
--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -35,12 +35,14 @@
 - name: check if 'ceph' partition exists on osd devices
   shell: "parted --script {{ item }} print | egrep -sq '^ 1.*ceph'"
   with_items: ceph_osd.devices
+  ignore_errors: true
   changed_when: false
   register: ceph_partition_osds
 
 - name: check if 'ceph' partition exists on journal devices
   shell: "parted --script {{ item }} print | egrep -sq '^ 1.*ceph'"
   with_items: ceph_osd.raw_journal_devices
+  ignore_errors: true
   changed_when: false
   register: ceph_partition_journals
 


### PR DESCRIPTION
After more thought and testing, we need `ignore_errors` on the
partition check. If it fails, it means the partition is not there,
so we're okay to proceed.

Part of the Ceph Epic & 104678: Improve Ceph Block Storage Automation — https://hub.jazz.net/ccm08/quickplanner/jazzhub.html#items:projectId=_MM_y5SldEeWSQOc0JZWznA&serverId=hub.jazz.net&planType=allwork&allIterations=true&itemId=97391