### PR TITLE
Remove system_dependencies variable

### DIFF
--- a/roles/swift-common/meta/main.yml
+++ b/roles/swift-common/meta/main.yml
@@ -7,7 +7,6 @@ dependencies:
     logdata: "{{ swift.logs }}"
   - role: openstack-source
     project_name: swift
-    system_dependencies: "{{ swift.source.system_dependencies }}"
     python_dependencies: "{{ swift.source.python_dependencies }}"
     project_rev: "{{ swift.source.rev }}"
     alternatives: "{{ swift.alternatives }}"


### PR DESCRIPTION
No system dependencies are required, so the system_dependencies variable is not required.  Without this variable, it should default to the empty set and fix the current issues.