### PR TITLE
Port standardization for openstack services with backward compatibility for existing keystone port

### DIFF
--- a/branch-validation.yml
+++ b/branch-validation.yml
@@ -1,3 +1,4 @@
+
 # playbook for validating a branch for release tagging
 # interactive, may prompt runner to affirm things have completed
 ---
@@ -25,7 +26,7 @@
           username: provider_admin
           project_name: admin
           password: "{{ secrets.provider_admin_password }}"
-          auth_url: "http://127.0.0.1:35357/v2.0"
+          auth_url: "http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}"
         name: validate
         state: present
       register: keypair
@@ -43,7 +44,7 @@
           username: provider_admin
           project_name: admin
           password: "{{ secrets.provider_admin_password }}"
-          auth_url: "http://127.0.0.1:35357/v2.0"
+          auth_url: "http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}"
         name: validate_ssh
         description: "validate group allowing ssh, icmp ipv4 ingress"
         state: present
@@ -54,7 +55,7 @@
           username: provider_admin
           project_name: admin
           password: "{{ secrets.provider_admin_password }}"
-          auth_url: "http://127.0.0.1:35357/v2.0"
+          auth_url: "http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}"
         security_group: validate_ssh
         protocol: "{{ item.ip_protocol }}"
         port_range_min: "{{ item.from_port }}"
@@ -78,7 +79,7 @@
           username: provider_admin
           project_name: admin
           password: "{{ secrets.provider_admin_password }}"
-          auth_url: "http://127.0.0.1:35357/v2.0"
+          auth_url: "http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}"
         flavor: 1
         image: cirros
         key_name: validate
@@ -100,7 +101,7 @@
           username: provider_admin
           project_name: admin
           password: "{{ secrets.provider_admin_password }}"
-          auth_url: "http://127.0.0.1:35357/v2.0"
+          auth_url: "http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}"
         network: external
         server: validate-{{ groups['compute'][0] }}
         reuse: true
@@ -151,7 +152,7 @@
           username: provider_admin
           project_name: admin
           password: "{{ secrets.provider_admin_password }}"
-          auth_url: "http://127.0.0.1:35357/v2.0"
+          auth_url: "http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}"
         network: external
         server: validate-{{ groups['compute'][0] }}
         floating_ip_address: "{{ fip.floating_ip.floating_ip_address }}"
@@ -173,7 +174,7 @@
           username: provider_admin
           project_name: admin
           password: "{{ secrets.provider_admin_password }}"
-          auth_url: "http://127.0.0.1:35357/v2.0"
+          auth_url: "http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}"
         network: external
         server: validate-{{ item }}
         reuse: true
@@ -186,7 +187,7 @@
           username: provider_admin
           project_name: admin
           password: "{{ secrets.provider_admin_password }}"
-          auth_url: "http://127.0.0.1:35357/v2.0"
+          auth_url: "http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}"
         network: external
         server: validate-{{ item }}
         reuse: true
@@ -295,7 +296,7 @@
           username: provider_admin
           project_name: admin
           password: "{{ secrets.provider_admin_password }}"
-          auth_url: "http://127.0.0.1:35357/v2.0"
+          auth_url: "http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}"
         name: validate-{{ item }}
         state: absent
         wait: "yes"
@@ -308,7 +309,7 @@
           username: provider_admin
           project_name: admin
           password: "{{ secrets.provider_admin_password }}"
-          auth_url: "http://127.0.0.1:35357/v2.0"
+          auth_url: "http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}"
         name: validate_ssh
         state: absent
       tags: delete
@@ -325,7 +326,7 @@
           username: provider_admin
           project_name: admin
           password: "{{ secrets.provider_admin_password }}"
-          auth_url: "http://127.0.0.1:35357/v2.0"
+          auth_url: "http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}"
         name: validate
         state: absent
       tags: delete

--- a/doc/endpoints.md
+++ b/doc/endpoints.md
@@ -34,23 +34,23 @@ request.
 | MySQL          | internal | mysql    | 3306  | internal floating IP   |
 | RabbitMQ       | internal | rabbitmq | 5672  | internal floating IP   |
 | Memcached      | internal | memcache | 11211 | controller internal IP |
-| Keystone       | haproxy  | HTTP     | 5000  | controller internal IP |
-| Keystone       | internal | HTTPS    | 5001  | external floating IP   |
-| Keystone       | public   | HTTPS    | 5001  | external floating IP   |
-| Keystone-admin | haproxy  | HTTP     | 35357 | controller internal IP |
-| Keystone-admin | internal | HTTPS    | 35358 | external floating IP   |
-| Keystone-admin | public   | HTTPS    | 35358 | external floating IP   |
-| Nova           | haproxy  | HTTP     | 8774  | controller internal IP |
-| Nova           | internal | HTTPS    | 8777  | external floating IP   |
-| Nova           | public   | HTTPS    | 8777  | external floating IP   |
-| Nova - noVNC   | internal | HTTP     | 6080  | controller internal IP |
-| Nova - noVNC   | public   | HTTPS    | 6081  | external floating IP   |
-| Neutron        | haproxy  | HTTP     | 9696  | controller internal IP |
-| Neutron        | internal | HTTPS    | 9797  | external floating IP   |
-| Neutron        | public   | HTTPS    | 9797  | external floating IP   |
-| Glance         | haproxy  | HTTP     | 9292  | controller internal IP |
-| Glance         | internal | HTTPS    | 9393  | external floating IP   |
-| Glance         | public   | HTTPS    | 9393  | external floating IP   |
+| Keystone       | haproxy  | HTTP     | 5001  | controller internal IP |
+| Keystone       | internal | HTTPS    | 5000  | external floating IP   |
+| Keystone       | public   | HTTPS    | 5000  | external floating IP   |
+| Keystone-admin | haproxy  | HTTP     | 35358 | controller internal IP |
+| Keystone-admin | internal | HTTPS    | 35357 | external floating IP   |
+| Keystone-admin | public   | HTTPS    | 35357 | external floating IP   |
+| Nova           | haproxy  | HTTP     | 9774  | controller internal IP |
+| Nova           | internal | HTTPS    | 8774  | external floating IP   |
+| Nova           | public   | HTTPS    | 8774  | external floating IP   |
+| Nova - noVNC   | internal | HTTP     | 6081  | controller internal IP |
+| Nova - noVNC   | public   | HTTPS    | 6080  | external floating IP   |
+| Neutron        | haproxy  | HTTP     | 9797  | controller internal IP |
+| Neutron        | internal | HTTPS    | 9696  | external floating IP   |
+| Neutron        | public   | HTTPS    | 9696  | external floating IP   |
+| Glance         | haproxy  | HTTP     | 9393  | controller internal IP |
+| Glance         | internal | HTTPS    | 9292  | external floating IP   |
+| Glance         | public   | HTTPS    | 9292  | external floating IP   |
 | Heat           | haproxy  | HTTP     | 8004  | controller internal IP |
 | Heat           | internal | HTTPS    | 8005  | external floating IP   |
 | Heat           | public   | HTTPS    | 8005  | external floating IP   |

