### PR TITLE
Clean up the source deps for horizon/swift

### DIFF
--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -9,7 +9,6 @@ horizon:
     python_dependencies:
       - { name: mysql-python }
       - { name: functools32 }
-      - { name: python-memcached }
       - { name: python-memcached, version: '1.48' }
       - { name: stevedore, version: '1.5.0' }
       - { name: "git+https://github.com/davidcusatis/bluebox-horizon-customization#egg=bluebox-horizon-customization"}

--- a/roles/swift-common/defaults/main.yml
+++ b/roles/swift-common/defaults/main.yml
@@ -7,11 +7,8 @@ swift:
   source:
     rev: 'stable/kilo'
     python_dependencies:
-      - { name: mysql-python }
       - { name: keystonemiddleware }
       - { name: python-swiftclient }
-    system_dependencies:
-      - libmysqlclient-dev
   alternatives:
     - swift-account-audit
     - swift-account-auditor


### PR DESCRIPTION
Horizon had a double entry for memcache, picked the one that sets a pin.
Swift doesn't use mysql, not sure why we were installing it into the
venv.