### PR TITLE
Updated vars plugin to support Ansible 2.0

### DIFF
--- a/plugins/vars/default_vars.py
+++ b/plugins/vars/default_vars.py
@@ -57,7 +57,10 @@ class VarsModule(object):
 
     def run(self, host, vault_password=None):
         default_vars = self._get_defaults()
-        group_vars = host.get_variables()
+        if hasattr(host, 'get_group_vars'):
+            group_vars = host.get_group_vars()
+        else:
+            group_vars = host.get_variables()
         if default_vars:
             return deep_update_dict(default_vars, group_vars)
         return group_vars


### PR DESCRIPTION
Ansible now provides the ability to gather group vars or host vars.  However, for backwards
compatibility they still provide both via `run`.  Given this plugin's use case, we want both.
This change is backwards compatible with Ansible 1.9 stable.