### PR TITLE
jsonrpclib bumped and is broken

### DIFF
--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -28,6 +28,7 @@ neutron:
     python_dependencies:
       - { name: mysql-python }
       - { name: "git+git://github.com/openstack/neutron-lbaas.git@stable/kilo#egg=neutron-lbaas" }
+      - { name: jsonrpclib, version: "0.1.3" }
     system_dependencies:
       - libmysqlclient-dev
   alternatives:


### PR DESCRIPTION
Pin it down to 0.1.3 until upstream sorts this out. This was breaking
neutron installs.