### PR TITLE
Updated logrotate for nova to reload nova-novncproxy after rotation.

### DIFF
--- a/roles/nova-common/tasks/logging.yml
+++ b/roles/nova-common/tasks/logging.yml
@@ -7,3 +7,6 @@
       - missingok
       - rotate 7
       - compress
+      - sharedscripts
+    scripts:
+      - postrotate: "/usr/sbin/service nova-novncproxy reload"


### PR DESCRIPTION
Updated logrotate to restart nova-novncproxy after rotation to address issue with service hanging.