### PR TITLE
Create GPT labels for ceph and swift

### DIFF
--- a/library/swift_disk.py
+++ b/library/swift_disk.py
@@ -14,7 +14,7 @@ options:
       - The device to make a swift disk
     required: false
   partition_path:
-    description: 
+    description:
       - Complete path to partition to be used for Swift
     required: false
 '''
@@ -47,27 +47,27 @@ def main():
 
     dev = module.params.get('dev')
     part_path = module.params.get('partition_path')
-    
+
     dev_path = None
     mount_point = "/srv/node/"
-    if dev is not None:   
+    if dev is not None:
         dev_path = "/dev/%s" % dev
         part_path = "/dev/%s1" % dev
         mount_point += ("%s1" % dev)
     else:
         # Get the last part of partition path
         mount_point += (part_path.split("/")[-1])
-        
+
     if dev_path is not None and not os.path.exists(dev_path):
         module.fail_json(msg="no such device: %s" % dev)
-    
-    
+
+
     if os.path.exists(part_path) and os.path.ismount(mount_point):
         module.exit_json(changed=False)
 
-    # setup the parted command
+    # create partitions
     if dev_path is not None:
-        cmd = ['parted', '--script', dev_path, 'mklabel', 'gpt', 'mkpart', 'primary', '1', '100%']
+        cmd = ['parted', '--script', dev_path, 'mkpart', 'primary', '1', '100%']
         rc, out, err = module.run_command(cmd, check_rc=True)
 
     # make an xfs

--- a/playbooks/unmount-and-clear-disks.yml
+++ b/playbooks/unmount-and-clear-disks.yml
@@ -5,6 +5,7 @@
 # Expects a hosts name as input into --extra-vars
 #
 # ex. ursula envs/example/swift playbooks/unmount-and-clear-disks.yml --extra-vars 'hosts=swiftnode'
+#     ursula envs/example/standard playbooks/unmount-and-clear-disks.yml --extra-vars 'hosts=ceph_osds'
 #
 
 ---
@@ -30,10 +31,10 @@
         [{% for item in hostvars[inventory_hostname]['ansible_devices'] -%}
             {{ comma() }}"{{ item }}"
         {%- endfor %}]
-  
+
   - name: unmount all mounted devices
     mount: name={{ item[0].mount }} src={{ item[0].device }} fstype={{ item[0].fstype }} state=unmounted
-    with_nested: 
+    with_nested:
       - "{{ ansible_mounts }}"
       - disk_list
     when: (item[0].mount != "/" and item[0].mount != "/boot") and item[1] in "{{ item[0].device }}"
@@ -52,5 +53,10 @@
   - name: clear all devices
     shell: dd if=/dev/zero of=/dev/{{ item }} bs=1M count=512
     ignore_errors: true
+    with_items: disk_list
+    when: item in disks_present
+
+  - name: create GPT labels
+    command: parted --script /dev/{{ item }} mklabel gpt
     with_items: disk_list
     when: item in disks_present


### PR DESCRIPTION
During the local install, we saw a problem with disks and invalid
partition data. Swift code is currently creating GPT labels in the 
`swift_disk` library. I consider this cleanup/prep, so I'd like to move
it to the cleanup play, which also allows ceph to access it.