--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -49,30 +49,15 @@ memcached:
 
 swift:
   enabled: False
-  haproxy_vip: "{{ swift_fqdn }}"
-  haproxy_port: 8090
 
 endpoints:
   main:     "{{ fqdn }}"
   db:       "{{ undercloud_floating_ip }}"
   mongodb:  "{{ undercloud_floating_ip }}"
   rabbit:   "{{ undercloud_floating_ip }}"
-  keystone: "{{ fqdn }}"
-  nova:     "{{ fqdn }}"
-  glance:   "{{ fqdn }}"
-  neutron:  "{{ fqdn }}"
-  vnc:      "{{ fqdn }}"
-  cinder:   "{{ fqdn }}"
-  keystonev3: "{{ fqdn }}"
-  cinderv2: "{{ fqdn }}"
-  heat:     "{{ fqdn }}"
-  heat-cfn: "{{ fqdn }}"
-  ceilometer: "{{ fqdn }}"
-  ironic:   "{{ fqdn }}"
-  swift:    "{{ swift.haproxy_vip }}"
-  magnum:   "{{ fqdn }}"
-  identity_uri: https://{{ fqdn }}:35358
-  auth_uri: https://{{ fqdn }}:5001/v2.0
+  magnum: "{{ fqdn }}"
+  identity_uri: https://{{ fqdn }}:35357
+  auth_uri: https://{{ fqdn }}:5000/v2.0
 
 mysql:
   root_password: asdf
@@ -336,57 +321,57 @@ keystone:
     - name: keystone
       type: identity
       description: 'Identity Service'
-      public_url: https://{{ endpoints.main }}:5001/v2.0
-      internal_url: https://{{ endpoints.main }}:5001/v2.0
-      admin_url: https://{{ endpoints.main }}:35358/v2.0
+      public_url: "{{ endpoints.keystone.url.public }}/{{ endpoints.keystone.version }}"
+      internal_url: "{{ endpoints.keystone.url.internal }}/{{ endpoints.keystone.version }}"
+      admin_url: "{{ endpoints.keystone.url.admin }}/{{ endpoints.keystone.version }}"
     - name: keystonev3
       type: identityv3
       description: 'Identity Service v3'
-      public_url: https://{{ endpoints.main }}:5001/v3
-      internal_url: https://{{ endpoints.main }}:5001/v3
-      admin_url: https://{{ endpoints.main }}:35358/v3
+      public_url: "{{ endpoints.keystone.url.public }}/{{ endpoints.keystonev3.version }}"
+      internal_url: "{{ endpoints.keystone.url.internal }}/{{ endpoints.keystonev3.version }}"
+      admin_url: "{{ endpoints.keystone.url.admin }}/{{ endpoints.keystonev3.version }}"
     - name: nova
       type: compute
       description: 'Compute Service'
-      public_url: https://{{ endpoints.main }}:8777/v2/%(tenant_id)s
-      internal_url: https://{{ endpoints.main }}:8777/v2/%(tenant_id)s
-      admin_url: https://{{ endpoints.main }}:8777/v2/%(tenant_id)s
+      public_url: "{{ endpoints.nova.url.public }}/{{ endpoints.nova.url.path }}"
+      internal_url: "{{ endpoints.nova.url.internal }}/{{ endpoints.nova.url.path }}"
+      admin_url: "{{ endpoints.nova.url.admin }}/{{ endpoints.nova.url.path }}"
     - name: glance
       type: image
       description: 'Image Service'
-      public_url: https://{{ endpoints.main }}:9393
-      internal_url: https://{{ endpoints.main }}:9393
-      admin_url: https://{{ endpoints.main }}:9393
+      public_url: "{{ endpoints.glance.url.public }}" 
+      internal_url: "{{ endpoints.glance.url.internal }}"
+      admin_url: "{{ endpoints.glance.url.admin }}"
     - name: neutron
       type: network
       description: 'Network Service'
-      public_url: https://{{ endpoints.main }}:9797
-      internal_url: https://{{ endpoints.main }}:9797
-      admin_url: https://{{ endpoints.main }}:9797
+      public_url: "{{ endpoints.neutron.url.public }}"
+      internal_url: "{{ endpoints.neutron.url.internal }}"
+      admin_url: "{{ endpoints.neutron.url.admin }}"
     - name: cinder
       type: volume
       description: 'Volume Service'
-      public_url: https://{{ endpoints.main }}:8778/v1/%(tenant_id)s
-      internal_url: https://{{ endpoints.main }}:8778/v1/%(tenant_id)s
-      admin_url: https://{{ endpoints.main }}:8778/v1/%(tenant_id)s
+      public_url: "{{ endpoints.cinder.url.public }}/{{ endpoints.cinder.url.path }}"
+      internal_url: "{{ endpoints.cinder.url.internal }}/{{ endpoints.cinder.url.path }}"
+      admin_url: "{{ endpoints.cinder.url.admin }}/{{ endpoints.cinder.url.path }}"
     - name: cinderv2
       type: volumev2
       description: 'Volume Service v2'
-      public_url: https://{{ endpoints.main }}:8778/v2/%(tenant_id)s
-      internal_url: https://{{ endpoints.main }}:8778/v2/%(tenant_id)s
-      admin_url: https://{{ endpoints.main }}:8778/v2/%(tenant_id)s
+      public_url: "{{ endpoints.cinderv2.url.public }}/{{ endpoints.cinderv2.url.path }}" 
+      internal_url: "{{ endpoints.cinderv2.url.internal }}/{{ endpoints.cinderv2.url.path }}"
+      admin_url: "{{ endpoints.cinderv2.url.admin }}/{{ endpoints.cinderv2.url.path }}"
     - name: heat
       type: orchestration
       description: 'Heat Orchestration API'
-      public_url: https://{{ endpoints.main }}:8005/v1/%(tenant_id)s
-      internal_url: https://{{ endpoints.main }}:8005/v1/%(tenant_id)s
-      admin_url: https://{{ endpoints.main }}:8005/v1/%(tenant_id)s
+      public_url: "{{ endpoints.heat.url.public }}/{{ endpoints.heat.url.path }}"
+      internal_url: "{{ endpoints.heat.url.internal }}/{{ endpoints.heat.url.path }}"
+      admin_url: "{{ endpoints.heat.url.admin }}/{{ endpoints.heat.url.path }}"
     - name: heat-cfn
       type: cloudformation
       description: 'Heat CloudFormation API'
