### PR TITLE
Install python-prettytable for client usage

### DIFF
--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -12,3 +12,5 @@ client:
     - python-ironicclient
     - python-swiftclient
     - python-magnumclient
+  apt_packages:
+    - python-prettytable

--- a/roles/client/meta/main.yml
+++ b/roles/client/meta/main.yml
@@ -1,3 +1,7 @@
 ---
 dependencies:
   - role: endpoints
+  - role: apt-repos
+    repos:
+      - repo: 'deb {{ apt_repos.bbg_ubuntu.repo }} {{ ansible_lsb.codename }} main'
+        key_url: "{{ apt_repos.bbg_ubuntu.key_url }}"

--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -2,6 +2,12 @@
 - name: openstack creds
   template: src=root/stackrc dest=/root/stackrc
 
+- name: install required packages for clients
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items: client.apt_packages
+
 - name: install openstack clients
   pip: name={{ item }}
   with_items: client.names


### PR DESCRIPTION
If the package is not installed, pip will pull in python-prettytable
from pypi. Installation this way can lead to prettytable packages that
are only readable by root, breaking non-root usage of clients or other
things like that. Work around this by installing the package from apt to
satisfy the dependency.