### PR TITLE
Move the crud extensions after the jellyroll custom filters for the p…

### DIFF
--- a/roles/keystone/templates/etc/keystone/keystone-paste.ini
+++ b/roles/keystone/templates/etc/keystone/keystone-paste.ini
@@ -85,10 +85,10 @@ paste.app_factory = keystone.service:v3_app_factory
 paste.app_factory = keystone.service:admin_app_factory
 
 [pipeline:public_api]
-pipeline = sizelimit url_normalize build_auth_context token_auth json_body ec2_extension user_crud_extension{{ ' passval unauthlog' if keystone.jellyroll|bool else '' }} public_service
+pipeline = sizelimit url_normalize build_auth_context token_auth json_body ec2_extension{{ ' passval unauthlog' if keystone.jellyroll|bool else '' }} user_crud_extension public_service
 
 [pipeline:admin_api]
-pipeline = sizelimit url_normalize build_auth_context token_auth{{ ' admin_token_auth' if insert_token|default(boolean=False) else '' }} json_body ec2_extension s3_extension crud_extension{{ ' passval unauthlog' if keystone.jellyroll|bool else '' }} admin_service
+pipeline = sizelimit url_normalize build_auth_context token_auth{{ ' admin_token_auth' if insert_token|default(boolean=False) else '' }} json_body ec2_extension s3_extension{{ ' passval unauthlog' if keystone.jellyroll|bool else '' }} crud_extension admin_service
 
 [pipeline:api_v3]
 pipeline = sizelimit url_normalize build_auth_context token_auth json_body ec2_extension_v3 s3_extension simple_cert_extension revoke_extension{{ ' rbac_filter passval unauthlog' if keystone.jellyroll|bool else '' }} service_v3


### PR DESCRIPTION
…ublic_api and admin_api pipelines
Without this the passval filter does not get invoked on the 'PUT' method. This allows you to set a weak password not compliant with the filter password policy
