### PR TITLE
common: sensu client_name default handle falsey values

### DIFF
--- a/roles/common/templates/monitoring/config.json
+++ b/roles/common/templates/monitoring/config.json
@@ -1,6 +1,6 @@
 {
   "client": {
-    "name": "{{ monitoring.client_name|default(ansible_hostname ~ '.' ~ ansible_domain ~ '-' ~ stack_env|default('unknown_site')) }}",
+    "name": "{{ monitoring.client_name|default(ansible_hostname ~ '.' ~ ansible_domain ~ '-' ~ stack_env|default('unknown_site'), true) }}",
     "address": "{{ primary_ip }}",
     "subscriptions": [
       "openstack"


### PR DESCRIPTION
The jinja2 ` | default()` filter does not respect falsey values like `~ (null)` by default. It only operates on fully `undefined` values. For sanity, we want to handle YAML `nil` and define the defaults so we know what vars are actually used in a role.