### PR TITLE
Unfreeze eventlet version

### DIFF
--- a/roles/common/tasks/python.yml
+++ b/roles/common/tasks/python.yml
@@ -4,8 +4,8 @@
        version={{ item.rev }} accept_hostkey=True
   with_items: common.python_extra_packages
 
-- name: freeze eventlet to 0.15.2 for nova to work
-  pip: name=eventlet version=0.15.2
+- name: pip install eventelt
+  pip: name=eventlet
 
 - name: install drivers
   command: python setup.py install chdir=/opt/stack/{{ item.name }}

--- a/roles/common/tasks/python.yml
+++ b/roles/common/tasks/python.yml
@@ -4,7 +4,7 @@
        version={{ item.rev }} accept_hostkey=True
   with_items: common.python_extra_packages
 
-- name: pip install eventelt
+- name: pip install eventlet
   pip: name=eventlet
 
 - name: install drivers


### PR DESCRIPTION
Kilo Swift needs version > 0.16.1 and reason that eventlet was set to 0.15.2 for Nova is not valid. Did a cloud deploy (from source) with latest eventlet and there were no issues