### PR TITLE
fixed ansible issue for ceph disk_detection

### DIFF
--- a/library/ceph_disks.py
+++ b/library/ceph_disks.py
@@ -167,8 +167,9 @@ def main():
         rc, adapterInfo, err = module.run_command(cmd, check_rc=False)
 
     ssd_devices = find_available_devices(module, adaptecTest, lsiTest, path, diskProps, adapterInfo)
+    devices_dict = {'ssd_devices': ssd_devices}
 
-    module.exit_json(changed=False, ansible_facts=ssd_devices)
+    module.exit_json(changed=False, ansible_facts=devices_dict)
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *


### PR DESCRIPTION
Previous disk_detection code had an ansible issue where the script wouldn't run. These changes, tested throughout, should be enough to fix that problem.

Story: https://hub.jazz.net/ccm08/quickplanner/jazzhub.html#items:projectId=_MM_y5SldEeWSQOc0JZWznA&serverId=hub.jazz.net&planType=allwork&allIterations=true&itemId=104678

IDS Epic: https://hub.jazz.net/ccm08/quickplanner/jazzhub.html#items:projectId=_MM_y5SldEeWSQOc0JZWznA&serverId=hub.jazz.net&planType=allwork&allIterations=true&itemId=97391
