### PR TITLE
Generalize references to files in other roles

### DIFF
--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: add admin_token_auth to keystone pipeline
   template: dest=/etc/keystone/keystone-paste.ini
-            src=roles/keystone/templates/etc/keystone/keystone-paste.ini
+            src='{{ role_path }}/../keystone/templates/etc/keystone/keystone-paste.ini'
 
 - name: restart keystone api
   service: name=keystone state=restarted
@@ -93,7 +93,7 @@
 
 - name: remove admin_token_auth from keystone pipeline
   template: dest=/etc/keystone/keystone-paste.ini
-            src=roles/keystone/templates/etc/keystone/keystone-paste.ini
+            src='{{ role_path }}/../keystone/templates/etc/keystone/keystone-paste.ini'
 
 - name: restart keystone api
   service: name=keystone state=restarted


### PR DESCRIPTION
Errors occur while attempting to use ursula with a playbook
similiar to site.yml that does not exist in the root ursula
directory.  The errors are do to references to files in one
role that exist in another role. The file reference assumes
the roles directory is in the same directory as the playbook.

The change made uses the role_path variable to find files that
are referenced by other roles.