### PR TITLE
Make kvm techspec compliant

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -31,3 +31,12 @@ common:
     mcelog: True
   packages_to_remove:
     - language-selector-common
+  logs:
+    - paths:
+        - /var/log/audit/audit.log
+      fields:
+      type: syslog
+      tags: audit,common
+  logging:
+    debug: False
+    verbose: True

--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -14,3 +14,6 @@ dependencies:
     when: docker.enabled is defined and docker.enabled|bool
   - role: monitoring-common
     when: monitoring.enabled is not defined or monitoring.enabled|bool
+  - role: logging-config
+    service: common
+    logdata: "{{ common.logs }}"

--- a/roles/common/tasks/audit-logging.yml
+++ b/roles/common/tasks/audit-logging.yml
@@ -1,0 +1,10 @@
+---
+- name: setup logrotate for audit.log
+  logrotate: name=auditd path=/var/log/audit/audit.log
+  args:
+    options:
+      - daily
+      - rotate 7
+      - missingok
+      - compress
+      - minsize 100k

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -104,3 +104,9 @@
 
 - include: monitoring.yml tags=monitoring,common
   when: monitoring.enabled|default('True')|bool
+
+- include: audit-logging.yml
+  tags:
+    - logrotate
+    - logging
+  when: logging.enabled|default('True')|bool

--- a/roles/common/tasks/system-tools.yml
+++ b/roles/common/tasks/system-tools.yml
@@ -7,6 +7,7 @@
   with_items:
     - ack-grep
     - acl
+    - auditd
     - build-essential
     - curl
     - dstat


### PR DESCRIPTION
Kvm is already mostly techspec compliant. We install auditd, logstash,
and logrotate its log file.