### PR TITLE
Add our own rootwrap filter for neutron

### DIFF
--- a/roles/neutron-common/tasks/main.yml
+++ b/roles/neutron-common/tasks/main.yml
@@ -32,7 +32,12 @@
             mode=0440
 
 - name: neutron etc directories
-  file: dest=/etc/neutron/services/loadbalancer/haproxy state=directory
+  file:
+    dest: "{{ item }}"
+    state: directory
+  with_items:
+    - /etc/neutron/services/loadbalancer/haproxy
+    - /etc/neutron/rootwrap-ursula.d
 
 - name: neutron libdir
   file: dest=/var/lib/neutron state=directory owner=neutron
@@ -70,6 +75,14 @@
   with_fileglob: ../templates/etc/neutron/*
   notify:
      - restart neutron services
+
+- name: ursula rootwrap filters
+  template:
+    src: etc/neutron/rootwrap-ursula.d/ursula.filters
+    dest: /etc/neutron/rootwrap-ursula.d/
+    mode: 0640
+    owner: root
+    group: root
 
 - name: error for unknown plugin
   fail: msg="Invalid Neutron plugin, must be either ml2 or ovs"

--- a/roles/neutron-common/templates/etc/neutron/rootwrap-ursula.d/ursula.filters
+++ b/roles/neutron-common/templates/etc/neutron/rootwrap-ursula.d/ursula.filters
@@ -1,0 +1,7 @@
+{% set basepath = lookup('items', 'openstack_source.virtualenv_base') if
+openstack_install_method == 'source' else
+lookup('items', 'openstack_package.virtualenv_base') %}
+## Filters we add to deal with Ursula install paths
+
+[Filters]
+kill_ursulapaths: KillFilter, root, {{ basepath }}/neutron/bin/python, -9

--- a/roles/neutron-common/templates/etc/neutron/rootwrap.conf
+++ b/roles/neutron-common/templates/etc/neutron/rootwrap.conf
@@ -5,7 +5,7 @@
 [DEFAULT]
 # List of directories to load filter definitions from (separated by ',').
 # These directories MUST all be only writeable by root !
-filters_path=/etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap
+filters_path=/etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap,/etc/neutron/rootwrap-ursula.d
 
 # List of directories to search executables in, in case filters do not
 # explicitely specify a full path (separated by ',')


### PR DESCRIPTION
We need to allow for killing processes that start from our virtualenv
python.

This may need care around upgrade time as to not leave agents stale from
the old venv path.