### PR TITLE
Increased thresholds for rabbitmq-numqueues check

### DIFF
--- a/roles/rabbitmq/defaults/main.yml
+++ b/roles/rabbitmq/defaults/main.yml
@@ -8,3 +8,5 @@ rabbitmq:
   port: 5672
   management_port: 15672
   admin_cli_url: 'http://localhost:15672/cli/rabbitmqadmin'
+  numqueues_warning_multiplier: 60
+  numqueues_critical_multiplier: 120

--- a/roles/rabbitmq/tasks/monitoring.yml
+++ b/roles/rabbitmq/tasks/monitoring.yml
@@ -20,8 +20,8 @@
 
 - name: rabbit queue num check
   sensu_check: name=rabbitmq-numqueues plugin=check-rabbitmq-queues.rb
-               args="-t number -w {{ cluster_node_count|int * 50 }}
-                     -c {{ cluster_node_count|int * 100 }}
+               args="-t number -w {{ cluster_node_count|int * rabbitmq.numqueues_warning_multiplier|int }}
+                     -c {{ cluster_node_count|int * rabbitmq.numqueues_critical_multiplier|int }}
                      --timeout 2"
                use_sudo=true
   notify: restart sensu-client


### PR DESCRIPTION
Increased thresholds for rabbitmq-numqueues check to cluster_node_count\*60 for warning and cluster_node_count\*120 for critical