### PR TITLE
monitoring: sensu client_name use domain too

### DIFF
--- a/roles/common/templates/monitoring/config.json
+++ b/roles/common/templates/monitoring/config.json
@@ -1,6 +1,6 @@
 {
   "client": {
-    "name": "{{ inventory_hostname }}-{{ stack_env }}",
+    "name": "{{ monitoring.client_name|default(ansible_hostname ~ '.' ~ ansible_domain ~ '-' ~ stack_env|default('unknown_site')) }}",
     "address": "{{ primary_ip }}",
     "subscriptions": [
       "openstack"

--- a/roles/monitoring-common/defaults/main.yml
+++ b/roles/monitoring-common/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 monitoring:
+  client_name: ~
   checks:
     memory:
       warning: 4096


### PR DESCRIPTION
Sensu should use the full hostname including domain whenever available
for registering the sensu client into monitoring. However, at times we
still need to override this automatic naming which is supported via the
`monitoring.client_name` configuration variable.

--
**NOTE:**
On upgrades to existing sites, this **will** cause alerting to the
production Sensu instance. There will be keepalive alerts for the
existing sensu client_name, and any silenced alerts will again alert on
the newly registered client_name with domain.

Essentially, upgrade with alerting the on-call pager receivers
proactively prior to deployment.