### PR TITLE
swiftops user need sudo access to swift-init to start services

### DIFF
--- a/roles/swift-common/templates/etc/sudoers.d/swiftops
+++ b/roles/swift-common/templates/etc/sudoers.d/swiftops
@@ -1,2 +1,3 @@
 swiftops ALL= NOPASSWD: /usr/local/bin/swifttool
 swiftops ALL= NOPASSWD: /usr/bin/lshw
+swiftops ALL= NOPASSWD: /usr/local/bin/swift-init


### PR DESCRIPTION
Allowing swift-init root access for swiftops user so it could start all services as part of ring deployment 

https://github.com/blueboxgroup/swifttool/pull/3