### PR TITLE
Turn off mysql general logging

### DIFF
--- a/roles/percona-server/templates/etc/my.cnf
+++ b/roles/percona-server/templates/etc/my.cnf
@@ -1,6 +1,6 @@
 [mysqld]
 
-general-log = 1
+general-log = 0
 general-log-file = /var/log/mysql/mysql.log
 log-error = /var/log/mysql/mysql.err
 log-warnings = 10


### PR DESCRIPTION
mysql will log all queries when this option is turned on. This leads to
many gig log files. Turning this off keeps the logs from filling our fs.