### PR TITLE
Make sure that neutron client version is < 4.0.0

### DIFF
--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -5,7 +5,7 @@ client:
     - python-keystoneclient
     - python-glanceclient>=1.1.0
     - python-novaclient<2.27.0
-    - python-neutronclient
+    - python-neutronclient<4.0.0
     - python-cinderclient
     - python-heatclient
     - python-ceilometerclient


### PR DESCRIPTION
The current version of neutron client crashes, so until it gets
fixed, we should use an earlier version.