### PR TITLE
Pin oslo.utils (1.2.x)

### DIFF
--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -2,6 +2,7 @@
 client:
   self_signed_cert: false
   names:
+    - oslo.utils==3.2.0
     - python-keystoneclient
     - python-glanceclient>=1.1.0
     - python-novaclient


### PR DESCRIPTION
oslo.utils 3.3.0 is breaking python-keystoneclient. Will track this
upstream but for now we need to pin it to keep clients working.

(cherry picked from commit 85c3841c1287c51021388cb042987f30bef78e48)