### PR TITLE
Support ip allocation pool definition for subnets

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -219,6 +219,8 @@ neutron:
       network_name: internal
       ip_version: 4
       cidr: 172.16.255.0/24
+      pool_start: 172.16.255.2
+      pool_end: 172.16.255.254
       enable_dhcp: "true"
       gateway_ip: 172.16.255.1
       dns_nameservers: '8.8.8.8,8.8.4.4'

--- a/roles/openstack-setup/tasks/networks.yml
+++ b/roles/openstack-setup/tasks/networks.yml
@@ -26,6 +26,8 @@
     ipv6_address_mode: "{{ item.ipv6_ra_mode | default(omit) }}"
     ip_version: "{{ item.ip_version }}"
     dns_nameservers: "{{ item.dns_nameservers|default(omit) }}"
+    allocation_pool_start: "{{ item.pool_start|default(omit) }}"
+    allocation_pool_end: "{{ item.pool_end|default(omit) }}"
     state: present
     auth:
       auth_url: "{{ endpoints.auth_uri }}"


### PR DESCRIPTION
In some environments we cannot use the default IP allocation of the
entire subnet, and instead need to define a start and end to the pool.
When no start/end have been defined, do not pass along the options to
the module.