### PR TITLE
A way to install additional CA certificates

### DIFF
--- a/roles/common/tasks/ssl.yml
+++ b/roles/common/tasks/ssl.yml
@@ -7,6 +7,14 @@
             dest=/usr/local/share/ca-certificates/{{ endpoints.main }}.crt
   notify: refresh CAs
 
+- name: Install any additional CA certificates
+  copy:
+    content: "{{ item.content | default(omit) }}"
+    dest: "/usr/local/share/ca-certificates/{{ item.name }}.crt"
+    src: "{{ item.src | default(omit) }}"
+  with_items: "{{ ssl.extracacerts | default([]) }}"
+  notify: refresh CAs
+
 - name: ssl directory
   file: dest=/opt/stack/ssl state=directory
 


### PR DESCRIPTION
This provides a way to add additional CA certificates to the system
store from an environment file. This can be useful for custom mirrors or
using a non-default CA certificate as an endpoint.