### PR TITLE
horizon UI changes through customization module for cloud_admin/project_admin

### DIFF
--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -12,9 +12,8 @@ horizon:
       - { name: python-memcached }
       - { name: python-memcached, version: '1.48' }
       - { name: stevedore, version: '1.5.0' }
+      - { name: "git+https://github.com/davidcusatis/bluebox-horizon-customization#egg=bluebox-horizon-customization"}
     system_dependencies:
       - apache2
       - libapache2-mod-wsgi
       - libmysqlclient-dev
-
-

--- a/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
+++ b/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
@@ -47,6 +47,7 @@ OPENSTACK_API_VERSIONS = {
 
 # Default OpenStack Dashboard configuration.
 HORIZON_CONFIG = {
+    'customization_module': 'bluebox_horizon_customization.horizon_customization',
     'dashboards': ('project', 'admin', 'settings',),
     'default_dashboard': 'project',
     'user_home': 'openstack_dashboard.views.get_user_home',


### PR DESCRIPTION
hid all admin panels from cloud_admin role, except host_aggregates.
hid domains panel, and resource types panel from non full admins.