### PR TITLE
ping requests to 2.7.0 so the urllib3 will be less then 1.11 for glance http header to work

### DIFF
--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -6,6 +6,7 @@ heat:
     python_dependencies:
       - { name: mysql-python }
       - { name: functools32 }
+      - { name: requests, version: 2.7.0 }
     system_dependencies:
       - libmysqlclient-dev
   alternatives:


### PR DESCRIPTION
A new python requests was released that bundles urllib3, which causes issues with the glanceclient that heat is using. So pin to the previous release of requests which was working just fine. The fix is the same as https://github.com/blueboxgroup/ursula/commit/92e68a6ac6ea3ebc71d5b266173fe4b8a283eaab