-      public_url: https://{{ endpoints.main }}:8001/v1
-      internal_url: https://{{ endpoints.main }}:8001/v1
-      admin_url: https://{{ endpoints.main }}:8001/v1
+      public_url: "{{ endpoints.heat_cfn.url.public }}/{{ endpoints.heat_cfn.version }}"
+      internal_url: "{{ endpoints.heat_cfn.url.internal }}/{{ endpoints.heat_cfn.version }}"
+      admin_url: "{{ endpoints.heat_cfn.url.admin }}/{{ endpoints.heat_cfn.version }}"
     - name: ceilometer
       type: metering
       description: 'Telemetry Service'
@@ -396,15 +381,15 @@ keystone:
     - name: ironic
       type: baremetal
       description: 'Ironic bare metal provisioning service'
-      public_url: https://{{ endpoints.main }}:6384
-      internal_url: https://{{ endpoints.main }}:6384
-      admin_url: https://{{ endpoints.main }}:6384
+      public_url: "{{ endpoints.ironic.url.public }}"
+      internal_url: "{{ endpoints.ironic.url.internal }}"
+      admin_url: "{{ endpoints.ironic.url.admin }}"
     - name: swift
       type: object-store
       description: 'Object Storage Service'
-      public_url: https://{{ endpoints.swift }}:{{ swift.haproxy_port}}/v1/%(tenant_id)s
-      internal_url: https://{{ endpoints.swift }}:{{ swift.haproxy_port}}/v1/%(tenant_id)s
-      admin_url: https://{{ endpoints.swift }}:{{ swift.haproxy_port}}/v1/%(tenant_id)s
+      public_url: "{{ endpoints.swift.url.public }}/{{ endpoints.swift.url.path }}"
+      internal_url: "{{ endpoints.swift.url.internal }}/{{ endpoints.swift.url.path }}"
+      admin_url: "{{ endpoints.swift.url.admin }}/{{ endpoints.swift.url.path }}"
     - name: magnum
       type: container
       description: 'Magnum Container Service'

--- a/library/cinder_volume_type.py
+++ b/library/cinder_volume_type.py
@@ -43,7 +43,7 @@ options:
      description:
         - the keystone url for authentication
      required: false
-     default: 'http://127.0.0.1:5000/v2.0/'
+     default: 'http://127.0.0.1:5001/v2.0/'
    encryption_type:
      description:
         - flag indicating whether this is a encrption type or not
@@ -82,7 +82,7 @@ EXAMPLES = '''
     login_username=admin
     login_password=password
     login_tenant_id=123456789
-    auth_url=http://keystone:5000/v2.0
+    auth_url=http://keystone:5001/v2.0
     volume_type=encrypted-aes-256
 '''
 
@@ -192,7 +192,7 @@ def main():
             login_username=dict(default=None),
             login_password=dict(default=None),
             login_tenant_name=dict(default=None),
-            auth_url=dict(default='http://127.0.0.1:5000/v2.0/'),
+            auth_url=dict(default='http://127.0.0.1:5001/v2.0/'),
             volume_type=dict(required=True),
             encryption_type=dict(default=False),
             provider=dict(default=None),

--- a/library/keystone_service.py
+++ b/library/keystone_service.py
@@ -63,9 +63,9 @@ keystone_service: >
     name=keystone
     type=identity
     description="Keystone Identity Service"
-    publicurl=http://192.168.206.130:5000/v2.0
-    internalurl=http://192.168.206.130:5000/v2.0
-    adminurl=http://192.168.206.130:35357/v2.0
+    publicurl=http://192.168.206.130:5001/v2.0
+    internalurl=http://192.168.206.130:5001/v2.0
+    adminurl=http://192.168.206.130:35358/v2.0
 
 keystone_service: >
     name=glance
@@ -250,7 +250,7 @@ def main():
             region=dict(required=True),
             state=dict(default='present', choices=['present', 'absent']),
             endpoint=dict(required=False,
-                          default="http://127.0.0.1:35357/v2.0",
+                          default="http://127.0.0.1:35358/v2.0",
                           aliases=['auth_url']),
             token=dict(required=False),
             insecure=dict(required=False, default=False, choices=BOOLEANS),

--- a/library/keystone_user.py
+++ b/library/keystone_user.py
@@ -50,7 +50,7 @@ options:
      description:
         - The keystone url for authentication
      required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
+     default: 'http://127.0.0.1:35358/v2.0/'
    user:
      description:
         - The name of the user that has to added/removed from OpenStack
@@ -327,7 +327,7 @@ def main():
             role=dict(required=False),
             state=dict(default='present', choices=['present', 'absent']),
             endpoint=dict(required=False,
-                          default="http://127.0.0.1:35357/v2.0"),
+                          default="http://127.0.0.1:35358/v2.0"),
             token=dict(required=False),
             login_user=dict(required=False),
             login_password=dict(required=False),

--- a/library/neutron_network.py
+++ b/library/neutron_network.py
@@ -54,7 +54,7 @@ options:
      description:
         - The keystone url for authentication
      required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
+     default: 'http://127.0.0.1:35358/v2.0/'
    region_name:
      description:
         - Name of the region
@@ -235,7 +235,7 @@ def main():
             login_username = dict(default='admin'),
             login_password = dict(required=True),
             login_tenant_name = dict(required='True'),
-            auth_url = dict(default='http://127.0.0.1:35357/v2.0/'),
+            auth_url = dict(default='http://127.0.0.1:35358/v2.0/'),
             cacert = dict(default=None),
             region_name = dict(default=None),
             name = dict(required=True),

--- a/library/neutron_router.py
+++ b/library/neutron_router.py
@@ -48,7 +48,7 @@ options:
      description:
         - The keystone url for authentication
      required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
+     default: 'http://127.0.0.1:35358/v2.0/'
    region_name:
      description:
         - Name of the region
@@ -173,7 +173,7 @@ def main():
         login_username                  = dict(default='admin'),
         login_password                  = dict(required=True),
         login_tenant_name               = dict(required='True'),
-        auth_url                        = dict(default='http://127.0.0.1:35357/v2.0/'),
+        auth_url                        = dict(default='http://127.0.0.1:35358/v2.0/'),
         cacert                          = dict(default=None),
         region_name                     = dict(default=None),
         name                            = dict(required=True),

--- a/library/neutron_router_gateway.py
+++ b/library/neutron_router_gateway.py
@@ -48,7 +48,7 @@ options:
      description:
         - The keystone URL for authentication
      required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
+     default: 'http://127.0.0.1:35358/v2.0/'
    region_name:
      description:
         - Name of the region
