### PR TITLE
Implement smart choosing of glance store

### DIFF
--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -12,8 +12,10 @@ glance:
     storage_path: /var/lib/btsync
     device_name: image-cache
     dir: /var/lib/glance/images
+  store_smart: True
   store_swift: False
   store_ceph: False
+  store_file: False
   show_multiple_locations: True
   source:
     rev: 'stable/kilo'

--- a/roles/glance/templates/etc/glance/glance-api.conf
+++ b/roles/glance/templates/etc/glance/glance-api.conf
@@ -28,12 +28,9 @@ container_formats = {{ glance.container_formats }}
 
 show_multiple_locations = {{ glance.show_multiple_locations }}
 
-{% if glance.store_ceph|bool %}
-show_image_direct_url = True
-{% endif %}
-
+{% if (glance.store_smart|bool and swift.enabled|bool) or
+      glance.store_swift|bool  %}
 [glance_store]
-{% if glance.store_swift|bool %}
 stores = glance.store.swift.Store,
          glance.store.http.Store
 swift_store_auth_address = {{ endpoints.keystone.url.internal }}/{{ endpoints.keystone.version }}
@@ -44,8 +41,11 @@ swift_store_auth_version = 2
 swift_store_container = glance
 swift_store_cacert = {{ glance.cafile }}
 default_store = swift
+{% elif (glance.store_smart|bool and ceph.enabled|bool) or
+        glance.store_ceph|bool  %}
+show_image_direct_url = True
 
-{% elif glance.store_ceph|bool %}
+[glance_store]
 stores = glance.store.rbd.Store,
          glance.store.http.Store
 
@@ -55,7 +55,8 @@ rbd_store_user = glance
 rbd_store_pool = default
 
 default_store = rbd
-{% else %}
+{% elif glance.store_smart|bool or glance.store_file|bool %}
+[glance_store]
 stores = glance.store.filesystem.Store,
          glance.store.http.Store
 


### PR DESCRIPTION
If swift is enabled, store glance in swift.  If swift is not enabled,
but ceph is, store in ceph. If neither swift nor ceph are enabled, store
on the filesystem. Also still allow for explicitly setting the store
method. Defaults to smart choice of backend.