### PR TITLE
Feature flag Neutron external network interface config

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -254,6 +254,7 @@ neutron:
   tenant_nameservers:
     - 8.8.4.4
     - 8.8.8.8
+  enable_external_interface: True
 
 glance:
   api_workers: 1

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -100,3 +100,4 @@ neutron:
     debug: False
     verbose: True
   cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"
+  enable_external_interface: False

--- a/site.yml
+++ b/site.yml
@@ -363,7 +363,9 @@
   roles:
     - role: 'openstack-network'
       tags: ['openstack', 'setup', 'openstack-network']
+      when: neutron.enable_external_interface|bool
   environment: "{{ env_vars|default({}) }}"
+
 
 - name: extra neutron setup
   hosts: network:compute


### PR DESCRIPTION
In some legacy deployments without firewalls we used the controllers as
gateways for the Neutron external and internal pNodes networks. All new
deployments use external network infrastructure to provide the gateway
for these networks. Remove code to automatically generate an
interfaces(5) file for the brq* interface for the external Neutron
network. Existing deployments will be unaffected since this file is
already written, and in most cases defined host_vars network_interfaces.
This will prevent erroneously assigning a duplicate IP address to the
controllers as the external default gateway. -- Dustin Lundquist