### PR TITLE
Make mongod.conf template more robust

### DIFF
--- a/roles/mongodb-common/templates/etc/mongodb/mongod.conf
+++ b/roles/mongodb-common/templates/etc/mongodb/mongod.conf
@@ -18,7 +18,7 @@ bind_ip = {{ mongodb.bind_ip }}
 port = {{ mongodb.port }}
 
 # Disables write-ahead journaling
-{% if primary_ip in groups['mongo_arbiter'] -%}
+{% if 'mongo_arbiter' in groups.keys() and primary_ip in groups['mongo_arbiter'] -%}
   nojournal = true
 {% else -%}
   nojournal = false


### PR DESCRIPTION
When `mongo_arbiter` is not defined in the host file, mongod.conf should default to nojournal = false.