### PR TITLE
Add missing environment exports

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -98,6 +98,7 @@
     - role: mongodb-server
       tags: ['mongodb', 'mongodb-server']
       when: ceilometer.enabled|bool
+  environment: "{{ env_vars|default({}) }}"
 
 - name: install mongodb arbiter
   gather_facts: force
@@ -106,6 +107,7 @@
     - role: mongodb-arbiter
       tags: ['mongodb', 'mongodb-arbiter']
       when: ceilometer.enabled|bool
+  environment: "{{ env_vars|default({}) }}"
 
 - name: memcached for keystone and horizon
   gather_facts: force
@@ -137,6 +139,7 @@
   roles:
     - role: ceph-monitor
       tags: ['ceph', 'ceph-monitor']
+  environment: "{{ env_vars|default({}) }}"
 
 - name: ceph osds
   gather_facts: force
@@ -144,6 +147,7 @@
   roles:
     - role: ceph-osd
       tags: ['ceph', 'ceph-osd']
+  environment: "{{ env_vars|default({}) }}"
 
 # OPENSTACK SERVICES
 - name: openstack client tools
@@ -220,6 +224,7 @@
     - role: ceph-compute
       tags: ['ceph', 'ceph-compute']
       when: ceph.enabled|bool and ansible_architecture != "ppc64le"
+  environment: "{{ env_vars|default({}) }}"
 
 - name: neutron control plane
   gather_facts: force
@@ -292,6 +297,7 @@
     - role: ceilometer-control
       tags: ['openstack', 'ceilometer', 'control']
       when: ceilometer.enabled|bool
+  environment: "{{ env_vars|default({}) }}"
 
 - name: ceilometer data plane
   gather_facts: force
@@ -300,6 +306,7 @@
     - role: ceilometer-data
       tags: ['openstack', 'ceilometer', 'data']
       when: ceilometer.enabled|bool
+  environment: "{{ env_vars|default({}) }}"
 
 - name: magnum code and config
   gather_facts: force


### PR DESCRIPTION
A number of tasks were failing to download things because the
required proxy settings needed in production deployments were not
being exported to the environment.