### PR TITLE
Removed incorrect adding of firewall rule

### DIFF
--- a/roles/novnc/tasks/main.yml
+++ b/roles/novnc/tasks/main.yml
@@ -18,5 +18,3 @@
 
 - service: name=nova-novncproxy state=started
 
-- name: Permit access to NoVNC
-  ufw: rule=allow to_port={{ endpoints.nova.port.novnc_haproxy_api }} proto=tcp


### PR DESCRIPTION
 Removed incorrect adding of firewall rule (did not point to an existing variable). The rule was also a duplicate, and can be found in roles/nova-common/tasks/novnc.yml line 34.
https://github.com/blueboxgroup/ursula/blob/master/roles/nova-control/tasks/novnc.yml#L33