### PR TITLE
Do all reboots serially

### DIFF
--- a/playbooks/reboot_cluster.yml
+++ b/playbooks/reboot_cluster.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: all:!db
+  serial: 1
   tasks:
   - name: Reboot
     command: shutdown -r now
@@ -14,6 +15,7 @@
     delegate_to: "{{ groups['controller']|first }}"
 
 - hosts: db_arbiter
+  serial: 1
   tasks:
   - name: Ensure Garbd is up before rebooting database servers
     wait_for: host={{ ansible_default_ipv4.address }}


### PR DESCRIPTION
We should be doing everything one at a time, to avoid having significant
portions of instances down at once.