### PR TITLE
Added parameters to tune block device allocation retry timeouts.

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -30,6 +30,8 @@ nova:
   preallocate_images: space
   floating_pool: external
   state_path: "{{ state_path_base }}/nova"
+  block_device_allocate_retries: 200
+  block_device_allocate_retries_interval: 3
   install_packages:
     - python-numpy
     - virt-top

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -103,6 +103,8 @@ ec2_workers={{ nova.ec2_workers }}
 # Cinder #
 volume_api_class=nova.volume.cinder.API
 osapi_volume_listen_port=5900
+block_device_allocate_retries={{ nova.block_device_allocate_retries }}
+block_device_allocate_retries_interval={{ nova.block_device_allocate_retries_interval }}
 
 {% macro rabbitmq_hosts() -%}
 {% for host in groups['controller'] -%}


### PR DESCRIPTION
Adding this due to timeouts observed when copying large glance images to cinder volumes.  The default only allows 3 minutes for this action to finish.  This bumps the settings up to allow for 10 minutes.