### PR TITLE
Enable jellyroll keystone middleware

### DIFF
--- a/roles/keystone/defaults/main.yml
+++ b/roles/keystone/defaults/main.yml
@@ -18,6 +18,7 @@ keystone:
   alternatives:
     - keystone-manage
     - keystone-all
+  jellyroll: False # custom middleware for password compliance
   logs:
     - paths:
       - /var/log/keystone/keystone-all.log

--- a/roles/keystone/templates/etc/keystone/keystone-paste.ini
+++ b/roles/keystone/templates/etc/keystone/keystone-paste.ini
@@ -63,6 +63,14 @@ paste.filter_factory = keystone.contrib.stats:StatsExtension.factory
 [filter:access_log]
 paste.filter_factory = keystone.contrib.access:AccessLogMiddleware.factory
 
+{% if keystone.jellyroll %}
+[filter:passval]
+paste.filter_factory = jellyroll.keystone.password_validation:KeystonePasswordValidation
+
+[filter:unauthlog]
+paste.filter_factory = jellyroll.keystone.password_validation:UnauthorizedLogger
+{% endif %}
+
 [app:public_service]
 paste.app_factory = keystone.service:public_app_factory
 
@@ -73,13 +81,13 @@ paste.app_factory = keystone.service:v3_app_factory
 paste.app_factory = keystone.service:admin_app_factory
 
 [pipeline:public_api]
-pipeline = sizelimit url_normalize build_auth_context token_auth json_body ec2_extension user_crud_extension public_service
+pipeline = sizelimit url_normalize build_auth_context token_auth json_body ec2_extension user_crud_extension{{ ' passval unauthlog' if keystone.jellyroll else '' }} public_service
 
 [pipeline:admin_api]
-pipeline = sizelimit url_normalize build_auth_context token_auth{{ ' admin_token_auth' if insert_token|default(boolean=False) else '' }} json_body ec2_extension s3_extension crud_extension admin_service
+pipeline = sizelimit url_normalize build_auth_context token_auth{{ ' admin_token_auth' if insert_token|default(boolean=False) else '' }} json_body ec2_extension s3_extension crud_extension{{ ' passval unauthlog' if keystone.jellyroll else '' }} admin_service
 
 [pipeline:api_v3]
-pipeline = sizelimit url_normalize build_auth_context token_auth json_body ec2_extension_v3 s3_extension simple_cert_extension revoke_extension service_v3
+pipeline = sizelimit url_normalize build_auth_context token_auth json_body ec2_extension_v3 s3_extension simple_cert_extension revoke_extension{{ ' passval unauthlog' if keystone.jellyroll else '' }} service_v3
 
 [app:public_version_service]
 paste.app_factory = keystone.service:public_version_app_factory

--- a/site.yml
+++ b/site.yml
@@ -155,6 +155,9 @@
 
 - name: keystone setup
   hosts: controller[0]
+  vars_files:
+    - roles/keystone/defaults/main.yml
+
   roles:
     - role: keystone-setup
       keystone_configured: false


### PR DESCRIPTION
If a site wants jellyroll, they get jellyroll. Middleware for password
validation and logging of rejected auth attempts.