### PR TITLE
allow swift to connect to proper memcached host

### DIFF
--- a/roles/swift-proxy/handlers/main.yml
+++ b/roles/swift-proxy/handlers/main.yml
@@ -4,3 +4,6 @@
 
 - name: restart haproxy
   service: name=haproxy state=restarted
+
+- name: restart memcached
+  action: service name=memcached state=restarted enabled=yes

--- a/roles/swift-proxy/tasks/main.yml
+++ b/roles/swift-proxy/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: comment out default memcached ip address
+  lineinfile: dest=/etc/memcached.conf
+              regexp='^-l 0.0.0.0'
+              line="# -l 0.0.0.0" state=present
+
+- name: use bond0 ip address for memcached
+  lineinfile: dest=/etc/memcached.conf insertafter="^# -l"
+              line="-l {{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}"
+              state=present
+  notify: restart memcached
+
 - name: permit swift proxy from anywhere
   ufw: rule=allow to_port=8090 proto=tcp
 


### PR DESCRIPTION
the default memcached ip address of `0.0.0.0` resulted in errors of the swift-proxy service. the respective line is now commented out in the `/etc/memcached.conf` file and the appropriate bond0 ip address is used. after these file edits, memcached will be restarted to ensure that the changes actually take place.