### PR TITLE
Make rbd and rados locations overridable

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -7,7 +7,6 @@ ceph:
   #  - sdc
   #  - sdd
 
-  ceph_version: v0.94.5
   stable_release: hammer
 
   openstack_keys:
@@ -55,6 +54,8 @@ ceph:
   rbd_default_features: 3
   rbd_default_map_options: rw
   rbd_default_format: 2
+  rbd_url: https://raw.githubusercontent.com/ceph/ceph/v0.94.5/src/pybind/rbd.py
+  rados_url: https://raw.githubusercontent.com/ceph/ceph/v0.94.5/src/pybind/rados.py
 
   # Monitor options
   monitor_interface: bond0

--- a/roles/cinder-common/tasks/ceph_integration.yml
+++ b/roles/cinder-common/tasks/ceph_integration.yml
@@ -1,6 +1,6 @@
 ---
 - name: fetch rados.py
-  get_url: url=https://raw.githubusercontent.com/ceph/ceph/{{ ceph.ceph_version }}/src/pybind/rados.py
+  get_url: url={{ ceph.rados_url }}
            dest="{{ openstack_source.virtualenv_base }}/cinder/lib/python2.7/site-packages/rados.py"
            owner=root
            group=root
@@ -8,7 +8,7 @@
   when: openstack_install_method == 'source'
 
 - name: fetch rbd.py
-  get_url: url=https://raw.githubusercontent.com/ceph/ceph/{{ ceph.ceph_version }}/src/pybind/rbd.py
+  get_url: url={{ ceph.rbd_url }}
            dest="{{ openstack_source.virtualenv_base }}/cinder/lib/python2.7/site-packages/rbd.py"
            owner=root
            group=root
@@ -16,7 +16,7 @@
   when: openstack_install_method == 'source'
 
 - name: fetch rados.py
-  get_url: url=https://raw.githubusercontent.com/ceph/ceph/{{ ceph.ceph_version }}/src/pybind/rados.py
+  get_url: url={{ ceph.rados_url }}
            dest="{{ lookup('items', 'openstack_package.virtualenv_base') }}/cinder/lib/python2.7/site-packages/rados.py"
            owner=root
            group=root
@@ -24,7 +24,7 @@
   when: openstack_install_method == 'package'
 
 - name: fetch rbd.py
-  get_url: url=https://raw.githubusercontent.com/ceph/ceph/{{ ceph.ceph_version }}/src/pybind/rbd.py
+  get_url: url= {{ ceph.rbd_url }}
            dest="{{ lookup('items', 'openstack_package.virtualenv_base') }}/cinder/lib/python2.7/site-packages/rbd.py"
            owner=root
            group=root

--- a/roles/glance/tasks/ceph_integration.yml
+++ b/roles/glance/tasks/ceph_integration.yml
@@ -1,6 +1,6 @@
 ---
 - name: fetch rados.py
-  get_url: url=https://raw.githubusercontent.com/ceph/ceph/{{ ceph.ceph_version }}/src/pybind/rados.py
+  get_url: url={{ ceph.rados_url }}
            dest="{{ openstack_source.virtualenv_base }}/glance/lib/python2.7/site-packages/rados.py"
            owner=root
            group=root
@@ -8,7 +8,7 @@
   when: openstack_install_method == 'source'
 
 - name: fetch rbd.py
-  get_url: url=https://raw.githubusercontent.com/ceph/ceph/{{ ceph.ceph_version }}/src/pybind/rbd.py
+  get_url: url={{ ceph.rbd_url }}
            dest="{{ openstack_source.virtualenv_base }}/glance/lib/python2.7/site-packages/rbd.py"
            owner=root
            group=root
@@ -16,7 +16,7 @@
   when: openstack_install_method == 'source'
 
 - name: fetch rados.py
-  get_url: url=https://raw.githubusercontent.com/ceph/ceph/{{ ceph.ceph_version }}/src/pybind/rados.py
+  get_url: url={{ ceph.rados_url }}
            dest="{{ lookup('items', 'openstack_package.virtualenv_base') }}/glance/lib/python2.7/site-packages/rados.py"
            owner=root
            group=root
@@ -24,7 +24,7 @@
   when: openstack_install_method == 'package'
 
 - name: fetch rbd.py
-  get_url: url=https://raw.githubusercontent.com/ceph/ceph/{{ ceph.ceph_version }}/src/pybind/rbd.py
+  get_url: url={{ ceph.rbd_url }}
            dest="{{ lookup('items', 'openstack_package.virtualenv_base') }}/glance/lib/python2.7/site-packages/rbd.py"
            owner=root
            group=root


### PR DESCRIPTION
Squash the rbd and rados fetch blocks and extract the download urls so
that they can be overridden in openstack-envs based on the environment
being deployed.