### PR TITLE
Upgrade pip in test

### DIFF
--- a/test/setup
+++ b/test/setup
@@ -6,6 +6,7 @@ if [[ "$CI" == "jenkins" ]]; then
     VENV=$WORKSPACE/venv
     virtualenv $VENV
     source $VENV/bin/activate
+    pip install -U pip
     pip install -U -r requirements.txt
 fi
 


### PR DESCRIPTION
Upgrading pip from 1.5.4 to 1.7.2 will get rid of the following type of
error during test run setup:

  ERROR: os_security_group is not a legal parameter in an Ansible task
  or handler