@@ -172,7 +172,7 @@ def main():
             login_username = dict(default='admin'),
             login_password = dict(required=True),
             login_tenant_name = dict(required='True'),
-            auth_url = dict(default='http://127.0.0.1:35357/v2.0/'),
+            auth_url = dict(default='http://127.0.0.1:35358/v2.0/'),
             region_name = dict(default=None),
             router_name = dict(required=True),
             network_name = dict(required=True),

--- a/library/neutron_router_interface.py
+++ b/library/neutron_router_interface.py
@@ -47,7 +47,7 @@ options:
      description:
         - The keystone url for authentication
      required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
+     default: 'http://127.0.0.1:35358/v2.0/'
    region_name:
      description:
         - Name of the region
@@ -203,7 +203,7 @@ def main():
             login_username                  = dict(default='admin'),
             login_password                  = dict(required=True),
             login_tenant_name               = dict(required='True'),
-            auth_url                        = dict(default='http://127.0.0.1:35357/v2.0/'),
+            auth_url                        = dict(default='http://127.0.0.1:35358/v2.0/'),
             cacert                          = dict(default=None),
             region_name                     = dict(default=None),
             router_name                     = dict(required=True),

--- a/roles/cinder-common/meta/main.yml
+++ b/roles/cinder-common/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: endpoints 
   - role: monitoring-common
   - role: logging-config
     service: cinder

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -3,6 +3,7 @@ debug = {{ cinder.logging.debug }}
 verbose = {{ cinder.logging.verbose }}
 
 osapi_volume_workers = {{ cinder.api_workers }}
+osapi_volume_listen_port={{ endpoints.cinder.port.backend_api }}
 
 # Logging #
 log_dir = /var/log/cinder
@@ -47,7 +48,8 @@ rabbit_password = {{ secrets.rabbit_password }}
 volume_clear_size = {{ cinder.volume_clear_size }}
 {% endif -%}
 
-glance_host = {{ endpoints.glance }}
+glance_host = {{ endpoints.main }}
+glance_port = {{ endpoints.glance.port.backend_api }}
 
 {% if cinder.enabled_backends != None -%}
 enabled_backends = {{ cinder.enabled_backends }}

--- a/roles/cinder-control/tasks/main.yml
+++ b/roles/cinder-control/tasks/main.yml
@@ -34,7 +34,7 @@
     - cinder-scheduler
 
 - name: Permit access to Cinder
-  ufw: rule=allow to_port=8778 proto=tcp
+  ufw: rule=allow to_port={{ endpoints.cinder.port.haproxy_api }} proto=tcp
 
 - include: monitoring.yml tags=monitoring,common
   when: monitoring.enabled|default('True')|bool

--- a/roles/endpoints/defaults/main.yml
+++ b/roles/endpoints/defaults/main.yml
@@ -1,0 +1,165 @@
+---
+endpoints:
+  main: "{{ fqdn }}"
+  db: "{{ undercloud_floating_ip }}"
+  rabbit: "{{ undercloud_floating_ip }}"
+  identity_uri: https://{{ fqdn }}:35357
+  auth_uri: https://{{ fqdn }}:5000/v2.0
+  nova:
+    name: nova
+    type: compute
+    description: Compute Service
+    version: v2
+    url:
+      admin: https://{{ fqdn }}:8774
+      internal: https://{{ fqdn }}:8774 
+      public: https://{{ fqdn }}:8774
+      path: v2/%(tenant_id)s
+    port:
+      backend_api: 9774
+      haproxy_api: 8774
+  glance:
+    name: glance
+    type: image
+    description: Image Service
+    url:                                                                           
+      admin: https://{{ fqdn }}:9292                                                                       
+      internal: https://{{ fqdn }}:9292                                                                   
+      public: https://{{ fqdn }}:9292                                                                     
+    port:                                                                          
+      backend_api: 9393                                              
+      haproxy_api: 9292
+  cinder:
+    name: cinder
+    type: volume
+    description: Volume Service
+    version: v1
+    url:                                                                           
+      admin: https://{{ fqdn }}:8776                                                             
+      internal: https://{{ fqdn }}:8776                                                                    
+      public: https://{{ fqdn }}:8776 
+      path: v1/%(tenant_id)s
+    port:                                                                          
+      backend_api: 8778                                              
+      haproxy_api: 8776
+  cinderv2:     
+    name: cinderv2
+    type: volume                                                                   
+    description: 'Volume Service v2'                                                   
+    version: v2                                                                    
+    url:                                                                           
+      admin: https://{{ fqdn }}:8776                                                
+      internal: https://{{ fqdn }}:8776                                             
+      public: https://{{ fqdn }}:8776                                              
+      path: v2/%(tenant_id)s                                                                                                         
+  keystone:
+    name: keystone
+    type: identity
+    description: 'Identity Service'
+    version: v2.0
+    url:                                                                           
+      internal: https://{{ fqdn }}:5000                                                                   
+      public: https://{{ fqdn }}:5000 
+      admin: https://{{ fqdn }}:35357
+    port:                                                                          
+      backend_api: 5002                                                                 
+      haproxy_api: 5000
+  keystone_admin:
+    port:                                                                          
+      backend_api: 35358                                                                 
+      haproxy_api: 35357
+  keystone_legacy:
+    port:
+      backend_api: 5002
+      haproxy_api: 5001
+  keystonev3:                                                                     
+    name: keystonev3                                                              
+    type: identity                                                              
+    description: 'Identity Service v3'                                               
+    version: v3                                                               
+    url:                                                                        
+      internal: https://{{ fqdn }}:5000                                         
+      public: https://{{ fqdn }}:5000                                           
+      admin: https://{{ fqdn }}:35357                                           
+    port:                                                                       
+      backend_api: 5002                                                         
+      haproxy_api: 5000
+  novnc:
+    url:                                                                           
+      admin: https://{{ fqdn }}:6080                                                                       
+      internal: https://{{ fqdn }}:6080                                                                    
+      public: https://{{ fqdn }}:6080                                                                      
+    port:                                                                          
+      backend_api: 6081                                                                 
+      haproxy_api: 6080
+  neutron:
+    name: neutron
+    type: network
+    description: 'Network Service'
+    url:
+      admin: https://{{ fqdn }}:9696
+      internal: https://{{ fqdn }}:9696
+      public: https://{{ fqdn }}:9696
+    port:
+      backend_api: 9797
+      haproxy_api: 9696
+  heat:
+    name: heat
+    type: orchestration 
+    description: 'Heat Orchestration API'
+    version: v1
+    url:                                                                           
+      admin: https://{{ fqdn }}:8004                                                                       
+      internal: https://{{ fqdn }}:8004                                                                    
+      public: https://{{ fqdn }}:8004
+      path: v1/%(tenant_id)s                                                                      
+    port:                                                                          
+      backend_api: 8005                                                                 
+      haproxy_api: 8004
+  heat_cfn:
+    name: heat-cfn
+    type: cloudformation
+    description: 'Heat Cloudformation API'
+    version: v1
+    url:                                                                           
+      admin: https://{{ fqdn }}:8000                                                                       
+      internal: https://{{ fqdn }}:8000                                                                   
+      public: https://{{ fqdn }}:8000                                                                      
+    port:                                                                          
+      backend_api: 8001                                                                 
+      haproxy_api: 8000
+  ceilometer:
+    name: ceilometer
+    type: Telemetry
+    description: 'Telemetry Service'
+    url:                                                                           
+      admin: https://{{ fqdn }}:8777                                                                       
+      internal: https://{{ fqdn }}:8777                                                                    
+      public: https://{{ fqdn }}:8777                                                                      
+    port:                                                                          
+      backend_api: 9777                                                                 
+      haproxy_api: 8777
+  ironic:
+    name: ironic
+    type: baremetal
+    description: 'Ironic bare metal provisioning service'
+    url:                                                                           
+      admin: https://{{ fqdn }}:6385                                                                    
+      internal: https://{{ fqdn }}:6385                                                                     
+      public: https://{{ fqdn }}:6385                                                                       
+    port:                                                                          
+      backend_api: 6384                                                                 
+      haproxy_api: 6385
+  swift:
+    name: swift
+    type: object-storage
+    haproxy_vip: "{{ fqdn }}"
+    description: 'Object Storage Service'
+    version: v1
+    url:
+      admin: https://{{ fqdn }}:8090
+      internal: https://{{ fqdn }}:8090
+      public: https://{{ fqdn }}:8090
+      path: v1/%(tenant_id)s
+    port:
+      haproxy_api: 8090

