### PR TITLE
Support keyserver/id for apt_key in apt-repos role

### DIFF
--- a/roles/apt-repos/tasks/main.yml
+++ b/roles/apt-repos/tasks/main.yml
@@ -1,10 +1,13 @@
 ---
 - name: add any dependent repository keys from url
   apt_key:
-    url: "{{ item.key_url }}"
-    validate_certs: "{{ item.validate_certs|default(omit) }}"
+    url: "{{ item.key_url | default(omit) }}"
+    validate_certs: "{{ item.validate_certs | default(omit) }}"
+    keyserver: "{{ item.key_server | default(omit) }}"
+    id: "{{ item.id | default(omit) }}"
   with_items: repos
-  when: repos is defined and item.key_url is defined
+  when: repos is defined and
+        (item.key_url is defined or item.keyserver is defined)
 
 # things like keyrings may come as packages vs. keys
 - name: add any dependent repository key packages


### PR DESCRIPTION
Some keys seem to only be available via keyserver and ID rather than via
url. This change allows using keyserver/id intead of url, thanks to the
omit filter. The task will only fire if either a key_url or a keyserver
is passed in for a repo.