### PR TITLE
Fix disk cleanup play to use new swift disk layout

### DIFF
--- a/playbooks/unmount-and-clear-disks.yml
+++ b/playbooks/unmount-and-clear-disks.yml
@@ -17,7 +17,7 @@
     apt: pkg="gdisk"
 
   - name: define disk list
-    set_fact: disk_list="{{ swift.disks }}"
+    set_fact: disk_list="{{ swift.disks | selectattr('disk', 'defined') | map(attribute='disk') | list }}"
     when: hosts == "swiftnode"
 
   - name: define disk list


### PR DESCRIPTION
Some test results after the change:

```
ok: [swiftnode1] => {
    "var": {
        "disk_list": [
            "sdb",
            "sdc",
            "sdd",
            "sde",
            "sdf",
            "sdg"
        ]
    }
}
```
Same format as ceph:
```
ok: [ceph1] => {
    "var": {
        "disk_list": [
            "sdd",
            "sde",
            "sdf"
        ]
    }
}
```