### PR TITLE
Remove motd script from ceph monitor nodes

### DIFF
--- a/roles/ceph-monitor/tasks/main.yml
+++ b/roles/ceph-monitor/tasks/main.yml
@@ -61,13 +61,6 @@
            creates=/etc/ceph/ceph.{{ item.name }}.keyring
   with_items: ceph_monitor.openstack_keys
 
-- name: drop in a motd script to report status when logging in
-  template: src=etc/update-motd.d/92-ceph
-            dest=/etc/update-motd.d/92-ceph
-            owner=root
-            group=root
-            mode=0755
-
 - include: monitoring.yml
   tags:
     - monitoring

--- a/roles/ceph-monitor/templates/etc/update-motd.d/92-ceph
+++ b/roles/ceph-monitor/templates/etc/update-motd.d/92-ceph
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-echo -n "Ceph state is: "
-/usr/bin/ceph health
-echo ""


### PR DESCRIPTION
This script is doing more harm than good. When the cluster is in a bad
state, it takes forever to get the status and causes issues with ssh.