### PR TITLE
Upgrade deployments to pip 8.0.2

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -24,7 +24,7 @@ common:
       - ::/0
     disable_root: False
     disable_dns: True
-  pip_version: 7.1.2
+  pip_version: 8.0.2
   setuptools_version: system
   ursula_monitoring:
     path: /opt/ursula-monitoring

--- a/test/setup
+++ b/test/setup
@@ -6,7 +6,7 @@ if [[ "$CI" == "jenkins" ]]; then
     VENV=$WORKSPACE/venv
     virtualenv $VENV
     source $VENV/bin/activate
-    pip install -I pip==7.1.2
+    pip install -U pip
     pip install -U -r requirements.txt
 fi
 


### PR DESCRIPTION
Now that https://github.com/pypa/pip/issues/3384 has been resolved we
can use the latest version.