### PR TITLE
move percona check to correct role

### DIFF
--- a/roles/common/tasks/monitoring.yml
+++ b/roles/common/tasks/monitoring.yml
@@ -214,10 +214,3 @@
 - name: raid check
   sensu_check: name=check-raid plugin=check-raid.sh interval=300 occurrences=1
   notify: restart sensu-client
-
-- name: percona xtradb backup
-  sensu_check:
-    name: check-percona-xtradb-backup
-    plugin: check-percona-xtrabackup.py
-    interval: 43200
-    occurrences: 1

--- a/roles/percona-backup/tasks/main.yml
+++ b/roles/percona-backup/tasks/main.yml
@@ -4,3 +4,8 @@
 
 - name: add percona-xtrabackup.sh to cron.daily
   template: src=percona-xtrabackup.sh dest=/etc/cron.daily/percona-xtrabackup owner=root group=root mode=0755
+
+- include: monitoring.yml
+  tags:
+    - monitoring
+  when: monitoring.enabled|default('True')|bool

--- a/roles/percona-backup/tasks/monitoring.yml
+++ b/roles/percona-backup/tasks/monitoring.yml
@@ -1,0 +1,7 @@
+---
+- name: percona xtradb backup
+  sensu_check:
+    name: check-percona-xtradb-backup
+    plugin: check-percona-xtrabackup.py
+    interval: 43200
+    occurrences: 1


### PR DESCRIPTION
Being in the common role means that every node that doesn't have the percona-backup role will falsely alert on this.