### PR TITLE
Ensure logstash can read all ceph logs

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -4,6 +4,19 @@
     path: /etc/ceph
     state: directory
 
+- name: create ceph log directory
+  file: dest=/var/log/ceph state=directory mode=2750 owner=root group=adm
+
+- name: Change ceph log dir acl
+  acl: name=/var/log/ceph state=present default=yes etype={{ item.etype }} permissions={{ item.permission }}
+  with_items:
+    - etype: user
+      permission: rw
+    - etype: group
+      permission: r
+    - etype: other
+      permission: r
+
 - name: install dependencies
   apt: pkg={{ item }}
        state=present

--- a/roles/ceph-monitor/tasks/main.yml
+++ b/roles/ceph-monitor/tasks/main.yml
@@ -36,6 +36,20 @@
            --keyring /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
            creates=/var/lib/ceph/mon/ceph-{{ ansible_hostname }}/keyring
 
+- name: make sure ceph.log has proper permissions for logstash
+  file: dest=/var/log/ceph/ceph.log
+        state=touch
+        owner=root
+        group=adm
+        mode=0644
+
+- name: make sure ceph.audit.log has proper permissions for logstash
+  file: dest=/var/log/ceph/ceph.audit.log
+        state=touch
+        owner=root
+        group=adm
+        mode=0644
+
 - name: activate monitor with upstart
   file: path=/var/lib/ceph/mon/ceph-{{ ansible_hostname }}/{{ item }}
         state=touch


### PR DESCRIPTION
Fix for issue https://github.com/blueboxgroup/ursula/issues/1433. 
Ensure ceph log files on Monitor and Storage/osd nodes are collected by logstash.