### PR TITLE
Cinder backup changes to use Swift internal URL

### DIFF
--- a/roles/cinder-common/tasks/main.yml
+++ b/roles/cinder-common/tasks/main.yml
@@ -41,6 +41,10 @@
 - include: ceph_integration.yml
   when: ceph.enabled
 
+- name: Error out when Swift HAProxy VIP is not defined
+  fail: msg="Swift HAProxy VIP must be set for Cinder backup to function correctly"
+  when: swift.enabled and not endpoints.swift.haproxy_vip
+
 - name: cinder config
   template: src={{ item }} dest=/etc/cinder mode=0644
   with_fileglob: ../templates/etc/cinder/*

--- a/roles/cinder-common/tasks/main.yml
+++ b/roles/cinder-common/tasks/main.yml
@@ -41,9 +41,9 @@
 - include: ceph_integration.yml
   when: ceph.enabled
 
-- name: Error out when Swift HAProxy VIP is not defined
-  fail: msg="Swift HAProxy VIP must be set for Cinder backup to function correctly"
-  when: swift.enabled and not endpoints.swift.haproxy_vip
+- name: error out when swift haproxy vip is not updated
+  fail: msg="swift haproxy vip needs to be updated for use with cinder backup"
+  when: swift.enabled|bool and (endpoints.swift.haproxy_vip == fqdn)
 
 - name: cinder config
   template: src={{ item }} dest=/etc/cinder mode=0644

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -60,6 +60,7 @@ default_backend = {{ cinder.default_backend }}
 
 {% if swift.enabled|bool -%}
 backup_driver = cinder.backup.drivers.swift
+backup_swift_url = http://{{ endpoints.swift.haproxy_vip }}:{{ endpoints.swift.port.cinder_backup }}/v1/
 {% endif -%}
 
 {% for backend in cinder.backends %}

--- a/roles/endpoints/defaults/main.yml
+++ b/roles/endpoints/defaults/main.yml
@@ -153,7 +153,7 @@ endpoints:
   swift:
     name: swift
     type: object-storage
-    haproxy_vip: "{{ fqdn }}"
+    haproxy_vip:
     description: 'Object Storage Service'
     version: v1
     url:
@@ -163,3 +163,5 @@ endpoints:
       path: v1/%(tenant_id)s
     port:
       haproxy_api: 8090
+      cinder_backup: 8091
+      proxy_api: 8080

--- a/roles/endpoints/defaults/main.yml
+++ b/roles/endpoints/defaults/main.yml
@@ -153,7 +153,7 @@ endpoints:
   swift:
     name: swift
     type: object-storage
-    haproxy_vip:
+    haproxy_vip: "{{ fqdn }}"
     description: 'Object Storage Service'
     version: v1
     url:

--- a/roles/haproxy/templates/etc/haproxy/haproxy_swift.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_swift.cfg
@@ -23,25 +23,22 @@ defaults
   stats refresh 10s
   stats uri /stats
 
-{% for name, clear_port, enc_port in
-  [
-    [ 'swift', 8080, 8090 ],
-  ]
-%}
-
-frontend {{ name }}
+frontend swift
   # Require TLS with AES
-  bind :{{ enc_port }} ssl crt /etc/haproxy/openstack.pem no-sslv3 ciphers AES128-SHA:AES256-SHA
-  default_backend {{ name }}
+  bind :{{ endpoints.swift.port.haproxy_api }} ssl crt /etc/haproxy/openstack.pem no-sslv3 ciphers AES128-SHA:AES256-SHA
+  default_backend swift
 
-backend {{ name }}
+frontend cinder-backup-swift
+  bind :{{ endpoints.swift.port.cinder_backup }}
+  default_backend swift
+
+backend swift
   mode    http
   balance source
   option  httpchk HEAD /healthcheck HTTP/1.0
   option  forwardfor
   option  httpclose
   {% for host in groups['swiftnode'] -%}
-  server proxy{{ loop.index }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ clear_port }} weight 5 check inter 2000
+  server proxy{{ loop.index }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ endpoints.swift.port.proxy_api }} weight 5 check inter 2000
   {% endfor -%}
 
-{% endfor %}

--- a/roles/swift-proxy/defaults/main.yml
+++ b/roles/swift-proxy/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 swift_proxy:
   ip: "{{ primary_ip }}"
-  port: 8080
+  port: "{{ endpoints.swift.port.proxy_api }}"
   workers: 10
   operator_roles: Member,_member,admin,cloud_admin,project_admin
   reseller_admin_role: cloud_admin

--- a/roles/swift-proxy/meta/main.yml
+++ b/roles/swift-proxy/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - role: memcached
+  - role: endpoints


### PR DESCRIPTION
Cinder backup to Swift is currently going through public endpoint. Made changes to use internal URL that doesn't require SSL termination