### PR TITLE
Fix git_mirror env example defaults

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -95,16 +95,16 @@ monitoring:
 
 openstack:
   pypi_mirror: https://pypi.python.org/simple/
-  git_mirror:  https://github.com/openstack
-  git_update: yes
   pypi_mirror: https://pypi-mirror.openstack.blueboxgrid.com/root/pypi
   easy_install_mirror: https://pypi-mirror.openstack.blueboxgrid.com/root/pypi/+simple
   pip_trusted: pypi-mirror.openstack.blueboxgrid.com
   gem_sources:
     - https://gem-mirror.openstack.blueboxgrid.com
-  git_mirror:  https://github.com/openstack
-  git_update: yes
   ubuntu_mirror: https://apt-mirror.openstack.blueboxgrid.com/archive.ubuntu.com/ubuntu
+
+openstack_source:
+  git_mirror:  https://github.com/openstack
+  git_update: no
 
 apt_repos:
   docker:


### PR DESCRIPTION
The git_mirror and git_update values are not valid in the openstack
block, they should be part of openstack_source.
