### PR TITLE
Cleaning up how memcached bind address was configured in Swift

### DIFF
--- a/roles/memcached/defaults/main.yml
+++ b/roles/memcached/defaults/main.yml
@@ -3,3 +3,4 @@ memcached:
   gem:
     url: https://rubygems.org/downloads/memcached-1.8.0.gem
     name: memcached-1.8.0.gem
+  bind_ip: '0.0.0.0'

--- a/roles/memcached/templates/memcached.conf
+++ b/roles/memcached/templates/memcached.conf
@@ -32,7 +32,7 @@ logfile /var/log/memcached.log
 # Specify which IP address to listen on. The default is to listen on all IP addresses
 # This parameter is one of the only security measures that memcached has, so make sure
 # it's listening on a firewalled interface.
--l 0.0.0.0
+-l {{ memcached.bind_ip }}
 
 # Limit the number of simultaneous incoming connections. The daemon default is 1024
 -c {{ memcached.max_connections }}

--- a/roles/swift-proxy/handlers/main.yml
+++ b/roles/swift-proxy/handlers/main.yml
@@ -5,5 +5,3 @@
 - name: restart haproxy
   service: name=haproxy state=restarted
 
-- name: restart memcached
-  action: service name=memcached state=restarted enabled=yes

--- a/roles/swift-proxy/tasks/main.yml
+++ b/roles/swift-proxy/tasks/main.yml
@@ -1,15 +1,4 @@
 ---
-- name: comment out default memcached ip address
-  lineinfile: dest=/etc/memcached.conf
-              regexp='^-l 0.0.0.0'
-              line="# -l 0.0.0.0" state=present
-
-- name: use bond0 ip address for memcached
-  lineinfile: dest=/etc/memcached.conf insertafter="^# -l"
-              line="-l {{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}"
-              state=present
-  notify: restart memcached
-
 - name: permit swift proxy from anywhere
   ufw: rule=allow to_port=8090 proto=tcp
 

--- a/roles/swift-proxy/vars/main.yml
+++ b/roles/swift-proxy/vars/main.yml
@@ -1,0 +1,3 @@
+---
+memcached:
+  bind_ip: "{{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}"


### PR DESCRIPTION
Parameterized the bind address in memcached role. Instead of manipulating memcached.conf, override that variable in proxy role.