### PR TITLE
Blacklist OVS

### DIFF
--- a/roles/neutron-common/tasks/main.yml
+++ b/roles/neutron-common/tasks/main.yml
@@ -5,6 +5,16 @@
     - vlan
     - bridge-utils
 
+- name: unload openvswitch if present
+  modprobe: name=openvswitch state=absent
+
+- name: blacklist openvswitch
+  template: dest=/etc/modprobe.d/blacklist-openvswitch.conf 
+            src=etc/modprobe.d/blacklist-openvswitch.conf
+            mode=0644
+            owner=root
+            group=root
+
 - name: configure VXLAN to use IANA assigned port 4789
   copy: content="options vxlan udp_port=4789"
         dest=/etc/modprobe.d/vxlan-port.conf owner=root group=root mode=0644

--- a/roles/neutron-common/templates/etc/modprobe.d/blacklist-openvswitch.conf
+++ b/roles/neutron-common/templates/etc/modprobe.d/blacklist-openvswitch.conf
@@ -1,0 +1,1 @@
+blacklist openvswitch


### PR DESCRIPTION
We do not want OVS starting when we are not using it...so blacklist
it on all neutron-common nodes (all nodes participating in the
neutron data plane shoudl be covered here).