### PR TITLE
Pin ursula-monitoring to the 2.0.0 tag

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -559,7 +559,7 @@ common:
   ursula_monitoring:
     method: tar # git|tar
     tar_url: https://file-mirror.openstack.blueboxgrid.com/ursula-monitoring/master.tar.gz
-    tar_version: master
+    tar_version: 2.0.0
   ntpd:
     servers: []
     #  - servertime.service.softlayer.com

--- a/envs/example/mirrors/group_vars/all.yml
+++ b/envs/example/mirrors/group_vars/all.yml
@@ -73,8 +73,8 @@ common:
   ursula_monitoring:
     path: /opt/ursula-monitoring
     method: tar # git|tar
-    tar_url: https://file-mirror.openstack.blueboxgrid.com/ursula-monitoring/RELEASE-1.3.x.tar.gz
-    tar_version: RELEASE-1.3.x
+    tar_url: https://file-mirror.openstack.blueboxgrid.com/ursula-monitoring/2.0.0.tar.gz
+    tar_version: 2.0.0
 
 #env_vars:
 #  http_proxy: http://172.16.1.115:3128

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -27,9 +27,9 @@ common:
     path: /opt/ursula-monitoring
     method: git # git|tar
     git_repo: https://github.com/blueboxgroup/ursula-monitoring.git
-    git_rev: master
-    tar_url: https://github.com/blueboxgroup/ursula-monitoring/archive/master.tar.gz
-    tar_version: master
+    git_rev: 2.0.0
+    tar_url: https://github.com/blueboxgroup/ursula-monitoring/archive/2.0.0.tar.gz
+    tar_version: 2.0.0
   system_tools:
     mcelog: True
   packages_to_remove:


### PR DESCRIPTION
Very little should be changing in ursula-monitoring for the 2.0.x point
releases, just point to the tag.