### PR TITLE
Make use of custom state paths for services

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -34,6 +34,8 @@ etc_hosts:
   - name: "{{ fqdn }}"
     ip: "{{ floating_ip }}"
 
+state_path_base: /var/lib
+
 rabbitmq:
   port: 5672
   user: openstack

--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -8,6 +8,7 @@ cinder:
     #- name: rbd_volumes
     #  volume_driver: cinder.volume.drivers.rbd.RBDDriver
   api_workers: 5
+  state_path: "{{ state_path_base }}/cinder"
   volume_type: file
   volume_group: cinder-volumes
   create_vg: true

--- a/roles/cinder-common/tasks/main.yml
+++ b/roles/cinder-common/tasks/main.yml
@@ -17,11 +17,8 @@
 - name: /etc/cinder
   file: dest=/etc/cinder state=directory
 
-- name: cinder lib dirs
-  file: dest={{ item }} state=directory owner=cinder group=cinder
-  with_items:
-    - /var/lib/cinder
-    - /var/lib/cinder/images
+- name: cinder image dir (and leading paths)
+  file: dest={{ cinder.state_path }}/images state=directory owner=cinder group=cinder
 
 - name: cinder private dirs
   file:
@@ -32,7 +29,7 @@
     group: cinder
   with_items:
     - /var/cache/cinder
-    - /var/lib/cinder/lock
+    - "{{ cinder.state_path }}/lock"
 
 - name: cinder log dir
   file: dest=/var/log/cinder state=directory mode=2750 owner=cinder group=adm

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -10,10 +10,9 @@ log_dir = /var/log/cinder
 use_syslog = False
 syslog_log_facility = LOG_LOCAL0
 
-state_path = /var/lib/cinder
+state_path = {{ cinder.state_path }}
 rootwrap_config=/etc/cinder/rootwrap.conf
 api_paste_config = /etc/cinder/api-paste.ini
-lock_path = /var/lock/cinder
 
 {% if not ceph.enabled|bool -%}
 iscsi_helper=tgtadm
@@ -94,7 +93,7 @@ nimble_subnet_label = {{ backend.nimble_subnet_label }}
 {% endfor -%}
 
 [oslo_concurrency]
-lock_path = /var/lib/cinder/lock
+lock_path = {{ cinder.state_path }}/lock
 
 [database]
 connection=mysql://cinder:{{ secrets.db_password }}@{{ endpoints.db }}/cinder?charset=utf8

