### PR TITLE
Install kernel debug symbols for fast crashdumps

### DIFF
--- a/playbooks/dbgsym-kernel.yml
+++ b/playbooks/dbgsym-kernel.yml
@@ -1,0 +1,27 @@
+---
+- name: add debug symbol archive key
+  apt_key: keyserver=keyserver.ubuntu.com id=2512191FEF8729D6E5AF414DECDCAD72428D7C01
+
+- name: add debug symbol apt repository
+  apt_repository:
+    repo: 'deb http://ddebs.ubuntu.com/ {{ item }} main restricted universe multiverse'
+    update_cache: yes
+  with_items:
+  - precise
+  - precise-updates
+  - precise-proposed
+  when: ansible_distribution_version == "12.04"
+
+- name: add debug symbol apt repository
+  apt_repository:
+    repo: 'deb http://ddebs.ubuntu.com/ {{ item }} main restricted universe multiverse'
+    update_cache: yes
+  with_items:
+  - trusty
+  - trusty-security
+  - trusty-updates
+  - trusty-proposed
+  when: ansible_distribution_version == "14.04"
+
+- name: install kernel debug symbols for running kernel (requires recent kernel)
+  apt: pkg=linux-image-{{ ansible_kernel }}-dbgsym state=present

--- a/roles/common/tasks/kernel-tuning.yml
+++ b/roles/common/tasks/kernel-tuning.yml
@@ -48,7 +48,7 @@
 - name: Increase grub-common crashkernel reserved size
   lineinfile: dest=/etc/grub.d/10_linux
               regexp="^    GRUB_CMDLINE_EXTRA=.+crashkernel="
-              line="    GRUB_CMDLINE_EXTRA=\"$GRUB_CMDLINE_EXTRA crashkernel=256M\""
+              line="    GRUB_CMDLINE_EXTRA=\"$GRUB_CMDLINE_EXTRA crashkernel=512M\""
   notify: update grub config
 
 - name: "Disable GRUB OS prober so we don't try to boot instance's cinder volumes"


### PR DESCRIPTION
The dbgsym ddeb is large and on a slow mirror, and this only needs to be done upon kernel upgrade. Without debug symbols, kdump is forced to use a much slower page filtering method with makedumpfile. Only the last five kernel releases have dbgsym packages on the mirrors.

Also increases reserved crashkernel memory to 512M--[though this worked for me, it may not be sufficient for systems with >64GB RAM](https://activedoc.opensuse.org/book/opensuse-system-analysis-and-tuning-guide/chapter-18-kexec-and-kdump#cha.tuning.kdump.basic.manual), and so this likely needs to be dynamic.  (It's unclear to me if `crashkernel=auto` DTRT.) If makedumpfile is oomkilled, kdump will simply `cp /proc/vmcore /var/crash/xxxx`, taking even longer.