### PR TITLE
Fix sysctl ipv4 changes made in PR #1336

### DIFF
--- a/roles/common/tasks/networking.yml
+++ b/roles/common/tasks/networking.yml
@@ -32,17 +32,6 @@
   notify:
     - apply-sysctl
 
-- name: sysctl config file
-  sysctl:
-    state: present
-    name: "{{ item.name }}"
-    value: "{{ item.value }}"
-    reload: yes
-  with_items:
-    - { name: "net.ipv4.tcp_syncookies", value: 1 }
-    - { name: "net.ipv4.icmp_echo_ignore_broadcasts", value: 1 }
-    - { name: "net.ipv4.conf.all.accept_redirects", value: 0 }
-
 - name: ipv6 privacy
   lineinfile: dest=/etc/sysctl.d/10-ipv6-privacy.conf
               regexp="{{ item.value.regex }}"

--- a/roles/common/templates/etc/sysctl.d/60-tcp-tuning.conf
+++ b/roles/common/templates/etc/sysctl.d/60-tcp-tuning.conf
@@ -1,6 +1,8 @@
 # Parameters for high-performance TCP/UDP stack
 # Note that buffer values may need to be increased even further to take
 # full advantage of 10Gbit network interfaces
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.icmp_echo_ignore_broadcasts = 1
 net.ipv4.tcp_max_tw_buckets = 5000000
 net.ipv4.tcp_max_orphans = 5000000
 net.ipv4.tcp_max_syn_backlog = 40960


### PR DESCRIPTION
The changes made in the previous PR for sysctl failed on baremetal deployments.
This PR will correct those changes and put the ipv4 settings in the
correct spot for deployment.

Swift-common contained a tuning role which would override one of these
settings so it has been depreciated.