### PR TITLE
Fix Controller2 ucarp Issue During MongoDB Deployment

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -57,7 +57,7 @@ swift:
 endpoints:
   main:     "{{ fqdn }}"
   db:       "{{ undercloud_floating_ip }}"
-  mongodb:  "{{ undercloud_floating_ip }}"
+  mongodb:  "{{ hostvars[groups['mongo_db'][0]][primary_interface]['ipv4']['address'] }}"
   rabbit:   "{{ undercloud_floating_ip }}"
   magnum: "{{ fqdn }}"
   identity_uri: https://{{ fqdn }}:35357


### PR DESCRIPTION
Whenever ucarp was on controller2, MongoDB would fail during deployment.
By switching the endpoint to be just controller1, MongoDB HA can handle everything.