--- a/roles/cinder-data/templates/etc/tgt/conf.d/cinder_tgt.conf
+++ b/roles/cinder-data/templates/etc/tgt/conf.d/cinder_tgt.conf
@@ -1,1 +1,1 @@
-include /var/lib/cinder/volumes/*
+include {{ cinder.state_path }}/volumes/*

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -48,8 +48,8 @@
   notify:
     - update timezone
 
-- name: /opt/stack
-  file: dest=/opt/stack state=directory
+- name: state path base directory
+  file: dest={{ state_path_base }} state=directory
 
 - include: ssl.yml tags=ssl
 

--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -3,6 +3,7 @@ glance:
   api_workers: 5
   rbd_store_chunk_size: 8
   registry_workers: 5
+  state_path: "{{ state_path_base }}/glance"
   sync:
     enabled: true
     listening_port: 25307
@@ -11,7 +12,10 @@ glance:
     folder_rescan_interval: 600
     storage_path: /var/lib/btsync
     device_name: image-cache
-    dir: /var/lib/glance/images
+    # This needs to match the leading paths from state_path above
+    # and match the path listed in glance-api.conf for local image
+    # store. TODO: find a way to use a variable for all of these
+    dir: "{{ state_path_base }}/glance/images"
   store_smart: True
   store_swift: False
   store_ceph: False

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -16,8 +16,15 @@
 - name: /etc/glance
   file: dest=/etc/glance state=directory
 
-- name: glance images dir
-  file: dest=/var/lib/glance/images state=directory owner=glance group=glance
+- name: glance images dirs
+  file:
+    dest: "{{ item }}"
+    state: directory
+    owner: glance
+    group: glance
+  with_items:
+    - "{{ glance.state_path }}/images"
+    - "{{ glance.state_path }}/image-cache"
 
 - name: glance cache dir
   file: dest=/var/cache/glance state=directory mode=0700 owner=glance

--- a/roles/glance/tasks/monitoring.yml
+++ b/roles/glance/tasks/monitoring.yml
@@ -18,7 +18,10 @@
     state: present
 
 - name: glance-store check
-  sensu_check: name=check-glance-store plugin=check-glance-store.py
+  sensu_check:
+    name: check-glance-store
+    plugin: check-glance-store.py
+    args: "--imagedir={{ glance.sync.dir }}"
   notify: restart sensu-client
 
 - name: glance metrics

--- a/roles/glance/templates/etc/cron.d/glance-image-sync
+++ b/roles/glance/templates/etc/cron.d/glance-image-sync
@@ -6,8 +6,8 @@ PATH=/bin:/usr/bin
 {% for host in groups['controller'] %}
 {% if host != inventory_hostname %}
 # Synchronize images from {{ host }}
-* * * * * glance  flock --nonblock /tmp/glance-image-sync.lock -c "nice ionice -c3 rsync --archive --update --xattrs --bwlimit=50000 rsync://{{ hostvars[host][primary_interface]['ipv4']['address'] }}/glance/????????-????-????-????-???????????? /var/lib/glance/images/"
+* * * * * glance  flock --nonblock /tmp/glance-image-sync.lock -c "nice ionice -c3 rsync --archive --update --xattrs --bwlimit=50000 rsync://{{ hostvars[host][primary_interface]['ipv4']['address'] }}/glance/????????-????-????-????-???????????? {{ glance.sync.dir }}/"
 {% endif %}
 {% endfor %}
 # Remove all deleted glance images
-* * * * * glance  flock --timeout 60 /tmp/glance-image-sync.lock -c "mysql --defaults-file=/etc/glance/.my.cnf glance --batch -e \"SELECT value FROM image_locations WHERE value LIKE 'file:///var/lib/glance/images/\%' AND deleted_at IS NOT NULL;\" | egrep '^file://' | cut -c 8- | xargs rm -f"
+* * * * * glance  flock --timeout 60 /tmp/glance-image-sync.lock -c "mysql --defaults-file=/etc/glance/.my.cnf glance --batch -e \"SELECT value FROM image_locations WHERE value LIKE 'file://{{ glance.sync.dir }}/\%' AND deleted_at IS NOT NULL;\" | egrep '^file://' | cut -c 8- | xargs rm -f"

--- a/roles/glance/templates/etc/glance/glance-api.conf
+++ b/roles/glance/templates/etc/glance/glance-api.conf
@@ -16,6 +16,8 @@ syslog_log_facility = LOG_LOCAL0
 
 log_dir = /var/log/glance
 
+image_cache_dir = {{ glance.state_path }}/image-cache
+
 registry_host = 0.0.0.0
 registry_port = 9191
 registry_client_protocol = http
@@ -60,7 +62,7 @@ default_store = rbd
 stores = glance.store.filesystem.Store,
          glance.store.http.Store
 
-filesystem_store_datadir = /var/lib/glance/images/
+filesystem_store_datadir = {{ glance.state_path }}/images/
 
 default_store = file
 {% endif %}

--- a/roles/glance/templates/etc/rsyncd.conf
+++ b/roles/glance/templates/etc/rsyncd.conf
@@ -1,6 +1,6 @@
 [glance]
     comment = "Glance Images"
-    path = /var/lib/glance/images
+    path = {{ glance.sync.dir }}
     use chroot = yes
     read only = yes
     list = yes

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -29,6 +29,7 @@ nova:
   compute_reserve_ram: 2048
   preallocate_images: space
   floating_pool: external
+  state_path: "{{ state_path_base }}/nova"
   install_packages:
     - python-numpy
     - virt-top

--- a/roles/nova-common/tasks/main.yml
+++ b/roles/nova-common/tasks/main.yml
@@ -1,7 +1,14 @@
 ---
 - name: nova user
-  user: name=nova comment=nova shell=/bin/sh system=yes home=/var/lib/nova
-        createhome=yes generate_ssh_key=yes ssh_key_bits=4096
+  user:
+    name: nova
+    comment: nova
+    shell: /bin/sh
+    system: yes
+    home: "{{ nova.state_path }}"
+    createhome: yes
+    generate_ssh_key: yes
+    ssh_key_bits: 4096
 
 - name: nova packages
   apt:
@@ -11,8 +18,8 @@
 - name: create nova config dir
   file: dest=/etc/nova state=directory
 
-- name: create nova lib dir
-  file: dest=/var/lib/nova state=directory owner=nova
+- name: create nova lock dir (and parents)
+  file: dest={{ nova.state_path }}/lock state=directory owner=nova
 
 - name: create nova cache dir
   file: dest=/var/cache/nova state=directory mode=0700 owner=nova group=nova

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -49,11 +49,10 @@ cc_host={{ endpoints.main }}
 nova_url=http://{{ endpoints.main }}:{{ endpoints.nova.port.backend_api }}/v1.1/
 
 # Paths to important items #
-state_path=/var/lib/nova
-lock_path=/var/lib/nova
+state_path={{ nova.state_path }}
 rootwrap_config=/etc/nova/rootwrap.conf
 api_paste_config=/etc/nova/api-paste.ini
-keys_path=/var/lib/nova/keys
+keys_path={{ nova.state_path }}/keys
 
 # Auth
 use_deprecated_auth=false
@@ -169,6 +168,9 @@ reserved_host_memory_mb=4096
 [conductor]
 use_local = False
 workers = {{ nova.conductor_workers }}
+
+[oslo_concurrency]
+lock_path = {{ nova.state_path }}/lock
 
 [keystone_authtoken]
 identity_uri = {{ endpoints.keystone.url.admin }}

--- a/roles/nova-data/tasks/main.yml
+++ b/roles/nova-data/tasks/main.yml
@@ -12,7 +12,10 @@
   apt: pkg=sysfsutils
 
 - name: nova instances directory
-  file: dest=/var/lib/nova/instances state=directory owner=nova
+  file:
+    dest: "{{ nova.state_path }}/instances"
+    state: directory
+    owner: nova
 
 - name: nbd module
   lineinfile: dest=/etc/modules line="nbd"

--- a/roles/nova-data/tasks/ssh.yml
+++ b/roles/nova-data/tasks/ssh.yml
@@ -5,20 +5,36 @@
   register: nova_user
 
 - name: nova authorized_keys
-  template: src=var/lib/nova/ssh/authorized_keys
-            dest=/var/lib/nova/.ssh/authorized_keys owner=nova group=nova
-            mode=0600
+  template:
+    src: var/lib/nova/ssh/authorized_keys
+    dest: "{{ nova.state_path }}/.ssh/authorized_keys"
+    owner: nova
+    group: nova
+    mode: 0600
 
 - name: nova known_hosts
-  template: src=var/lib/nova/ssh/known_hosts
-            dest=/var/lib/nova/.ssh/known_hosts owner=nova group=nova mode=0600
+  template:
+    src: var/lib/nova/ssh/known_hosts
+    dest: "{{ nova.state_path }}/.ssh/known_hosts"
+    owner: nova
+    group: nova
+    mode: 0600
 
 - name: nova bin directory
-  file: dest=/var/lib/nova/bin state=directory owner=nova group=nova mode=0755
+  file:
+    dest: "{{ nova.state_path }}/bin"
+    state: directory
+    owner: nova
+    group: nova
+    mode: 0755
 
 - name: nova verify-ssh
-  template: src=var/lib/nova/bin/verify-ssh dest=/var/lib/nova/bin/verify-ssh
-            owner=nova group=nova mode=0755
+  template:
+    src: var/lib/nova/bin/verify-ssh
+    dest: "{{ nova.state_path }}/bin/verify-ssh"
+    owner: nova
+    group: nova
+    mode: 0755
 
 - name: verify ssh among compute nodes
-  command: sudo -u nova -H /bin/sh -c /var/lib/nova/bin/verify-ssh
+  command: sudo -u nova -H /bin/sh -c {{ nova.state_path }}/bin/verify-ssh

--- a/test/setup
+++ b/test/setup
@@ -39,6 +39,7 @@ cp ${ROOT}/envs/example/defaults.yml ${ROOT}/envs/test/defaults.yml
 cp -r ${ROOT}/envs/example/ci/* ${ROOT}/envs/test
 echo "---" > ${ROOT}/envs/test/group_vars/all.yml
 echo "testenv_instance_prefix: ${testenv_instance_prefix}" >> ${ROOT}/envs/test/group_vars/all.yml
+echo "state_path_base: /opt/stack/data" >> ${ROOT}/envs/test/group_vars/all.yml
 
 echo "generating ssl cert for openstack.example.com"
 CERT_DIR=$(mktemp -d 2> /dev/null || mktemp -d -t 'setup')


### PR DESCRIPTION
For the services that create potentially large amounts of data, move the
data to a standard data path, /opt/stack/data/<service>. In some
deployments we may have a different filesystem mounted to
/opt/stack/data.