### PR TITLE
Unpin glanceclient.

### DIFF
--- a/playbooks/tests/tasks/controller.yml
+++ b/playbooks/tests/tasks/controller.yml
@@ -118,7 +118,9 @@
     shell: . /root/stackrc; glance image-list | grep cirros
 
   - name: cirros image is public
-    shell: . /root/stackrc; glance image-show cirros |grep is_public |grep True
+    shell: . /root/stackrc; glance --os-image-api-version 1 image-show cirros |grep is_public |grep True
+    # Use glance version 1 API until we replace this with something more
+    # elegant
 
   - name: nova has a working api
     shell: . /root/stackrc; nova list | grep ID

--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -3,7 +3,7 @@ client:
   self_signed_cert: false
   names:
     - python-keystoneclient
-    - python-glanceclient<1.0.0
+    - python-glanceclient>=1.1.0
     - python-novaclient<2.27.0
     - python-neutronclient
     - python-cinderclient

--- a/roles/common/tasks/python.yml
+++ b/roles/common/tasks/python.yml
@@ -12,4 +12,4 @@
   with_items: common.python_extra_packages
 
 - name: install shade for ansible modules
-  pip: name=git+https://github.com/openstack-infra/shade.git@ab1c566cb8afbf477492180e2cc8257817a06893#egg=shade
+  pip: name=shade

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -42,6 +42,7 @@ nova:
     python_dependencies:
       - { name: mysql-python }
       - { name: python-memcached }
+      - { name: requests, version: 2.7.0 }
     system_dependencies:
       - libjs-jquery-tablesorter
       - libmysqlclient-dev


### PR DESCRIPTION
The pinned version was having difficulty in parsing Kilo's glance
output. But the new version defaults to API v2, which does not translate
image names to IDs, so for now use v1 when looking at the cirros image
in our tests.