### PR TITLE
Gather facts smartly

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -9,6 +9,7 @@ connection_plugins = plugins/connection
 callback_plugins = plugins/callbacks
 filter_plugins = plugins/filters
 forks = 25
+gathering = smart
 
 [ssh_connection]
 pipelining=true


### PR DESCRIPTION
Using smart, instead of the default of implicit, facts will be gathered
from each host only once and cached between plays. This should improve
our runs a bit as we have a lot of plays where facts are gathered and
ansbile is needlessly gathering over and over again.