### PR TITLE
Fix virtualenv_base for package install

### DIFF
--- a/roles/openstack-package/defaults/main.yml
+++ b/roles/openstack-package/defaults/main.yml
@@ -2,3 +2,4 @@ openstack_package_version: 11.0-bbc73
 openstack_package:
   package_name: 'openstack-{{ project_name }}-{{ openstack_package_version }}'
   rootwrap: "{{ rootwrap|default(False)|bool }}"
+  virtualenv_base: /opt/bbc/openstack-{{ openstack_package_version }}

--- a/roles/openstack-package/tasks/main.yml
+++ b/roles/openstack-package/tasks/main.yml
@@ -37,7 +37,7 @@
 
 - name: update-alternatives
   alternatives: name={{ item }}
-                path={{ virtualenv_base }}/{{ project_name }}/bin/{{ item }}
+                path={{ openstack_package.virtualenv_base }}/{{ project_name }}/bin/{{ item }}
                 link=/usr/local/bin/{{ item }}
   with_items: alternatives
   when: alternatives is defined


### PR DESCRIPTION
Ran into an issue with this when trying to deploy from packages.  Ansible wasn't finding the variable in it's scope.  Looked around and didn't find anything in the defaults either...

I modeled the fix after how it is done in the roles/openstack-source/ role, I believe this is how it was intended to be.