### PR TITLE
Typo in roles/percona-server/tasks/main.yml

### DIFF
--- a/roles/percona-server/tasks/main.yml
+++ b/roles/percona-server/tasks/main.yml
@@ -66,7 +66,7 @@
 - name: install root .my.cnf defaults file
   template: src=root/.my.cnf dest=/root/.my.cnf owner=root group=root mode=0600
 
-- name: are we already already bootstrapped
+- name: are we already bootstrapped
   shell: mysql -e "SHOW VARIABLES LIKE 'wsrep_on'" | grep 'ON'
   register: already_bootstrapped
   failed_when: False


### PR DESCRIPTION
In roles/percona-server/tasks/main.yml, there is a typo on line 69. The name of the task is currently "are we already already bootstrapped" in master instead of just "are we already bootstrapped".