### PR TITLE
Make the undercloud_cidr less specific for testing

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -8,7 +8,7 @@ openstack_install_method: 'source'
 
 primary_interface: 'ansible_eth0'
 primary_ip: "{{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}"
-undercloud_cidr: 10.230.7.0/24
+undercloud_cidr: 10.0.0.0/8
 
 secrets:
   db_password:      asdf


### PR DESCRIPTION
By using 10.0.0.0/8 we won't have to care about what dhcp is handing out
to instances in the target cloud we are testing on.