### PR TITLE
ceph-compute depends on nova-compute

### DIFF
--- a/roles/ceph-compute/meta/main.yml
+++ b/roles/ceph-compute/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: nova-data

--- a/site.yml
+++ b/site.yml
@@ -229,6 +229,7 @@
 
 - name: ceph compute
   hosts: compute
+  gather_facts: force
   roles:
     - role: ceph-compute
       tags: ['ceph', 'ceph-compute']


### PR DESCRIPTION
Setup the appropriate dependency for ceph-compute, else running with
ceph-compute tag will fail.