### PR TITLE
ensure fstab gets cleaned after unmounting

### DIFF
--- a/playbooks/unmount-and-clear-disks.yml
+++ b/playbooks/unmount-and-clear-disks.yml
@@ -24,6 +24,9 @@
     set_fact: disk_list="{{ ceph.disks }}"
     when: hosts == "ceph_osds"
 
+  - name: define partition_paths
+    set_fact: partition_paths="{{ swift.disks | selectattr('partition_path', 'defined') | map(attribute='partition_path') | list}}"
+
   - name: create list of disks present on node
     set_fact:
       disks_present: |
@@ -39,10 +42,26 @@
       - disk_list
     when: (item[0].mount != "/" and item[0].mount != "/boot") and item[1] in "{{ item[0].device }}"
 
-  - name: unmount shared partition if defined
-    mount: name={{ item.mount }} src={{ item.device }} fstype={{ item.fstype }} state=unmounted
-    with_items: "{{ ansible_mounts }}"
-    when: swift.os_shared_partition is defined and item.device == swift.os_shared_partition and hosts == "swiftnode"
+  - name: clean fstab for mounted devices
+    mount: name={{ item[0].mount }} src={{ item[0].device }} fstype={{ item[0].fstype }} state=absent
+    with_nested:
+      - "{{ ansible_mounts }}"
+      - disk_list
+    when: (item[0].mount != "/" and item[0].mount != "/boot") and item[1] in "{{ item[0].device }}"
+
+  - name: unmount partition_path
+    mount: name={{ item[0].mount }} src={{ item[0].device }} fstype={{ item[0].fstype }} state=unmounted
+    with_nested:
+      - "{{ ansible_mounts }}"
+      - partition_paths
+    when: item[0].device == item[1] and hosts == "swiftnode"
+
+  - name: clean fstab for partition_path
+    mount: name={{ item[0].mount }} src={{ item[0].device }} fstype={{ item[0].fstype }} state=absent
+    with_nested:
+      - "{{ ansible_mounts }}"
+      - partition_paths
+    when: item[0].device == item[1] and hosts == "swiftnode"
 
   - name: destroy GPT structures
     shell: sgdisk --zap-all /dev/{{ item }}


### PR DESCRIPTION
The ansible mount module now has a bug where setting the state to unmounted doesn't clean the /etc/fstab file as it should. Some new tasks are introduced to remove the appropriate entries from the fstab file. Also, the new disk layout structure for swift had to be accommodated when removing shared partitions.