### PR TITLE
Add 'swift_backup_url' back to cinder.conf

### DIFF
--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -59,6 +59,7 @@ default_backend = {{ cinder.default_backend }}
 
 {% if swift.enabled|bool -%}
 backup_driver = cinder.backup.drivers.swift
+backup_swift_url = http://{{ endpoints.swift.haproxy_vip }}:{{ endpoints.swift.port.cinder_backup }}/v1/
 {% endif -%}
 
 {% for backend in cinder.backends %}


### PR DESCRIPTION
Removed as part of a cleanup to use FQDNs in place of IPs. However,
cinder swift driver does not support certificates other than those
acknowledged by curl or python requests. Thus we must connect
directly to swift without ssl. If we gather the url's from keystone
we are then trying to connect to the swift ssl port without using
ssl.