### PR TITLE
Limit heat engine workers

### DIFF
--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -39,3 +39,4 @@ heat:
     verbose: True
   cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"
   plugin_dirs: []
+  engine_workers: 4

--- a/roles/heat/templates/etc/heat/heat.conf
+++ b/roles/heat/templates/etc/heat/heat.conf
@@ -47,6 +47,8 @@ default_deployment_signal_transport=HEAT_SIGNAL
 plugin_dirs = {{ heat.plugin_dirs|join(', ') }}
 {% endif %}
 
+num_engine_workers = {{ heat.engine_workers }}
+
 [database]
 connection=mysql://heat:{{ secrets.db_password }}@{{ endpoints.db }}/heat?charset=utf8
 


### PR DESCRIPTION
Upstream docs say that the default is 4, but in reality the default is
number of CPUs. Limit it to 4 as a default that can be overridden.