### PR TITLE
No IGMP with l2pop

### DIFF
--- a/roles/neutron-data-network/tasks/main.yml
+++ b/roles/neutron-data-network/tasks/main.yml
@@ -18,7 +18,7 @@
 - include: dnsmasq.yml
 
 - include: igmp-router.yml
-  when: neutron.plugin == 'ml2' and 'vxlan' in neutron.tunnel_types
+  when: neutron.plugin == 'ml2' and 'vxlan' in neutron.tunnel_types and not neutron.l2_population
 
 - name: assert kernel supports vxlan
   command: modinfo -F version vxlan


### PR DESCRIPTION
When we are using vxlan in unicast mode via l2pop, we do not need to run
an IGMP router using xorp.