### PR TITLE
Add support for neutron l3ha

### DIFF
--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -12,11 +12,20 @@ neutron:
   service_plugins:
     - neutron.services.l3_router.l3_router_plugin.L3RouterPlugin
   enable_flat_networks: False
+  l3ha:
+    enabled: False
+    max_agents: 2
+    min_agents: 2
+    cidr: 169.254.192.0/18
+    password: password
+    interval: 2
+
   # Tunneling encapsulations enabled e.g. gre, vxlan
   # Including any tunnels will enable tunnling
   tunnel_types: []
   lbaas:
     enable: False
+    default: True
     interface_driver: neutron.agent.linux.interface.BridgeInterfaceDriver
     service_plugin:
       - neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPluginv2

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -23,6 +23,15 @@ service_plugins = {{ neutron.service_plugins|join(',') }}
 {% endif %}
 allow_overlapping_ips = {{ neutron.allow_overlapping_ips }}
 
+{% if neutron.l3ha.enabled|bool %}
+l3_ha = {{ neutron.l3ha.default }}
+max_l3_agents_per_router = {{ neutron.l3ha.max_agents }}
+min_l3_agents_per_router = {{ neutron.l3ha.min_agents }}
+l3_ha_net_cidr = 169.254.192.0/18
+ha_vrrp_advert_int = {{ neutron.l3ha.interval }}
+ha_vrrp_auth_password = {{ neutron.l3ha.password }}
+{% endif %}
+
 {% macro rabbitmq_hosts() -%}
 {% for host in groups['controller'] -%}
    {% if loop.last -%}

--- a/roles/neutron-data-network/tasks/main.yml
+++ b/roles/neutron-data-network/tasks/main.yml
@@ -8,6 +8,12 @@
     - ucarp
     - radvd
 
+- name: install packages for l3ha
+  apt: pkg={{ item }}
+    - keepalived
+    - conntrackd
+  when: neutron.l3ha.enabled|bool
+
 - include: dnsmasq.yml
 
 - name: ensure ovs br-ex bridge present

--- a/roles/neutron-data-network/templates/etc/ipchanged/add_floating_ip
+++ b/roles/neutron-data-network/templates/etc/ipchanged/add_floating_ip
@@ -24,6 +24,8 @@ function neutron_and_local_agents_alive () {
 
 logger "ipchanged UP floating interface"
 
+{% if not neutron.l3ha.enabled|bool %}
+
 # restart neutron-server so that it re-connects to rabbit
 restart neutron-server
 
@@ -45,3 +47,5 @@ if [[ neutron_and_local_agents_alive ]]; then
 else
   logger "ipchanged UP timed out waiting for neutron agents"
 fi
+
+{% endif %}


### PR DESCRIPTION
neutron l3ha uses keepalived to create a shared network to distribute
HA neutron routers.

It appears to play okay with the existing ucarp stuff,  but could probably
do with some stronger testing.   it's feature flagged, so can probably be
merged but disabled until further testing is done.