### PR TITLE
Use "smart" logic to enable lbaas

### DIFF
--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -23,7 +23,9 @@ neutron:
   # Including any tunnels will enable tunnling
   tunnel_types: []
   lbaas:
-    enable: False
+    # enabled can be "smart" or true / false. Smart will turn on lbaas if
+    # controllers are dedicated.
+    enable: smart
     interface_driver: neutron.agent.linux.interface.BridgeInterfaceDriver
     service_plugin:
       - neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPluginv2

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -16,7 +16,9 @@ core_plugin = neutron.plugins.ml2.plugin.Ml2Plugin
 {% elif neutron.plugin == 'ovs' %}
 core_plugin = neutron.plugins.openvswitch.ovs_neutron_plugin.OVSNeutronPluginV2
 {% endif %}
-{% if neutron.lbaas.enable %}
+{% if (neutron.lbaas.enable == 'smart' and
+  groups['controller'][0] not in groups['compute']) or
+  neutron.lbaas.enable|bool %}
 service_plugins = {{ neutron.service_plugins|union(neutron.lbaas.service_plugin)|join(',') }}
 {% elif neutron.service_plugins|length %}
 service_plugins = {{ neutron.service_plugins|join(',') }}

--- a/roles/neutron-control/tasks/main.yml
+++ b/roles/neutron-control/tasks/main.yml
@@ -37,7 +37,10 @@
 - name: sync neutron database for lbaas
   command: neutron-db-manage --service lbaas --config-file /etc/neutron/neutron.conf \
            --config-file /etc/neutron/plugins/ml2/ml2_plugin.ini upgrade head
-  when: (database_create.changed or force_sync|default('false')|bool) and neutron.lbaas.enable
+  when: (database_create.changed or force_sync|default('false')|bool) and
+        ((neutron.lbaas.enable == "smart" and
+         groups['controller'][0] not in groups['compute']) or
+         neutron.lbaas.enable|bool)
   run_once: true
   changed_when: true
   notify: restart neutron services

--- a/roles/neutron-data-network/handlers/main.yml
+++ b/roles/neutron-data-network/handlers/main.yml
@@ -5,7 +5,9 @@
 
 - name: restart neutron lbaas agent
   service: name=neutron-lbaasv2-agent state=restarted_if_running
-  when: restart|default('True') and neutron.lbaas.enable
+  when: restart|default('True') and ((neutron.lbaas.enable == "smart" and
+                     groups['controller'][0] not in groups['compute']) or
+                     neutron.lbaas.enable|bool)
 
 - name: restart xorp
   service: name=xorp state=restarted sleep=10

--- a/roles/neutron-data-network/tasks/main.yml
+++ b/roles/neutron-data-network/tasks/main.yml
@@ -71,7 +71,9 @@
     src: etc/neutron/neutron_lbaas.conf
     dest: /etc/neutron/neutron_lbaas.conf
     mode: 0644
-  when: neutron.lbaas.enable
+  when: (neutron.lbaas.enable == "smart" and
+         groups['controller'][0] not in groups['compute']) or
+         neutron.lbaas.enable|bool
   notify:
     - restart neutron lbaas agent
 
@@ -80,7 +82,9 @@
     src: etc/neutron/services/loadbalancer/haproxy/lbaas_agent.ini
     dest: /etc/neutron/services/loadbalancer/haproxy
     mode: 0644
-  when: neutron.lbaas.enable
+  when: (neutron.lbaas.enable == "smart" and
+         groups['controller'][0] not in groups['compute']) or
+         neutron.lbaas.enable|bool
   notify:
     - restart neutron lbaas agent
 
@@ -95,7 +99,9 @@
     config_dirs: /etc/neutron
     config_files: "{{ item.value.config_files|join(',') }}"
     envs: "{{ neutron.service.envs }}"
-  when: neutron.lbaas.enable
+  when: (neutron.lbaas.enable == "smart" and
+         groups['controller'][0] not in groups['compute']) or
+         neutron.lbaas.enable|bool
   with_dict:
     neutron-lbaasv2-agent:
       config_files:
@@ -114,7 +120,9 @@
 
 - name: start neutron lbaas agent
   service: name=neutron-lbaasv2-agent state=started
-  when: neutron.lbaas.enable
+  when: (neutron.lbaas.enable == "smart" and
+         groups['controller'][0] not in groups['compute']) or
+         neutron.lbaas.enable|bool
 
 - include: ipchanged.yml
 

--- a/roles/neutron-data-network/tasks/monitoring.yml
+++ b/roles/neutron-data-network/tasks/monitoring.yml
@@ -10,7 +10,9 @@
 - name: neutron lbaas process check
   sensu_process_check: service=neutron-lbaasv2-agent
   notify: restart sensu-client
-  when: neutron.lbaas.enable
+  when: (neutron.lbaas.enable == "smart" and
+         groups['controller'][0] not in groups['compute']) or
+         neutron.lbaas.enable|bool
 
 - name: ipchanged process check
   sensu_process_check: service=/usr/local/sbin/ipchanged


### PR DESCRIPTION
Default of "smart" will enable lbaas when the controllers are dedicated.
Can still hard set true/false to enable/disable regardless of controller
configuration.