### PR TITLE
Limit setuptools version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ python-keystoneclient
 python-glanceclient<=0.19.0
 python-cinderclient
 oslo.utils==1.9.0
+setuptools<19
 tox
 pep8
 -e git://github.com/willthames/ansible-lint.git@9777f20aafd4be8706c9ce17005c981cb19a6a25#egg=ansible-lint


### PR DESCRIPTION
Newer setuptools is barfing on the configs of some of the python
packages we need. This limit keeps us working.