### PR TITLE
updating packages and creating ceph.conf on compute nodes

### DIFF
--- a/roles/ceph-compute/meta/main.yml
+++ b/roles/ceph-compute/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - role: nova-data
+  - role: ceph-common

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -163,6 +163,7 @@ reserved_host_memory_mb=0
 {% elif inventory_hostname in groups['controller'] -%}
 reserved_host_memory_mb=4096
 {% endif %}
+disk_cachemodes="network=writeback"
 
 [conductor]
 use_local = False


### PR DESCRIPTION
This is going to deprecate PR #1493. Adding ceph-common as a dependency for ceph-compute so that librbd1 and librados2 packages on compute nodes will be synced with the ceph nodes. In addition, a ceph.conf file will be generated for the compute nodes as well, allowing for RBD client configuration.