### PR TITLE
Add firewall rule for rabbitmq

### DIFF
--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -46,3 +46,6 @@
 
 - include: monitoring.yml tags=monitoring,common
   when: monitoring.enabled|default('True')|bool
+
+- name: permit access to rabbitmq
+  ufw: rule=allow to_port={{ rabbitmq.port }} proto=tcp


### PR DESCRIPTION
There is no firewall rule to allow rabbitmq access from outside the
controller nodes.