### PR TITLE
Support ip allocation pool definition for subnets (1.2.x)

### DIFF
--- a/envs/example/defaults.yml
+++ b/envs/example/defaults.yml
@@ -150,6 +150,8 @@ neutron:
     - name: internal
       network_name: internal
       cidr: 172.16.255.0/24
+      pool_start: 172.16.255.2
+      pool_end: 172.16.255.254
       enable_dhcp: "true"
       gateway_ip: 172.16.255.1
       ip_version: 4

--- a/roles/openstack-setup/tasks/networks.yml
+++ b/roles/openstack-setup/tasks/networks.yml
@@ -27,6 +27,25 @@
                   login_username=provider_admin
                   login_password={{ secrets.provider_admin_password }}
   with_items: neutron.subnets
+  when: item.pool_start is not defined
+
+- name: neutron subnets with allocation pool
+  neutron_subnet: name={{ item.name }}
+                  network_name={{ item.network_name }}
+                  cidr={{ item.cidr }}
+                  allocation_pool_start={{ item.pool_start }}
+                  allocation_pool_end={{ item.pool_end }}
+                  enable_dhcp={{ item.enable_dhcp }}
+                  gateway_ip={{ item.gateway_ip }}
+                  ip_version={{ item.ip_version }}
+                  dns_nameservers={{ neutron.tenant_nameservers|join(',') }}
+                  state=present
+                  auth_url={{ endpoints.auth_uri }}
+                  login_tenant_name=admin
+                  login_username=provider_admin
+                  login_password={{ secrets.provider_admin_password }}
+  with_items: neutron.subnets
+  when: item.pool_start is defined
 
 - name: neutron routers
   neutron_router: state=present


### PR DESCRIPTION
In some environments we cannot use the default IP allocation of the
entire subnet, and instead need to define a start and end to the pool.
When no start/end have been defined, do not pass along the options to
the module.

THe subnet creation task is duplicated here becuase Ansible 1.7 does not
have the "omit" filter.