### PR TITLE
Use os_server in delete task

### DIFF
--- a/playbooks/ci-full/tasks/delete.yml
+++ b/playbooks/ci-full/tasks/delete.yml
@@ -9,7 +9,9 @@
 
   tasks:
     - name: delete test instances
-      local_action: nova_compute name={{ item }} state=absent
+      os_server:
+        name: "{{ item }}"
+        state: absent
       with_items: testenv_instance_names
 
     - name: remove security group


### PR DESCRIPTION
A traceback in one of our Jenkins logs indicated we were still using
the nova_compute module to delete the instance instead of os_server.

Associated with: https://trello.com/c/fXNGJuFH