### PR TITLE
Fix problem with glance logs becoming bloated

### DIFF
--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -76,6 +76,8 @@ backend {{ name }}
   option tcp-check /
   {% elif name == "magnum" -%}
   # option httpchk /
+  {% elif name == "glance" -%}
+  option httpchk GET /versions
   {% else -%}
   option httpchk /
   {% endif -%}


### PR DESCRIPTION
Haproxy does an httpchk on glance on / instead of /versions. This causes
a warning message to constantly fill the glance log files every ~2 seconds and
bloats the logs on a deploy. As of liberty, this warning message has been changed
to a debug. This is a workaround.

Please reference https://bugs.launchpad.net/mos/+bug/1479408 and https://bugs.launchpad.net/glance/+bug/1496138