### PR TITLE
ipmi modprobe state should be 'present'

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -8,7 +8,7 @@ common:
   ipmi:
     enabled: True
     serial_console: ttyS1
-    state: probe
+    state: present 
     baud_rate: 115200
   python_extra_packages: []
   ntpd:


### PR DESCRIPTION
We've seen this error out a couple deploys.
The docs indicate just 'absent' or 'present' as being supported.
http://docs.ansible.com/ansible/modprobe_module.html