### PR TITLE
gather facts for ceph-osd role

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -130,6 +130,7 @@
       tags: ['ceph', 'ceph-monitor']
 
 - name: ceph osds
+  gather_facts: force
   hosts: ceph_osds
   roles:
     - role: ceph-osd


### PR DESCRIPTION
Found this bug this morning. The ceph-common role, which is called
by ceph-osd, populates a template that includes info about the monitor 
nodes. However, when you run with tag "ceph-osd", this info is not 
gathered and therefore absent from the conf file. Forcing fact 
gathering for this task fixes the issue.