### PR TITLE
Add HttpOnly and Secure attributes to any cookie created by horizon

### DIFF
--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -13,6 +13,17 @@
   notify:
     - restart apache
 
+- name: enable apache mod-headers
+  apache2_module: state=present name=headers
+  notify:
+    - restart apache
+
+- name: disable apache status
+  template: src=etc/apache2/mods-enabled/headers.conf
+            dest=/etc/apache2/mods-enabled/headers.conf
+  notify:
+    - restart apache
+
 - name: create horizon config directory
   file: dest=/etc/openstack-dashboard state=directory
 

--- a/roles/horizon/templates/etc/apache2/mods-enabled/headers.conf
+++ b/roles/horizon/templates/etc/apache2/mods-enabled/headers.conf
@@ -1,0 +1,4 @@
+<IfModule mod_headers.c>
+ Header edit Set-Cookie ^(.*)$ $1;HttpOnly;Secure
+</IfModule>
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
AppScan flagged that some of the cookies did not have the HttpOnly and the Secure attributes set on them. This enables mod_headers to always set the attributes on the cookies.