### PR TITLE
Force compute v2 in stackrc

### DIFF
--- a/roles/client/templates/root/stackrc
+++ b/roles/client/templates/root/stackrc
@@ -7,3 +7,4 @@ export OS_CACERT=/opt/stack/ssl/openstack.crt
 {% endif -%}
 export OS_NO_CACHE=True
 export OS_VOLUME_API_VERSION=2
+export OS_COMPUTE_API_VERSION=2

--- a/roles/common/templates/etc/sensu/stackrc
+++ b/roles/common/templates/etc/sensu/stackrc
@@ -8,3 +8,4 @@ export OS_CACERT=/opt/stack/ssl/openstack.crt
 export OS_NO_CACHE=True
 export NOVACLIENT_UUID_CACHE_DIR=/tmp/sensu
 export OS_VOLUME_API_VERSION=2
+export OS_COMPUTE_API_VERSION=2


### PR DESCRIPTION
Newer novaclient defaults to v3 which breaks.