### PR TITLE
library: sensu modules use default, metrics handlers

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -5,6 +5,7 @@ nocows = 1
 nocolor = 0
 transport = ssh
 vars_plugins = plugins/vars
+action_plugins = plugins/action
 connection_plugins = plugins/connection
 callback_plugins = plugins/callbacks
 filter_plugins = plugins/filters

--- a/library/sensu_check.py
+++ b/library/sensu_check.py
@@ -38,7 +38,7 @@ def main():
             prefix=dict(required=False,default=''),
             env_vars=dict(required=False,default=''),
             command=dict(required=False,default=''),
-            handler=dict(required=False,default='pagerduty'),
+            handler=dict(required=False,default='default'),
             plugin_dir=dict(default='/etc/sensu/plugins', required=False),
             check_dir=dict(default='/etc/sensu/conf.d/checks', required=False),
             state=dict(default='present', required=False, choices=['present','absent'])
@@ -60,7 +60,6 @@ def main():
                     command = '%s %s' % (module.params['prefix'], command)
                 if module.params['use_sudo']:
                     command = "sudo %s" % (command)
-            notification = '%s check failed' % (module.params['name'])
             check=dict({
                 'checks': {
                     module.params['name']: {
@@ -68,7 +67,6 @@ def main():
                         'standalone': True,
                         'handlers': [ module.params['handler'] ],
                         'interval': int(module.params['interval']),
-                        'notification': notification,
                         'occurrences': int(module.params['occurrences']),
                         'auto_resolve': module.params['auto_resolve'],
                         'handle': module.params['handle']

--- a/library/sensu_metrics_check.py
+++ b/library/sensu_metrics_check.py
@@ -56,7 +56,7 @@ def main():
                         'command': command,
                         'standalone': True,
                         'interval': int(module.params['interval']),
-                        'handlers': [ 'graphite' ]
+                        'handlers': [ 'metrics' ]
                     }
                 }
             })

--- a/library/sensu_process_check.py
+++ b/library/sensu_process_check.py
@@ -49,7 +49,7 @@ def main():
                     short_service_name: {
                         'command': command,
                         'standalone': True,
-                        'handlers': [ 'pagerduty' ],
+                        'handlers': [ 'default' ],
                         'interval': int(module.params['interval']),
                         'notification': notification,
                         'occurrences':  int(module.params['occurrences'])

--- a/plugins/action/sensu_check.py
+++ b/plugins/action/sensu_check.py
@@ -1,0 +1,43 @@
+from ansible.utils import parse_kv, template
+
+
+class ActionModule(object):
+    """
+    TODO: FIXME when upgrading to Ansible 2.x
+    """
+
+    TRANSFERS_FILES = False
+
+    def __init__(self, runner):
+        self.runner = runner
+        self.basedir = runner.basedir
+
+    def _arg_or_fact(self, arg_name, fact_name, args, inject):
+        res = args.get(arg_name)
+        if res is not None:
+            return res
+
+        template_string = '{{ %s }}' % fact_name
+        res = template.template(self.basedir, template_string, inject)
+        return None if res == template_string else res
+
+    def _merge_args(self, module_args, complex_args):
+        args = {}
+        if complex_args:
+            args.update(complex_args)
+
+        kv = parse_kv(module_args)
+        args.update(kv)
+
+        return args
+
+    def run(self, conn, tmp, module_name, module_args, inject, complex_args=None, **kwargs):
+        args = self._merge_args(module_args, complex_args)
+
+        check_handler = self._arg_or_fact('handler', 'monitoring.check_handler', args, inject)
+
+        complex_args['handler'] = check_handler
+        module_return = self.runner._execute_module(conn, tmp, 'sensu_check', module_args, inject=inject,
+                                             complex_args=args)
+
+        return module_return

--- a/plugins/action/sensu_metrics_check.py
+++ b/plugins/action/sensu_metrics_check.py
@@ -1,0 +1,43 @@
+from ansible.utils import parse_kv, template
+
+
+class ActionModule(object):
+    """
+    TODO: FIXME when upgrading to Ansible 2.x
+    """
+
+    TRANSFERS_FILES = False
+
+    def __init__(self, runner):
+        self.runner = runner
+        self.basedir = runner.basedir
+
+    def _arg_or_fact(self, arg_name, fact_name, args, inject):
+        res = args.get(arg_name)
+        if res is not None:
+            return res
+
+        template_string = '{{ %s }}' % fact_name
+        res = template.template(self.basedir, template_string, inject)
+        return None if res == template_string else res
+
+    def _merge_args(self, module_args, complex_args):
+        args = {}
+        if complex_args:
+            args.update(complex_args)
+
+        kv = parse_kv(module_args)
+        args.update(kv)
+
+        return args
+
+    def run(self, conn, tmp, module_name, module_args, inject, complex_args=None, **kwargs):
+        args = self._merge_args(module_args, complex_args)
+
+        metrics_handler = self._arg_or_fact('handler', 'monitoring.metrics_handler', args, inject)
+
+        complex_args['handler'] = metrics_handler
+        module_return = self.runner._execute_module(conn, tmp, 'sensu_metrics_check', module_args, inject=inject,
+                                             complex_args=args)
+
+        return module_return

--- a/plugins/action/sensu_process_check.py
+++ b/plugins/action/sensu_process_check.py
@@ -1,0 +1,43 @@
+from ansible.utils import parse_kv, template
+
+
+class ActionModule(object):
+    """
+    TODO: FIXME when upgrading to Ansible 2.x
+    """
+
+    TRANSFERS_FILES = False
+
+    def __init__(self, runner):
+        self.runner = runner
+        self.basedir = runner.basedir
+
+    def _arg_or_fact(self, arg_name, fact_name, args, inject):
+        res = args.get(arg_name)
+        if res is not None:
+            return res
+
+        template_string = '{{ %s }}' % fact_name
+        res = template.template(self.basedir, template_string, inject)
+        return None if res == template_string else res
+
+    def _merge_args(self, module_args, complex_args):
+        args = {}
+        if complex_args:
+            args.update(complex_args)
+
+        kv = parse_kv(module_args)
+        args.update(kv)
+
+        return args
+
+    def run(self, conn, tmp, module_name, module_args, inject, complex_args=None, **kwargs):
+        args = self._merge_args(module_args, complex_args)
+
+        check_handler = self._arg_or_fact('handler', 'monitoring.check_handler', args, inject)
+
+        complex_args['handler'] = check_handler
+        module_return = self.runner._execute_module(conn, tmp, 'sensu_process_check', module_args, inject=inject,
+                                             complex_args=args)
+
+        return module_return

--- a/roles/monitoring-common/defaults/main.yml
+++ b/roles/monitoring-common/defaults/main.yml
@@ -12,3 +12,5 @@ monitoring:
     vhost: /sensu
     username: sensu
     password: sensu
+  check_handler: pagerduty
+  metrics_handler: graphite


### PR DESCRIPTION
Since we are moving to Flapjack.io as part of the
alerting pipeline, we should use a default and metrics
handlers instead of explicitly using pagerduty and graphite.

This allows us to easily control which handlers are actually
used as part of a set of handlers on the sensu-server.
Currently, default set is pagerduty and flapjack_http, and the
metrics handler is graphite.

This gives us flexibility rather than updating ursula proper with
our internal requirements and systems.