### PR TITLE
Make update-pip play to work by default

### DIFF
--- a/roles/common/tasks/python.yml
+++ b/roles/common/tasks/python.yml
@@ -2,12 +2,12 @@
 - name: update pip
   pip: name=pip version={{ common.pip_version }}
        extra_args='-i {{ openstack.pypi_mirror }}/+simple'
-  when: ansible_distribution_version == "12.04" and openstack.pypi_mirror is defined
+  when: openstack.pypi_mirror is defined
 
 - name: update pip
   pip: name=pip version={{ common.pip_version }}
-       extra_args='-i {{ openstack.pypi_mirror }}/+simple'
-  when: ansible_distribution_version != "12.04"
+       extra_args='-i https://pypi.python.org/simple/'
+  when: openstack.pypi_mirror is undefined
 
 - name: root user pip config directory
   file: dest=/root/.pip state=directory


### PR DESCRIPTION
Right now if openstack.pypi_mirror is not defined then we end up with an
undefined variable error. The proper way to fix this would be to define
a default for this, but the play expects to be pointed at a devpi mirror
(see the appended +simple rather than /simple). This means that
pypi.python.org cannot be used by setting this variable.

Additionally, we are checking a boolean (ansible version) but we
perform the same operation for both cases. Lets not do that.