--- a/roles/glance/meta/main.yml
+++ b/roles/glance/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: endpoints 
   - role: monitoring-common
   - role: logging-config
     service: glance

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -29,8 +29,8 @@
 - name: permit access to glance
   ufw: rule=allow to_port={{ item }} proto=tcp
   with_items:
-    - 9292
-    - 9393
+    - "{{ endpoints.glance.port.haproxy_api }}"
+    - "{{ endpoints.glance.port.backend_api }}"
 
 - name: install glance services
   upstart_service: name={{ item }}

--- a/roles/glance/templates/etc/glance/glance-api.conf
+++ b/roles/glance/templates/etc/glance/glance-api.conf
@@ -3,7 +3,7 @@ debug = {{ glance.logging.debug }}
 verbose = {{ glance.logging.verbose }}
 
 bind_host = 0.0.0.0
-bind_port = 9292
+bind_port = {{ endpoints.glance.port.backend_api }}
 
 sql_connection=mysql://glance:{{ secrets.db_password }}@{{ endpoints.db }}/glance?charset=utf8
 
@@ -37,7 +37,7 @@ show_image_direct_url = True
 stores = glance.store.swift.Store,
          glance.store.http.Store
 
-swift_store_auth_address = https://{{ endpoints.main }}:35358/v2.0
+swift_store_auth_address = {{ endpoints.keystone.url.admin }}/{{ endpoints.keystone.version }}
 swift_store_user = service:glance
 swift_store_key {{ secrets.service_password }}
 swift_store_create_container_on_put = True
@@ -63,8 +63,8 @@ default_store = file
 {% endif %}
 
 [keystone_authtoken]
-identity_uri = {{ endpoints.identity_uri }}
-auth_uri = {{ endpoints.auth_uri }}
+identity_uri = {{ endpoints.keystone.url.admin }}
+auth_uri = {{ endpoints.keystone.url.internal }}/{{ endpoints.keystone.version }}
 admin_tenant_name = service
 admin_user = glance
 admin_password = {{ secrets.service_password }}

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -2,3 +2,4 @@
 haproxy:
   bufsize: 16384
   stats_group: monitor
+ 

--- a/roles/haproxy/meta/main.yml
+++ b/roles/haproxy/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: endpoints 
   - role: apt-repos
     repos:
       - name: 'haproxy package repo'

--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -1,27 +1,28 @@
 # Legend: name, clear_port, enc_port, prefer_primary_backend
 {% set haproxy_services = [
     [ 'horizon', 8080, 443, false ],
-    [ 'keystone', 5000, 5001, false ],
-    [ 'keystone-admin', 35357, 35358, false ],
-    [ 'nova', 8774, 8777, false ],
-    [ 'novnc', 6080, 6081, true ],
-    [ 'glance', 9292, 9393, true ],
-    [ 'neutron', 9696, 9797, false ],
-    [ 'cinder', 8776, 8778, false ],
+    [ 'keystone', endpoints.keystone.port.backend_api , endpoints.keystone.port.haproxy_api , false ],
+    [ 'keystone-admin', endpoints.keystone_admin.port.backend_api, endpoints.keystone_admin.port.haproxy_api, false ],
+    [ 'keystone_legacy', endpoints.keystone_legacy.port.backend_api , endpoints.keystone_legacy.port.haproxy_api , false ],
+    [ 'nova', endpoints.nova.port.backend_api, endpoints.nova.port.haproxy_api, false ],
+    [ 'novnc', endpoints.novnc.port.backend_api, endpoints.novnc.port.haproxy_api, true ],
+    [ 'glance', endpoints.glance.port.backend_api, endpoints.glance.port.haproxy_api, true ],
+    [ 'neutron', endpoints.neutron.port.backend_api, endpoints.neutron.port.haproxy_api, false ],
+    [ 'cinder', endpoints.cinder.port.backend_api, endpoints.cinder.port.haproxy_api, false ],
   ]
 -%}
-{% if heat.enabled|default('True')|bool -%}
-    {% set _ = haproxy_services.append(['heat', 8004, 8005, false]) %}
-    {% set _ = haproxy_services.append(['heat-cfn', 8000, 8001, false]) %}
-{% endif -%}
 {% if ceilometer.enabled|default('True')|bool -%}
     {% set _ = haproxy_services.append(['ceilometer', 8888, 8889, false]) %}
 {% endif -%}
 {% if magnum.enabled|default('False')|bool -%}
     {% set _ = haproxy_services.append(['magnum', 9512, 9511, false]) %}
 {% endif -%}
-{% if ironic.enabled|default('False')|bool -%}
-    {% set _ = haproxy_services.append(['ironic', 6385, 6384, false]) %}
+{% if heat.enabled -%}
+    {% set _ = haproxy_services.append(['heat', endpoints.heat.port.backend_api, endpoints.heat.port.haproxy_api, false]) %}
+    {% set _ = haproxy_services.append(['heat-cfn', endpoints.heat_cfn.port.backend_api, endpoints.heat_cfn.port.haproxy_api, false]) %}
+{% endif -%}
+{% if ironic.enabled -%}
+    {% set _ = haproxy_services.append(['ironic', endpoints.ironic.port.backend_api, endpoints.ironic.port.haproxy_api, false]) %}
 {% endif -%}
 
 global

