### PR TITLE
Fixed Heat Autoscaling By Making Ceilometer Alarms Not Verify SSL

### DIFF
--- a/roles/ceilometer-common/templates/etc/ceilometer/ceilometer.conf
+++ b/roles/ceilometer-common/templates/etc/ceilometer/ceilometer.conf
@@ -70,3 +70,6 @@ os_password = {{ secrets.service_password }}
 os_endpoint_type = internalURL
 os_region_name = RegionOne
 os_cacert = {{ ceilometer.cafile }}
+
+[alarm]
+rest_notifier_ssl_verify = false

--- a/roles/heat/templates/etc/heat/heat.conf
+++ b/roles/heat/templates/etc/heat/heat.conf
@@ -72,3 +72,6 @@ ca_file = {{ heat.cafile }}
 
 [clients]
 ca_file = {{ heat.cafile }}
+
+[ec2authtoken]
+ca_file = {{ heat.cafile }}


### PR DESCRIPTION
The alarm URL is signed with an AWS-style signature because /
the handler for it is provided (for now) by Heat's AWS compatibility API.
In liberty, heat will start to support signal url for autoscaling.