### PR TITLE
Pin shade to last known working version

### DIFF
--- a/roles/common/tasks/python.yml
+++ b/roles/common/tasks/python.yml
@@ -49,4 +49,4 @@
   with_items: common.python_extra_packages
 
 - name: install shade for ansible modules
-  pip: name=shade
+  pip: name=shade version=0.16.0


### PR DESCRIPTION
New version seems to have broken some of our code, so pin for now until
sorting out necessary changes.