--- a/roles/heat/meta/main.yml
+++ b/roles/heat/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: endpoints 
   - role: monitoring-common
   - role: logging-config
     service: heat

--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -16,8 +16,8 @@
 - name: permit access to heat
   ufw: rule=allow to_port={{ item }} proto=tcp
   with_items:
-    - 8001
-    - 8005
+    - "{{ endpoints.heat.port.haproxy_api }}"
+    - "{{ endpoints.heat_cfn.port.haproxy_api }}"
 
 - name: install heat services
   upstart_service: name={{ item }}
@@ -41,6 +41,7 @@
 - name: create heat trusts roles
   keystone_user: role={{ item }}
                  login_user=provider_admin
+                 endpoint="{{ endpoints.keystone.url.admin }}/{{ endpoints.keystone.version }}/"
                  login_password="{{ secrets.provider_admin_password }}"
                  login_tenant_name=admin
   with_items:

--- a/roles/heat/templates/etc/heat/heat.conf
+++ b/roles/heat/templates/etc/heat/heat.conf
@@ -31,8 +31,8 @@ stack_domain_admin_password={{ secrets.stack_domain_admin_password }}
 stack_user_domain_name=heat
 max_nested_stack_depth=16
 
-heat_metadata_server_url=https://{{ endpoints.heat }}:8001
-heat_waitcondition_server_url=https://{{ endpoints.heat }}:8001/v1/waitcondition
+heat_metadata_server_url={{ endpoints.heat_cfn.url.internal }}
+heat_waitcondition_server_url={{ endpoints.heat_cfn.url.internal }}/{{ endpoints.heat_cfn.version }}/waitcondition
 instance_connection_is_secure=1
 region_name_for_services=RegionOne
 
@@ -45,7 +45,7 @@ connection=mysql://heat:{{ secrets.db_password }}@{{ endpoints.db }}/heat?charse
 
 [keystone_authtoken]
 identity_uri = {{ endpoints.identity_uri }}
-auth_uri = https://{{ endpoints.keystone }}:5001/v2.0
+auth_uri = {{ endpoints.keystone.url.internal }}/{{ endpoints.keystone.version }}
 admin_tenant_name = service
 admin_user = heat
 admin_password = {{ secrets.service_password }}
@@ -55,12 +55,12 @@ delay_auth_decision=true
 
 [heat_api]
 bind_host = 0.0.0.0
-bind_port = 8004
+bind_port = {{ endpoints.heat.port.backend_api }}
 ca_file = {{ heat.cafile }}
 
 [heat_api_cfn]
 bind_host = 0.0.0.0
-bind_port = 8000
+bind_port = {{ endpoints.heat_cfn.port.backend_api }}
 ca_file = {{ heat.cafile }}
 
 [clients]

--- a/roles/horizon/meta/main.yml
+++ b/roles/horizon/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: endpoints
   - role: monitoring-common
   - role: openstack-source
     project_name: horizon

--- a/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
+++ b/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
@@ -122,17 +122,17 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # For multiple regions uncomment this configuration, and add (endpoint, title).
 # AVAILABLE_REGIONS = [
-#     ('http://cluster1.example.com:5000/v2.0', 'cluster1'),
-#     ('http://cluster2.example.com:5000/v2.0', 'cluster2'),
+#     ('http://cluster1.example.com:5001/v2.0', 'cluster1'),
+#     ('http://cluster2.example.com:5001/v2.0', 'cluster2'),
 # ]
 {% if horizon.keystone_api_version == 3 -%}
 AVAILABLE_REGIONS = [
-     ('https://{{ endpoints.main }}:5001/v3', 'RegionOne'),
+     ('{{ endpoints.keystone.url.internal }}/{{ endpoints.keystonev3.version  }}', 'RegionOne'),
 ]
 {% endif -%}
 
 OPENSTACK_HOST = "{{ endpoints.main }}"
-OPENSTACK_KEYSTONE_URL = "https://%s:5001/v{{horizon.keystone_api_version}}" % OPENSTACK_HOST
+OPENSTACK_KEYSTONE_URL = "https://%s:{{ endpoints.keystone.port.haproxy_api }}/v{{horizon.keystone_api_version}}" % OPENSTACK_HOST
 OPENSTACK_KEYSTONE_DEFAULT_ROLE = "service"
 SESSION_TIMEOUT = {{ horizon.session_timeout }}
 

--- a/roles/ironic-common/meta/main.yml
+++ b/roles/ironic-common/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: endpoints 
   - role: logging-config
     service: ironic
     logdata: "{{ ironic.logs }}"

--- a/roles/ironic-common/templates/etc/ironic/ironic.conf
+++ b/roles/ironic-common/templates/etc/ironic/ironic.conf
@@ -30,10 +30,10 @@ enabled_drivers={{ ironic.enabled_drivers|join(',') }}
 
 [keystone_authtoken]
 # This should work, but doesn't ?
-# identity_uri = https://{{ endpoints.keystone }}:5001/
-auth_uri = https://{{ endpoints.keystone }}:5001/
-auth_host = {{ endpoints.keystone }}
-auth_port = 5001
+# identity_uri = {{ endpoints.keystone.url.internal }}/
+auth_uri = {{ endpoints.keystone.url.internal }}/
+auth_host = {{ endpoints.main }}
+auth_port = {{ endpoints.keystone.port.haproxy_api }}
 auth_protocol = https
 admin_tenant_name = service
 admin_user = ironic
@@ -41,7 +41,7 @@ admin_password = {{ secrets.service_password }}
 cafile = {{ ironic.cafile }}
 
 [neutron]
-url=https://{{ endpoints.main }}:9797
+url={{ endpoints.neutron.url.internal }}
 
 [glance]
 glance_host={{ endpoints.main }}
@@ -51,4 +51,4 @@ tftp_server = {{ ironic.tftp_server }}
 tftp_root = {{ ironic.tftpboot_path }}
 
 [conductor]
-api_url = {{ ironic.api_url.scheme}}://{{ ironic.api_url.host }}:{{ ironic.api_url.port }}
+api_url = {{ ironic.api_url.scheme}}://{{ ironic.api_url.host }}:{{ endpoints.ironic.port.backend_api }}

--- a/roles/keystone-setup/meta/main.yml
+++ b/roles/keystone-setup/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: endpoints

