### PR TITLE
Unique keypair name

### DIFF
--- a/playbooks/ci-allinone/vars/main.yml
+++ b/playbooks/ci-allinone/vars/main.yml
@@ -2,8 +2,6 @@
 testenv_instance_prefix: test
 testenv_instance_names:
   - "{{ testenv_instance_prefix }}-allinone"
-testenv_keypair_name: int-test
-testenv_keypair_path: "{{ ansible_env.ROOT }}/envs/test/{{ testenv_keypair_name }}.pem"
 testenv_image_id: "{{ ansible_env.IMAGE_ID }}"
 testenv_security_groups_description: Rules for testing
 testenv_security_groups: "{{ testenv_instance_prefix }}_ursula"

--- a/playbooks/ci-full/vars/main.yml
+++ b/playbooks/ci-full/vars/main.yml
@@ -3,8 +3,6 @@ testenv_instance_names:
   - "{{ testenv_instance_prefix }}-controller-0"
   - "{{ testenv_instance_prefix }}-controller-1"
   - "{{ testenv_instance_prefix }}-compute-0"
-testenv_keypair_name: int-test
-testenv_keypair_path: "{{ ansible_env.ROOT }}/envs/test/{{ testenv_keypair_name }}.pem"
 testenv_image_id: "{{ ansible_env.IMAGE_ID }}"
 testenv_security_groups_description: Rules for testing
 testenv_security_groups: "{{ testenv_instance_prefix }}_ursula"

--- a/test/common
+++ b/test/common
@@ -4,8 +4,8 @@ export STACK_RC=${STACK_RC:-~/.stackrc}
 [[ -f ${STACK_RC} ]] && source ${STACK_RC}
 
 export ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
-KEY_NAME=int-test
-KEY_PATH=${ROOT}/envs/test/${KEY_NAME}.pem
+export KEY_NAME=${KEY_NAME:=int-test}
+export KEY_PATH=${ROOT}/envs/test/${KEY_NAME}.pem
 LOGIN_USER=ubuntu
 SSH_ARGS=\
 " ${ANSIBLE_SSH_ARGS}"\

--- a/test/setup
+++ b/test/setup
@@ -21,9 +21,13 @@ cat > ${ROOT}/envs/test/hosts <<eof
 # Tell ansible to use the python in PATH instead of /usr/bin/python
 localhost ansible_python_interpreter=python ansible_connection=local
 eof
-cp ${ROOT}/envs/example/defaults-2.0.yml ${ROOT}/envs/test/defaults-2.0.yml
 
-echo "testenv_instance_prefix: ${testenv_instance_prefix}" >> ${ROOT}/envs/test/defaults-2.0.yml
+cp ${ROOT}/envs/example/defaults-2.0.yml ${ANSIBLE_VAR_DEFAULTS_FILE}
+cat <<eof >> ${ANSIBLE_VAR_DEFAULTS_FILE}
+testenv_instance_prefix: ${testenv_instance_prefix}
+testenv_keypair_name: ${KEY_NAME}
+testenv_keypair_path: ${KEY_PATH}
+eof
 
 echo "destroying: ${VMS}"
 ${ROOT}/test/cleanup
@@ -36,7 +40,6 @@ CONTROLLER_IP=$(private_ip ${testenv_instance_prefix}-controller-0)
 rm -rf ${ROOT}/envs/test/group_vars/
 rm -f ${ROOT}/envs/test/hosts
 mkdir -p ${ROOT}/envs/test/group_vars
-cp ${ROOT}/envs/example/defaults-2.0.yml ${ROOT}/envs/test/defaults-2.0.yml
 cp -r ${ROOT}/envs/example/ci/* ${ROOT}/envs/test
 echo "---" > ${ROOT}/envs/test/group_vars/all.yml
 echo "testenv_instance_prefix: ${testenv_instance_prefix}" >> ${ROOT}/envs/test/group_vars/all.yml


### PR DESCRIPTION
To have concurrent test runs happening in the same cloud and tenant, we need to have unique keypair names.