### PR TITLE
Fix percona-extrabackup.sh for better monitoring

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -108,7 +108,10 @@
 - name: include stack name in /etc/issue
   lineinfile: dest=/etc/issue regexp="^{{ stack_env }} OpenStack Node" line="{{ stack_env }} OpenStack Node"
 
-- include: monitoring.yml tags=monitoring,common
+- include: monitoring.yml
+  tags:
+    - monitoring
+    - common
   when: monitoring.enabled|default('True')|bool
 
 - include: audit-logging.yml

--- a/roles/common/tasks/monitoring.yml
+++ b/roles/common/tasks/monitoring.yml
@@ -214,3 +214,10 @@
 - name: raid check
   sensu_check: name=check-raid plugin=check-raid.sh interval=300 occurrences=1
   notify: restart sensu-client
+
+- name: percona xtradb backup
+  sensu_check:
+    name: check-percona-xtradb-backup
+    plugin: check-percona-xtrabackup.py
+    interval: 43200
+    occurrences: 1

--- a/roles/percona-backup/files/percona-xtrabackup.sh
+++ b/roles/percona-backup/files/percona-xtrabackup.sh
@@ -1,4 +1,3 @@
-{% raw %}
 #!/bin/bash
 #
 # File: percona-xtrabackup.sh
@@ -15,19 +14,25 @@
 #
 # Author: mpatterson@bluebox.net
 
-set -o errexit
 
-email=team-infrastructure@bluebox.net
 backup_script=/usr/bin/innobackupex
 gzip=/bin/gzip
 
 backup_retention_days=7
 
 backup_root_dir=/backup/percona/
+logfile=$backup_root_dir/percona-backup.last.log
 
 # create a new db archive, use tar stream to compress on the fly
-"$backup_script" --user=root --socket=/var/run/mysqld/mysqld.sock --stream=tar "$backup_root_dir" | "$gzip" - > "$backup_root_dir"`/bin/date +"%Y-%m-%d_%H-%M-%S"`.tar.gz || (/bin/echo "failed to create db archive at: `/bin/date`" | mail "$email" -s "Percona backup failed")
+"$backup_script" --user=root --socket=/var/run/mysqld/mysqld.sock --stream=tar "$backup_root_dir" | "$gzip" - > "$backup_root_dir"`/bin/date +"%Y-%m-%d_%H-%M-%S"`.tar.gz
+# Copy return value of backup
+retval=$?
+# Write last exit status and date to logfile
+echo "${retval} $(date +%s)" > $logfile
+# If the return value is non-zero, exit with last status
+if [ $retval -ne 0 ]; then
+  exit $retval
+fi
 
 echo Removing backups older than "$backup_retention_days" days
 find "$backup_root_dir" -maxdepth 1 -type f -mtime +"$backup_retention_days" -print -delete
-{% endraw %}

--- a/roles/percona-backup/tasks/main.yml
+++ b/roles/percona-backup/tasks/main.yml
@@ -1,9 +1,6 @@
 ---
-- name: mailutils package
-  apt: pkg=mailutils
-
 - name: create backup directory
   file: path=/backup/percona state=directory mode=0755
 
 - name: add percona-xtrabackup.sh to cron.daily
-  template: src=percona-xtrabackup.sh dest=/etc/cron.daily/percona-xtrabackup owner=root group=root mode=0755
+  copy: src=percona-xtrabackup.sh dest=/etc/cron.daily/percona-xtrabackup owner=root group=root mode=0755

--- a/roles/percona-backup/tasks/main.yml
+++ b/roles/percona-backup/tasks/main.yml
@@ -3,4 +3,4 @@
   file: path=/backup/percona state=directory mode=0755
 
 - name: add percona-xtrabackup.sh to cron.daily
-  copy: src=percona-xtrabackup.sh dest=/etc/cron.daily/percona-xtrabackup owner=root group=root mode=0755
+  template: src=percona-xtrabackup.sh dest=/etc/cron.daily/percona-xtrabackup owner=root group=root mode=0755

--- a/roles/percona-backup/templates/percona-xtrabackup.sh
+++ b/roles/percona-backup/templates/percona-xtrabackup.sh
@@ -1,3 +1,4 @@
+{% raw %}
 #!/bin/bash
 #
 # File: percona-xtrabackup.sh
@@ -36,3 +37,4 @@ fi
 
 echo Removing backups older than "$backup_retention_days" days
 find "$backup_root_dir" -maxdepth 1 -type f -mtime +"$backup_retention_days" -print -delete
+{% endraw %}


### PR DESCRIPTION
Removes unused "email team if it fails" fucntionality which didn't work with 'set -e' anyway;
Installs file using copy instead of template, which was all templated in a "raw" block;
Removes unneeded "mailutils" dependency