### PR TITLE
Fix Percona logrotate script

### DIFF
--- a/roles/percona-server/tasks/logging.yml
+++ b/roles/percona-server/tasks/logging.yml
@@ -7,4 +7,7 @@
       - rotate 7
       - missingok
       - compress
+      - postrotate
+      - test -x /usr/bin/mysqladmin && /usr/bin/mysqladmin ping > /dev/null && /usr/bin/mysqladmin flush-logs > /dev/null
+      - endscript
       - minsize 100k


### PR DESCRIPTION
 Percona logrotate is leaving logs open, even when they are deleted, causing the disk to fill up. Logrotate is modified to use flush logs directive.