### PR TITLE
Fixed MongoDB Endpoint In Role To Match defaults.yml

### DIFF
--- a/roles/endpoints/defaults/main.yml
+++ b/roles/endpoints/defaults/main.yml
@@ -3,7 +3,7 @@ endpoints:
   main: "{{ fqdn }}"
   db: "{{ undercloud_floating_ip }}"
   rabbit: "{{ undercloud_floating_ip }}"
-  mongodb: "{{ undercloud_floating_ip }}"
+  mongodb: "{{ hostvars[groups['mongo_db'][0]][primary_interface]['ipv4']['address'] }}"
   magnum: "{{ fqdn }}"
   identity_uri: https://{{ fqdn }}:35357
   auth_uri: https://{{ fqdn }}:5000/v2.0


### PR DESCRIPTION
Was previously pointed to ucarp, now it's the first server for setup.

This is meant to match the previous PR - https://github.com/blueboxgroup/ursula/pull/1317/files