### PR TITLE
Define mysql socket path

### DIFF
--- a/roles/percona-backup/templates/percona-xtrabackup.sh
+++ b/roles/percona-backup/templates/percona-xtrabackup.sh
@@ -26,7 +26,7 @@ backup_retention_days=7
 backup_root_dir=/backup/percona/
 
 # create a new db archive, use tar stream to compress on the fly
-"$backup_script" --user=root --stream=tar "$backup_root_dir" | "$gzip" - > "$backup_root_dir"`/bin/date +"%Y-%m-%d_%H-%M-%S"`.tar.gz || (/bin/echo "failed to create db archive at: `/bin/date`" | mail "$email" -s "Percona backup failed")
+"$backup_script" --user=root --socket=/var/run/mysqld/mysqld.sock --stream=tar "$backup_root_dir" | "$gzip" - > "$backup_root_dir"`/bin/date +"%Y-%m-%d_%H-%M-%S"`.tar.gz || (/bin/echo "failed to create db archive at: `/bin/date`" | mail "$email" -s "Percona backup failed")
 
 echo Removing backups older than "$backup_retention_days" days
 find "$backup_root_dir" -maxdepth 1 -type f -mtime +"$backup_retention_days" -print -delete


### PR DESCRIPTION
This needs to be defined so that the percona backup script is able to
connect to the database.