### PR TITLE
Supply endpoint when adding heat_stack_user

### DIFF
--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -56,16 +56,11 @@
 
 - name: heat stack user
   keystone_user: user=heat_stack_user
+                 role=heat_stack_user
                  password="{{ secrets.service_password }}"
                  tenant=admin
                  token={{ admin_token }}
-  when: heat.enabled|bool
-
-- name: heat stack user role
-  keystone_user: role=heat_stack_user
-                 user=heat_stack_user
-                 tenant=admin
-                 token={{ admin_token }}
+                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
   when: heat.enabled|bool
 
 - name: keystone endpoint


### PR DESCRIPTION
The module defaults do not work for us, so we have to supply an
endpoint. Also we can add both the user and role in one shot.