### PR TITLE
Pull ip addresses out of configs

### DIFF
--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -60,7 +60,6 @@ default_backend = {{ cinder.default_backend }}
 
 {% if swift.enabled|bool -%}
 backup_driver = cinder.backup.drivers.swift
-backup_swift_url = http://{{ endpoints.swift.haproxy_vip }}:{{ endpoints.swift.port.cinder_backup }}/v1/
 {% endif -%}
 
 {% for backend in cinder.backends %}

--- a/roles/neutron-common/templates/etc/neutron/metadata_agent.ini
+++ b/roles/neutron-common/templates/etc/neutron/metadata_agent.ini
@@ -17,7 +17,7 @@ metadata_workers = {{ neutron.metadata_workers }}
 # Nova API returns HTTP 300 when these requests are made over HTTPS are run
 # through HA proxy, Send proxies meta-data requests to internal floating IP so
 # they are handled directly by nova-api on active controller.
-nova_metadata_ip = {{ undercloud_floating_ip }}
+nova_metadata_ip = {{ endpoints.main }}
 nova_metadata_port = 8775
 nova_metadata_protocol = http
 

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -23,7 +23,7 @@ nova:
   python_libvirt_version: 1.2.2-0ubuntu2~cloud0
   qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.16~cloud0
   librdb1_version: 0.80.9-0ubuntu0.14.04.2~cloud0
-  glance_endpoint: http://{{ undercloud_floating_ip }}:9393
+  glance_endpoint: http://{{ endpoints.main }}:9393
   reserved_host_disk_mb: 51200
   controller_reserve_ram: 4096
   compute_reserve_ram: 2048


### PR DESCRIPTION
We should rely on /etc/hosts entries to turn fqdns into undercloud
floating IPs, to bypass upstream gateways when communicating within the
cloud.