### PR TITLE
Fix horizon static directory not loading when doing source install

### DIFF
--- a/roles/horizon/templates/etc/apache2/sites-available/openstack_dashboard.conf
+++ b/roles/horizon/templates/etc/apache2/sites-available/openstack_dashboard.conf
@@ -26,8 +26,8 @@ WSGIPythonPath /etc/openstack-dashboard
     Alias /static /opt/openstack/current/horizon/static
     <Directory /opt/openstack/current/horizon/static>
 {% else %}
-    Alias /static /opt/openstack/current/horizon/static
-    <Directory /opt/openstack/current/horizon/static>
+    Alias /static /opt/stack/horizon/static
+    <Directory /opt/stack/horizon/static>
 {% endif %}
       Options FollowSymLinks
       AuthType None


### PR DESCRIPTION
CSS and other horizon elements were not loading correctly after a source install.

No static directory exists in  /opt/openstack/current/horizon/ (/opt/bbc/openstack-11.0-master/horizon/).
The static directory is available however, in /opt/stack/horizon/.