### PR TITLE
Set higher allowed overflow for heat db

### DIFF
--- a/roles/heat/templates/etc/heat/heat.conf
+++ b/roles/heat/templates/etc/heat/heat.conf
@@ -55,6 +55,7 @@ num_engine_workers = {{ heat.engine_workers }}
 
 [database]
 connection=mysql://heat:{{ secrets.db_password }}@{{ endpoints.db }}/heat?charset=utf8
+max_overflow=1000
 
 [keystone_authtoken]
 identity_uri = {{ endpoints.identity_uri }}


### PR DESCRIPTION
This is related to https://bugs.launchpad.net/heat/+bug/1491185 in which
large heat templates can cause errors from Heat. As a temporary work
around until the upstream code handles this automatically, we're bumping
the allowed overflows up to 1000.