### PR TITLE
Add iscsi checks only when ceph is not a backend for cinder

### DIFF
--- a/roles/cinder-data/tasks/monitoring.yml
+++ b/roles/cinder-data/tasks/monitoring.yml
@@ -7,6 +7,7 @@
 - name: iscsid process check
   sensu_process_check: service=iscsid
   notify: restart sensu-client
+  when: "'rbd_volumes' not in cinder.enabled_backends"
 
 - name: cinder volume group metrics
   sensu_metrics_check: name=cinder-vg-metrics plugin=metrics-volgroup.sh
@@ -17,4 +18,3 @@
 - name: cinder-backup process check
   sensu_process_check: service=cinder-backup
   notify: restart sensu-client
-

--- a/roles/nova-data/tasks/monitoring.yml
+++ b/roles/nova-data/tasks/monitoring.yml
@@ -13,6 +13,7 @@
   sensu_metrics_check: name=check-cinder-sessions plugin=check-cinder-sessions.py
                        interval=10
   notify: restart sensu-client
+  when: "'rbd_volumes' not in cinder.enabled_backends"
 
 # ovs
 


### PR DESCRIPTION
Easier to use `cinder.enabled_backends`. No fun looping over a
list of dictionaries to see if it contains a value.

This replaces #1382.