### PR TITLE
Change default collectd and sensu metrics collection interval to 60 seconds

### DIFF
--- a/library/sensu_metrics_check.py
+++ b/library/sensu_metrics_check.py
@@ -34,7 +34,7 @@ def main():
             plugin_dir=dict(default='/etc/sensu/plugins', required=False),
             check_dir=dict(default='/etc/sensu/conf.d/checks', required=False),
             prefix=dict(default='', required=False),
-            interval=dict(default=20, reuired=False),
+            interval=dict(default=60, required=False),
             state=dict(default='present', required=False, choices=['present','absent'])
         )
     )

--- a/roles/collectd-client/defaults/main.yml
+++ b/roles/collectd-client/defaults/main.yml
@@ -4,7 +4,7 @@ collectd:
   key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xE97C3D97792BD34E"
   client_name: "{{ ansible_hostname }}"
   plugin_conf_dir: /etc/collectd/plugins
-  interval: 10
+  interval: 60
   timeout: 2
   threads: 5
   graphite_prefix: "stats."


### PR DESCRIPTION
Change default collectd and sensu metrics collection interval to 60 seconds to match default graphite storage retention interval, so we're not collecting and relaying a bunch of data only to discard it.