--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -35,6 +35,7 @@
   keystone_user: tenant={{ item }}
                  tenant_description="{{ item }} tenant"
                  token={{ admin_token }}
+                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/" 
   with_items: keystone.tenants
 
 - name: keystone users
@@ -42,6 +43,7 @@
                  password={{ item.password }}
                  tenant={{ item.tenant }}
                  token={{ admin_token }}
+                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
   with_items: keystone.users
 
 - name: keystone roles
@@ -49,6 +51,7 @@
                  user={{ item.user }}
                  tenant={{ item.tenant }}
                  token={{ admin_token }}
+                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
   with_items: keystone.user_roles
 
 - name: heat stack user

--- a/roles/keystone/meta/main.yml
+++ b/roles/keystone/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: endpoints
   - role: monitoring-common
   - role: logging-config
     service: keystone

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -53,8 +53,8 @@
 - name: permit access to keystone
   ufw: rule=allow to_port={{ item }} proto=tcp
   with_items:
-    - 5001
-    - 35358
+    - "{{ endpoints.keystone.port.haproxy_api }}"
+    - "{{ endpoints.keystone_admin.port.haproxy_api }}"
 
 - name: add cron job to clean up expired tokens
   template:

--- a/roles/keystone/templates/etc/keystone/keystone.conf
+++ b/roles/keystone/templates/etc/keystone/keystone.conf
@@ -2,8 +2,11 @@
 debug = {{ keystone.logging.debug }}
 verbose = {{ keystone.logging.verbose }}
 
-public_endpoint = https://{{ endpoints.keystone }}:5001/
-admin_endpoint = https://{{ endpoints.keystone }}:35358/
+public_endpoint = {{ endpoints.keystone.url.public }}/
+admin_endpoint = {{ endpoints.keystone.url.admin }}/
+
+public_port = {{ endpoints.keystone.port.backend_api }}
+admin_port = {{ endpoints.keystone_admin.port.backend_api }}
 
 # Logging #
 log_dir = /var/log/keystone

--- a/roles/neutron-common/meta/main.yml
+++ b/roles/neutron-common/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: endpoints 
   - role: apt-repos
   - role: monitoring-common
   - role: logging-config

--- a/roles/neutron-common/tasks/main.yml
+++ b/roles/neutron-common/tasks/main.yml
@@ -49,7 +49,7 @@
 # when neutron can use tenant_name.
 - name: Fetch service tenant info from keystone
   keystone_user: tenant=service
-                 endpoint=https://{{ endpoints.main }}:5001/v2.0/
+                 endpoint="{{ endpoints.keystone.url.admin }}/{{ endpoints.keystone.version }}/"
                  login_tenant_name=admin
                  login_user=provider_admin
                  login_password={{ secrets.provider_admin_password }}

--- a/roles/neutron-common/templates/etc/neutron/l3_agent.ini
+++ b/roles/neutron-common/templates/etc/neutron/l3_agent.ini
@@ -9,11 +9,11 @@ interface_driver = neutron.agent.linux.interface.BridgeInterfaceDriver
 interface_driver = neutron.agent.linux.interface.OVSInterfaceDriver
 {% endif %}
 
-auth_url = https://{{ endpoints.keystone }}:35358/v2.0
+auth_url = {{ endpoints.keystone.url.admin }}/{{ endpoints.keystone.version }}
 admin_tenant_name = service
 admin_user = neutron
 admin_password = {{ secrets.service_password }}
-metadata_ip = {{ endpoints.nova }}
+metadata_ip = {{ endpoints.main }}
 use_namespaces = True
 {% if neutron.plugin == 'ml2' %}
 external_network_bridge =

--- a/roles/neutron-common/templates/etc/neutron/metadata_agent.ini
+++ b/roles/neutron-common/templates/etc/neutron/metadata_agent.ini
@@ -1,7 +1,7 @@
 [DEFAULT]
 debug = False
 
-auth_url = https://{{ endpoints.keystone }}:35358/v2.0
+auth_url = {{ endpoints.keystone.url.admin }}/{{ endpoints.keystone.version }}
 auth_region = RegionOne
 admin_tenant_name = service
 admin_user = neutron

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -44,7 +44,7 @@ rabbit_password = {{ secrets.rabbit_password }}
 rpc_backend = neutron.openstack.common.rpc.impl_kombu
 
 bind_host = 0.0.0.0
-bind_port = 9696
+bind_port = {{ endpoints.neutron.port.backend_api }}
 
 api_paste_config = api-paste.ini
 
@@ -59,7 +59,7 @@ lock_path = $state_path/lock
 # ======== neutron nova interactions ==========
 notify_nova_on_port_data_changes = True
 notify_nova_on_port_status_changes = True
-nova_url = https://{{ endpoints.nova }}:8777/v2
+nova_url = {{ endpoints.nova.url.internal }}/{{ endpoints.nova.version }}
 nova_region_name = RegionOne
 nova_admin_username = neutron
 nova_admin_tenant_id = {{ service_tenant.id }}

--- a/roles/neutron-control/tasks/main.yml
+++ b/roles/neutron-control/tasks/main.yml
@@ -50,7 +50,7 @@
   service: name=neutron-server state=started
 
 - name: Permit access to Neutron
-  ufw: rule=allow to_port=9797 proto=tcp
+  ufw: rule=allow to_port={{ endpoints.neutron.port.haproxy_api }} proto=tcp
 
 - include: monitoring.yml tags=monitoring,common
   when: monitoring.enabled|default('True')|bool

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -23,7 +23,7 @@ nova:
   python_libvirt_version: 1.2.2-0ubuntu2~cloud0
   qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.16~cloud0
   librdb1_version: 0.80.9-0ubuntu0.14.04.2~cloud0
-  glance_endpoint: http://{{ endpoints.glance }}:9292
+  glance_endpoint: http://{{ undercloud_floating_ip }}:9393
   reserved_host_disk_mb: 51200
   controller_reserve_ram: 4096
   compute_reserve_ram: 2048

--- a/roles/nova-common/meta/main.yml
+++ b/roles/nova-common/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: endpoints
   - role: apt-repos
     repos:
       - repo: 'deb {{ apt_repos.cloud_archive.repo }} precise-updates/icehouse main'

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -2,6 +2,8 @@
 debug = {{ nova.logging.debug }}
 verbose = {{ nova.logging.verbose }}
 
+osapi_compute_listen_port={{ endpoints.nova.port.backend_api }}
+
 # Policy #
 allow_resize_to_same_host = True
 
@@ -37,12 +39,12 @@ vcpu_pin_set = "1-31"
 {% endif -%}
 
 # Services offered #
