### PR TITLE
Make cinder techspec compliant

### DIFF
--- a/roles/cinder-common/tasks/main.yml
+++ b/roles/cinder-common/tasks/main.yml
@@ -46,7 +46,7 @@
   when: swift.enabled|bool and (endpoints.swift.haproxy_vip == fqdn)
 
 - name: cinder config
-  template: src={{ item }} dest=/etc/cinder mode=0644
+  template: src={{ item }} dest=/etc/cinder mode=0640 owner=cinder group=cinder
   with_fileglob: ../templates/etc/cinder/*
   notify:
     - restart cinder services
@@ -60,3 +60,11 @@
   tags:
     - logrotate
     - logging
+
+- name: change cinder log file permissions
+  file: path={{ item }} mode=0644 owner=cinder group=cinder state=touch
+  with_items:
+    - /var/log/cinder/cinder-api.log
+    - /var/log/cinder/cinder-volume.log
+    - /var/log/cinder/cinder-manage.log
+    - /var/log/cinder/cinder-scheduler.log


### PR DESCRIPTION
Give only cinder permissions to access cinder logs and cinder
configurations