### PR TITLE
Unpin glanceclient (1.2.x)

### DIFF
--- a/playbooks/tests/tasks/controller.yml
+++ b/playbooks/tests/tasks/controller.yml
@@ -98,7 +98,9 @@
     shell: . /root/stackrc; glance image-list | grep cirros
 
   - name: cirros image is public
-    shell: . /root/stackrc; glance image-show cirros |grep is_public |grep True
+    shell: . /root/stackrc; glance --os-image-api-version 1 image-show cirros |grep is_public |grep True
+    # Use glance version 1 API until we replace this with something more
+    # elegant
 
   - name: nova has a working api
     shell: . /root/stackrc; nova list | grep ID

--- a/playbooks/tests/tasks/integration.yml
+++ b/playbooks/tests/tasks/integration.yml
@@ -74,7 +74,7 @@
     shell: . /root/stackrc; nova volume-create --display-name=turtle-vol 2
 
   - name: discover volume id
-    shell: . /root/stackrc; nova volume-list |awk '/turtle-vol/ {print $2}'
+    shell: . /root/stackrc; cinder list |awk '/turtle-vol/ {print $2}'
     register: turtle_vol
 
   - name: nova can attach cinder volume

--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -3,7 +3,7 @@ client:
   self_signed_cert: false
   names:
     - python-keystoneclient
-    - python-glanceclient<1.0.0
+    - python-glanceclient>=1.1.0
     - python-novaclient
     - python-neutronclient<2.27.0
     - python-cinderclient


### PR DESCRIPTION
The pinned version was having difficulty in parsing Kilo's glance
output. But the new version defaults to API v2, which does not translate
image names to IDs, so for now use v1 when looking at the cirros image
in our tests.

(cherry picked from commit f3bd92bb8576ed7da61dad2dcf8b657f60562184)