-s3_host={{ endpoints.keystone }}
-ec2_host={{ endpoints.keystone }}
-ec2_dmz_host={{ endpoints.keystone }}
-ec2_url=http://{{ endpoints.nova }}:8773/services/Cloud
-cc_host={{ endpoints.keystone }}
-nova_url=http://{{ endpoints.nova }}:8774/v1.1/
+s3_host={{ endpoints.main }}
+ec2_host={{ endpoints.main }}
+ec2_dmz_host={{ endpoints.main }}
+ec2_url=http://{{ endpoints.main }}:8773/services/Cloud
+cc_host={{ endpoints.main }}
+nova_url=http://{{ endpoints.main }}:{{ endpoints.nova.port.backend_api }}/v1.1/
 
 # Paths to important items #
 state_path=/var/lib/nova
@@ -55,12 +57,12 @@ keys_path=/var/lib/nova/keys
 use_deprecated_auth=false
 auth_strategy=keystone
 use_forwarded_for=true
-keystone_ec2_url=https://{{ endpoints.keystone }}:5001/v2.0/ec2tokens
+keystone_ec2_url={{ endpoints.keystone.url.public }}/{{ endpoints.keystone.version }}/ec2tokens
 
 # Vnc configuration
 novnc_enabled=false
-novncproxy_base_url=https://{{ endpoints.vnc }}:6081/vnc_auto.html
-novncproxy_port=6080
+novncproxy_base_url={{ endpoints.novnc.url.internal }}/vnc_auto.html
+novncproxy_port={{ endpoints.novnc.port.backend_api }}
 vncserver_proxyclient_address={{ primary_ip }}
 vncserver_listen={{ primary_ip }}
 
@@ -167,8 +169,8 @@ use_local = False
 workers = {{ nova.conductor_workers }}
 
 [keystone_authtoken]
-identity_uri = {{ endpoints.identity_uri }}
-auth_uri = {{ endpoints.auth_uri }}
+identity_uri = {{ endpoints.keystone.url.admin }}
+auth_uri = {{ endpoints.keystone.url.internal }}/{{ endpoints.keystone.version }}
 admin_tenant_name = service
 admin_user = nova
 admin_password = {{ secrets.service_password }}
@@ -176,12 +178,12 @@ signing_dir = /var/cache/nova/api
 cafile = {{ nova.cafile }}
 
 [neutron]
-url=https://{{ endpoints.neutron }}:9797
+url={{ endpoints.neutron.url.internal }}
 auth_strategy=keystone
 admin_tenant_name=service
 admin_username=neutron
 admin_password={{ secrets.service_password }}
-admin_auth_url=https://{{ endpoints.keystone }}:35358/v2.0
+admin_auth_url={{ endpoints.keystone.url.admin}}/{{ endpoints.keystone.version }}
 ca_certificates_file={{ nova.cafile }}
 
 service_metadata_proxy=true
@@ -198,7 +200,7 @@ ca_certificates_file = {{ nova.cafile }}
 [ironic]
 admin_username=ironic
 admin_password={{ secrets.service_password }}
-admin_url=https://{{ endpoints.main }}:35358/v2.0
+admin_url={{ endpoints.keystone.url.admin }}/{{ endpoints.keystone.version }}
 admin_tenant_name=service
-api_endpoint=https://{{ endpoints.main }}:6384/v1
+api_endpoint={{ endpoints.ironic.url.internal }}/{{ endpoints.ironic.version }}
 {% endif -%}

--- a/roles/nova-control/tasks/main.yml
+++ b/roles/nova-control/tasks/main.yml
@@ -48,7 +48,7 @@
     - nova-scheduler
 
 - name: permit access to nova api
-  ufw: rule=allow to_port=8777 proto=tcp
+  ufw: rule=allow to_port={{ endpoints.nova.port.haproxy_api }} proto=tcp
 
 - include: novnc.yml tags=novnc
 

--- a/roles/nova-control/tasks/novnc.yml
+++ b/roles/nova-control/tasks/novnc.yml
@@ -31,4 +31,4 @@
   service: name=nova-novncproxy state=started
 
 - name: Permit access to NoVNC
-  ufw: rule=allow to_port=6081 proto=tcp
+  ufw: rule=allow to_port={{ endpoints.novnc.port.haproxy_api }} proto=tcp

--- a/roles/novnc/meta/main.yml
+++ b/roles/novnc/meta/main.yml
@@ -1,0 +1,3 @@
+---                                                                             
+dependencies:                                                                   
+  - role: endpoints 

--- a/roles/novnc/tasks/main.yml
+++ b/roles/novnc/tasks/main.yml
@@ -19,4 +19,4 @@
 - service: name=nova-novncproxy state=started
 
 - name: Permit access to NoVNC
-  ufw: rule=allow to_port=6081 proto=tcp
+  ufw: rule=allow to_port={{ endpoints.nova.port.novnc_haproxy_api }} proto=tcp

--- a/roles/openstack-network/meta/main.yml
+++ b/roles/openstack-network/meta/main.yml
@@ -1,0 +1,3 @@
+---                                                                             
+dependencies:                                                                   
+  - role: endpoints 

--- a/roles/openstack-network/tasks/main.yml
+++ b/roles/openstack-network/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: determine Neutron external interface name
   neutron_network: name=external
-                   auth_url=https://{{ endpoints.main }}:5001/v2.0/
+                   auth_url={{ endpoints.keystone.url.internal }}/{{ endpoints.keystone.version }}/
                    login_tenant_name=admin
                    login_username=provider_admin
                    login_password={{ secrets.provider_admin_password }}

--- a/roles/openstack-setup/meta/main.yml
+++ b/roles/openstack-setup/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: endpoints

--- a/roles/swift-common/meta/main.yml
+++ b/roles/swift-common/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: endpoints 
   - role: monitoring-common
   - role: logging-config
     service: swift

--- a/roles/swift-proxy/templates/etc/swift/proxy-server.conf
+++ b/roles/swift-proxy/templates/etc/swift/proxy-server.conf
@@ -86,8 +86,8 @@ use = egg:swift#dlo
 
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory
-identity_uri = https://{{ endpoints.keystone }}:35358/
-auth_uri = https://{{ endpoints.keystone }}:5001/
+identity_uri = {{ endpoints.keystone.url.admin }}/
+auth_uri = {{ endpoints.keystone.url.internal }}/
 admin_password = {{ secrets.service_password }}
 admin_tenant_name = service
 admin_user = swift


### PR DESCRIPTION
Port variable change

uncommented code

uncommented code

added old all.yml and hosts file

added a role for endpoints

changed hard coded ports to variables

Added endpoint role dependency and cleaned up code

cleaned up code

removed unwanted line

added keystone_user endpoints variable since we arent using the default ports as backend

removed left over code

Update main.yml

Update main.yml

removed code from cinder-common by mistake- fixing it