### PR TITLE
ipchanged: support case where controllers are not gateway

### DIFF
--- a/roles/neutron-data-network/tasks/ipchanged.yml
+++ b/roles/neutron-data-network/tasks/ipchanged.yml
@@ -24,6 +24,7 @@
 - name: configure neutron internal services failover
   template: src=etc/ipchanged/add_internal_floating_ip mode=0755
             dest=/etc/ipchanged/{{ hostvars[inventory_hostname][primary_interface].device }}/{{ undercloud_floating_ip }}/add
+  when: ansible_default_ipv4.interface != hostvars[inventory_hostname][primary_interface].device
 
 - name: start ipchanged service
   service: name=ipchanged state=started

--- a/roles/neutron-data-network/templates/etc/ipchanged/add_floating_ip
+++ b/roles/neutron-data-network/templates/etc/ipchanged/add_floating_ip
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Send gratuitous ARP broadcast for other pNodes to find RabbitMQ/MySQL endpoint
+arping -A -I {{ ansible_default_ipv4.interface }} {{ undercloud_floating_ip }} -c 3
+arping -U -I {{ ansible_default_ipv4.interface }} {{ undercloud_floating_ip }} -c 3
+
+# Send gratuitous ARP to default gateway (some discard broadcasts if already known)
+arping -A -I {{ ansible_default_ipv4.interface }} -s {{ floating_ip }} {{ ansible_default_ipv4.gateway }} -c 3
+
+
 . /root/stackrc
 export HOSTNAME=$( hostname )
 


### PR DESCRIPTION
Handler scripts for ipchanged do not work in deployments where gateway
for physical nodes and Neutron external network are external to the
controllers e.g. when using an external firewall. Refactor these so we
send gratuitous ARP to default gateway in all cases, and gratuitous ARP
to other pNodes in case when acting as gateway.