### PR TITLE
Undo log file permission setting

### DIFF
--- a/roles/cinder-common/tasks/main.yml
+++ b/roles/cinder-common/tasks/main.yml
@@ -35,7 +35,7 @@
     - /var/lib/cinder/lock
 
 - name: cinder log dir
-  file: dest=/var/log/cinder state=directory mode=0755 owner=cinder group=cinder
+  file: dest=/var/log/cinder state=directory mode=2750 owner=cinder group=adm
 
 # needs to happen before 'cinder config'
 - include: ceph_integration.yml
@@ -60,11 +60,3 @@
   tags:
     - logrotate
     - logging
-
-- name: change cinder log file permissions
-  file: path={{ item }} mode=0644 owner=cinder group=cinder state=touch
-  with_items:
-    - /var/log/cinder/cinder-api.log
-    - /var/log/cinder/cinder-volume.log
-    - /var/log/cinder/cinder-manage.log
-    - /var/log/cinder/cinder-scheduler.log

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -24,7 +24,7 @@
         group=glance
 
 - name: glance log dir
-  file: dest=/var/log/glance state=directory mode=0755 owner=glance group=glance
+  file: dest=/var/log/glance state=directory mode=2750 owner=glance group=adm
 
 - name: permit access to glance
   ufw: rule=allow to_port={{ item }} proto=tcp
@@ -86,10 +86,3 @@
     - logrotate
     - logging
   when: logging.enabled|default('True')|bool
-
-- name: change glance log file permissions
-  file: path={{ item }} mode=0644 owner=glance group=glance state=touch
-  with_items:
-    - /var/log/glance/glance-api.log
-    - /var/log/glance/glance-registry.log
-    - /var/log/glance/glance-manage.log

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -18,8 +18,8 @@
   file: dest=/etc/keystone state=directory
 
 - name: keystone log dir
-  file: dest=/var/log/keystone state=directory mode=0755 owner=keystone
-        group=keystone
+  file: dest=/var/log/keystone state=directory mode=2750 owner=keystone
+        group=adm
 
 - name: install keystone service
   upstart_service: name=keystone user=keystone cmd=/usr/local/bin/keystone-all
@@ -57,12 +57,6 @@
   with_items:
     - "{{ endpoints.keystone.port.haproxy_api }}"
     - "{{ endpoints.keystone_admin.port.haproxy_api }}"
-
-- name : change keystone log file ownership
-  file: path={{ item }} mode=0644 owner=keystone group=keystone state=touch
-  with_items:
-    - /var/log/keystone/keystone-all.log
-    - /var/log/keystone/keystone-manage.log
 
 - name: add cron job to clean up expired tokens
   template:

--- a/roles/neutron-common/tasks/main.yml
+++ b/roles/neutron-common/tasks/main.yml
@@ -42,8 +42,8 @@
         owner=neutron group=neutron
 
 - name: neutron log dir
-  file: dest=/var/log/neutron state=directory mode=0755
-        owner=neutron group=neutron
+  file: dest=/var/log/neutron state=directory mode=2750
+        owner=neutron group=adm
 
 # Neutron needs the service tenant id. This goes away after juno
 # when neutron can use tenant_name.
@@ -108,13 +108,3 @@
   tags:
     - logrotate
     - logging
-
-- name: change neutron log file permissions
-  file: path={{ item }} mode=0644 owner=neutron group=neutron state=touch
-  with_items:
-    - /var/log/neutron/neutron-server.log
-    - /var/log/neutron/neutron-l3-agent.log
-    - /var/log/neutron/neutron-linuxbridge-agent.log
-    - /var/log/neutron/neutron-dhcp-agent.log
-    - /var/log/neutron/neutron-metadata-agent.log
-    - /var/log/neutron/neutron-lbaasv2-agent.log


### PR DESCRIPTION
Set the permissions on the parent directory instead so that files
created within the directory get proper ownership.