### PR TITLE
Ignore emacs and vim backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ envs/test/group_vars/all.yml
 .tox
 build
 *.DS_Store
+*~
+*\#*\#


### PR DESCRIPTION
I just got annoyed from all of the vim and emacs backup files showing up in my `git status`.