### PR TITLE
conditional for heat notification driver

### DIFF
--- a/roles/heat/templates/etc/heat/heat.conf
+++ b/roles/heat/templates/etc/heat/heat.conf
@@ -37,7 +37,11 @@ instance_connection_is_secure=1
 region_name_for_services=RegionOne
 
 rpc_thread_pool_size=64
+{% if ceilometer.enabled|default('False')|bool -%}
 notification_driver = heat.openstack.common.notifier.rpc_notifier
+{% else -%}
+notification_driver = noop
+{% endif -%}
 rpc_response_timeout=60
 
 default_software_config_transport=POLL_SERVER_HEAT


### PR DESCRIPTION
When ceilometer is not enable, set heat notification driver to noop. 