### PR TITLE
Increased HAProxy server and client timeouts

### DIFF
--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -43,8 +43,8 @@ defaults
   option redispatch
   option forwardfor
   option httpclose # needed for empty reponse body 204's
-  timeout client 30s
-  timeout server 30s
+  timeout client 300s
+  timeout server 300s
   timeout connect 1s
   timeout http-keep-alive 60s
   timeout http-request 30s

--- a/roles/haproxy/templates/etc/haproxy/haproxy_swift.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_swift.cfg
@@ -13,8 +13,8 @@ defaults
   option httplog
   option dontlognull
   option redispatch
-  timeout client 30s
-  timeout server 30s
+  timeout client 300s
+  timeout server 300s
   timeout connect 1s
   timeout http-keep-alive 60s
   timeout http-request 5s


### PR DESCRIPTION
Increased HAProxy server and client timeouts from 30 seconds to 300 seconds to address issues with HTTP 504 errors on long-running API calls.