### PR TITLE
add osd node and ceph.conf tuning check for ceph

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -94,8 +94,8 @@ ceph_common:
   osd_max_scrubs: 1
 
   # Recovery tuning
-  osd_recovery_max_active: 1
-  osd_max_backfills: 1
+  osd_recovery_max_active: 2
+  osd_max_backfills: 2
   osd_recovery_op_priority: 2
   osd_recovery_max_chunk: 1048576
   osd_recovery_threads: 1

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -1,5 +1,14 @@
 ---
 ceph_osd:
 
+  disable_transparent_hugepage: true
+  os_tuning_params:
+    - { name: kernel.pid_max, value: 4194303 }
+    - { name: fs.file-max, value: 26234859 }
+    - { name: vm.zone_reclaim_mode, value: 0 }
+    - { name: vm.vfs_cache_pressure, value: 50 }
+    - { name: net.netfilter.nf_conntrack_max, value: 1048576 }
+    - { name: vm.swappiness, value: 0 }
+
   pkgs:
     - parted

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -59,3 +59,6 @@
   register: pool_output
   run_once: true
   delegate_to: "{{ groups[ceph.monitor_group_name][0] }}"
+
+- include: system_tuning.yml
+  tags: ceph-osd

--- a/roles/ceph-osd/tasks/system_tuning.yml
+++ b/roles/ceph-osd/tasks/system_tuning.yml
@@ -1,0 +1,34 @@
+---
+- name: disable osd directory parsing by updatedb
+  command: updatedb -e /var/lib/ceph
+  changed_when: false
+  failed_when: false
+
+- name: install dependencies
+  apt: pkg="hugepages"
+  when: ceph_osd.disable_transparent_hugepage
+
+- name: disable transparent hugepage until next reboot
+  command: hugeadm --thp-never
+  when: ceph_osd.disable_transparent_hugepage
+
+- name: disable transparent hugepages permanently
+  lineinfile: dest=/etc/default/grub
+    state=present
+    regexp="^GRUB_CMDLINE_LINUX_DEFAULT=\"(.*)\"$"
+    line="GRUB_CMDLINE_LINUX_DEFAULT=\"\1 transparent_hugepage=never\""
+    backrefs=yes
+  when: ceph_osd.disable_transparent_hugepage
+
+- name: update grub config with changes
+  command: update-grub
+  when: ceph_osd.disable_transparent_hugepage
+
+- name: apply operating system tuning
+  sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    state: present
+    sysctl_file: /etc/sysctl.conf
+    ignoreerrors: yes
+  with_items: ceph_osd.os_tuning_params


### PR DESCRIPTION
Additional tunings for Ceph Storage/OSD nodes based on recommendations from IBM Research and Ceph community.

Ceph community link: https://github.com/ceph/ceph-ansible/blob/master/roles/ceph-common/tasks/misc/system_tuning.yml