### PR TITLE
Fix percona backup template to avoid new line before shebang

### DIFF
--- a/roles/percona-backup/templates/percona-xtrabackup.sh
+++ b/roles/percona-backup/templates/percona-xtrabackup.sh
@@ -1,4 +1,4 @@
-{% raw %}
+{% raw -%}
 #!/bin/bash
 #
 # File: percona-xtrabackup.sh


### PR DESCRIPTION
Fix the template to avoid a new line before shebang. The run-parts command is failing to execute this for this.