### PR TITLE
Ceilometer Standard Ports

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -353,7 +353,7 @@ keystone:
     - name: glance
       type: image
       description: 'Image Service'
-      public_url: "{{ endpoints.glance.url.public }}" 
+      public_url: "{{ endpoints.glance.url.public }}"
       internal_url: "{{ endpoints.glance.url.internal }}"
       admin_url: "{{ endpoints.glance.url.admin }}"
     - name: neutron
@@ -371,7 +371,7 @@ keystone:
     - name: cinderv2
       type: volumev2
       description: 'Volume Service v2'
-      public_url: "{{ endpoints.cinderv2.url.public }}/{{ endpoints.cinderv2.url.path }}" 
+      public_url: "{{ endpoints.cinderv2.url.public }}/{{ endpoints.cinderv2.url.path }}"
       internal_url: "{{ endpoints.cinderv2.url.internal }}/{{ endpoints.cinderv2.url.path }}"
       admin_url: "{{ endpoints.cinderv2.url.admin }}/{{ endpoints.cinderv2.url.path }}"
     - name: heat
@@ -389,9 +389,9 @@ keystone:
     - name: ceilometer
       type: metering
       description: 'Telemetry Service'
-      public_url: https://{{ endpoints.main }}:8889
-      internal_url: https://{{ endpoints.main }}:8889
-      admin_url: https://{{ endpoints.main }}:8889
+      public_url: "{{ endpoints.ceilometer.url.public }}"
+      internal_url: "{{ endpoints.ceilometer.url.internal }}"
+      admin_url: "{{ endpoints.ceilometer.url.admin }}"
     - name: ironic
       type: baremetal
       description: 'Ironic bare metal provisioning service'
@@ -524,7 +524,7 @@ heat:
     verbose: True
 
 ceilometer:
-  enabled: True
+  enabled: False
   logging:
     debug: True
     verbose: True

--- a/roles/ceilometer-common/meta/main.yml
+++ b/roles/ceilometer-common/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: endpoints
   - role: monitoring-common
   - role: logging-config
     service: ceilometer

--- a/roles/ceilometer-common/templates/etc/ceilometer/ceilometer.conf
+++ b/roles/ceilometer-common/templates/etc/ceilometer/ceilometer.conf
@@ -44,7 +44,7 @@ mongodb_replica_set=mongoreplica
 
 [api]
 host = 0.0.0.0
-port = 8888
+port = {{ endpoints.ceilometer.port.backend_api }}
 
 [keystone_authtoken]
 identity_uri = {{ endpoints.identity_uri }}

--- a/roles/ceilometer-control/tasks/main.yml
+++ b/roles/ceilometer-control/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: permit access to ceilometer
-  ufw: rule=allow to_port=8889 proto=tcp
+  ufw: rule=allow to_port={{ endpoints.ceilometer.port.haproxy_api }} proto=tcp
 
 - name: install ceilometer controller services
   upstart_service: name={{ item }}

--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -12,7 +12,7 @@
   ]
 -%}
 {% if ceilometer.enabled|default('True')|bool -%}
-    {% set _ = haproxy_services.append(['ceilometer', 8888, 8889, false]) %}
+    {% set _ = haproxy_services.append(['ceilometer', endpoints.ceilometer.port.backend_api, endpoints.ceilometer.port.haproxy_api, false]) %}
 {% endif -%}
 {% if magnum.enabled|default('False')|bool -%}
     {% set _ = haproxy_services.append(['magnum', 9512, 9511, false]) %}

--- a/roles/mongodb-server/tasks/primary.yml
+++ b/roles/mongodb-server/tasks/primary.yml
@@ -6,10 +6,10 @@
   pause: seconds=20
 
 - name: rename primary replica member
-  command: mongo --host {{ endpoints.mongodb }} --eval 'cfg=rs.conf(); cfg.members[0].host="{{ primary_ip }}:{{ mongodb.port }}"; rs.reconfig(cfg)'
+  command: mongo --host {{ endpoints.mongodb }} --eval 'cfg=rs.conf(); cfg.members[0].host="{{ primary_ip }}:{{ mongodb.port }}"; cfg.members[0].priority = 2; rs.reconfig(cfg)'
 
 - name: install pymongo for mongodb_user module
   pip: name=pymongo state=present
 
 - name: create admin user
-  mongodb_user: database=admin name=admin password={{ mongodb.db_password }} roles='userAdminAnyDatabase' state=present
+  mongodb_user: database=admin name=admin password={{ mongodb.db_password }} replica_set={{ mongodb.replica_name }} roles='userAdminAnyDatabase' state=present


### PR DESCRIPTION
Added functionality to support standard ports from endpoints role.
Fixed corner case failure by prioritizing mongo primary to controller1.
Made Ceilometer disabled by default again.