### PR TITLE
Set mysql dir permissions

### DIFF
--- a/roles/percona-server/tasks/main.yml
+++ b/roles/percona-server/tasks/main.yml
@@ -35,6 +35,13 @@
   - percona-xtradb-cluster-server-{{ xtradb.server_version }}
   - percona-xtrabackup
 
+- name: set mysql data path permissions
+  file:
+    path: /var/lib/mysql
+    state: directory
+    owner: mysql
+    group: mysql
+
 # Workaround for 0.8.6 to 0.9.1 upgrade path
 - name: fix config header in replication.cnf
   lineinfile: dest=/etc/mysql/conf.d/replication.cnf create=yes


### PR DESCRIPTION
If the mysql data dir is provided by an LVM mount point, we need to
ensure permissions of the directory so that percona can write to it. We
have to have the task after the percona package installs so that the
mysql user/group exist.