### PR TITLE
Find and use actual subnet cidr

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -8,7 +8,6 @@ openstack_install_method: 'source'
 
 primary_interface: 'ansible_eth0'
 primary_ip: "{{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}"
-undercloud_cidr: 10.0.0.0/8
 
 secrets:
   db_password:      asdf

--- a/test/setup
+++ b/test/setup
@@ -53,6 +53,7 @@ cat >> ${ROOT}/envs/test/group_vars/all.yml <<eof
   key: |
 eof
 cat ${CERT_DIR}/openstack.example.com.key | sed 's/^/    /' >> ${ROOT}/envs/test/group_vars/all.yml
+UNDERCLOUD_CIDR="$(python -c 'import shade; cloud = shade.openstack_cloud(); print cloud.search_subnets("internal")[0]["cidr"]')"
 cat >> ${ROOT}/envs/test/defaults.yml <<eof
 logging:
   follow:
@@ -61,6 +62,7 @@ logging:
   forward:
     host: kibana.sea03.blueboxgrid.com
     port: 4560
+undercloud_cidr: ${UNDERCLOUD_CIDR}
 eof
 popd
 rm -rf ${CERT_DIR}


### PR DESCRIPTION
Rather than guessing at what the subnet cidr is of the testenv's
internal network, we should just query for it.