### PR TITLE
Fix for novnc in haproxy

### DIFF
--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -69,7 +69,7 @@ frontend {{ name }}
 backend {{ name }}
 
   {% if name == "novnc" -%}
-  option httpchk GET /vnc_auto.html
+  option tcp-check /
   {% elif name == "ironic" -%}
   option httpchk GET /v1
   {% elif name == "ceilometer" -%}


### PR DESCRIPTION
Disable httpchk in novnc in haproxy to avoid hangs of nova-novncproxy. The default method used is tcp-check