### PR TITLE
Added playbook to unmount and clear all disks

### DIFF
--- a/playbooks/unmount-and-clear-disks.yml
+++ b/playbooks/unmount-and-clear-disks.yml
@@ -1,0 +1,54 @@
+#
+# This playbook preps a node for ceph/swift deployment with Ursula
+# by unmounting and clearing specified drives in the env's all.yml
+#
+# Expects a hosts name as input into --extra-vars
+#
+# ex. ursula envs/example/swift playbooks/test-playbook.yml --extra-vars 'hosts=swiftnode'
+#
+
+---
+- name: unmount and clear all drives
+  hosts: "{{ hosts }}"
+
+  tasks:
+  - name: install dependencies
+    apt: pkg="gdisk"
+
+  - name: define disk list
+    set_fact: disk_list="{{ swift.disks }}"
+    when: hosts == "swiftnode"
+
+  - name: define disk list
+    set_fact: disk_list="{{ ceph.disks }}"
+    when: hosts == "ceph_osds"
+
+  - name: create list of disks present on node
+    set_fact:
+      disks_present: |
+        {% set comma = joiner(",") %}
+        [{% for item in hostvars[inventory_hostname]['ansible_devices'] -%}
+            {{ comma() }}"{{ item }}"
+        {%- endfor %}]
+
+  - name: unmount all mounted devices
+    mount: name={{ item.mount }} src={{ item.device }} fstype={{ item.fstype }} state=unmounted
+    with_items: "{{ ansible_mounts }}"
+    when: (item.mount != "/" or item.mount != "/boot") and "{{ item.device | relpath('/dev') }}" in disk_list
+
+  - name: unmount shared partition if defined
+    mount: name={{ item.mount }} src={{ item.device }} fstype={{ item.fstype }} state=unmounted
+    with_items: "{{ ansible_mounts }}"
+    when: swift.os_shared_partition  is defined and item.device == swift.os_shared_partition and hosts == "swiftnode"
+
+  - name: destroy GPT structures
+    shell: sgdisk --zap "/dev/"{{ item }}
+    ignore_errors: true
+    with_items: disk_list
+    when: item in disks_present
+
+  - name: clear all devices
+    shell: dd if=/dev/zero of="/dev/"{{ item }} bs=1M count=512
+    ignore_errors: true
+    with_items: disk_list
+    when: item in disks_present


### PR DESCRIPTION
To prep for swift deployment, this playbook unmounts and clears all drives specified for that node type. Skips unmounting any drives not defined as well as clearing any partitions. 