### PR TITLE
Remove use of nova_keypair

### DIFF
--- a/playbooks/ci-full/tasks/keypair.yml
+++ b/playbooks/ci-full/tasks/keypair.yml
@@ -4,16 +4,20 @@
   register: testenv_keypair_local
 
 - name: delete remote keypair
-  nova_keypair: name={{ testenv_keypair_name }} state=absent
+  os_keypair:
+    name: "{{ testenv_keypair_name }}"
+    state: absent
   when: not testenv_keypair_local.stat.exists
 
 - name: create the keypair
-  nova_keypair: name={{ testenv_keypair_name }} state=present
+  os_keypair:
+    name: "{{ testenv_keypair_name }}"
+    state: present
   register: testenv_keypair
 
 - name: persist the keypair
   copy:
     dest: "{{ testenv_keypair_path }}"
-    content: "{{ testenv_keypair.key }}"
+    content: "{{ testenv_keypair.key.private_key }}"
     mode: 0600
   when: testenv_keypair.changed


### PR DESCRIPTION
This is preventing us from unpinning our install of python-novaclient.