### PR TITLE
Make serial console a variable defaulting to ttyS0

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -43,3 +43,4 @@ common:
   logging:
     debug: False
     verbose: True
+  serial_console: ttyS0

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -67,7 +67,7 @@
   tags: ntp
 
 # Include serial console before kernel-tuning to build serial_console_cmdline
-- include: serial-console.yml tty=ttyS0
+- include: serial-console.yml tty={{ common.serial_console }}
   tags: ['prereboot']
 
 - include: ipmi.yml


### PR DESCRIPTION
This will make the serial console passed to
roles/common/tasks/serial_console.yml a variable that defaults to ttyS0

It addresses issue #1472.