### PR TITLE
Switch to "round-robin" mode for nova and keystone in haproxy

### DIFF
--- a/roles/endpoints/defaults/main.yml
+++ b/roles/endpoints/defaults/main.yml
@@ -21,6 +21,10 @@ endpoints:
     port:
       backend_api: 9774
       haproxy_api: 8774
+    haproxy:
+      health_check: 'httpchk /'
+      balance: 'roundrobin'
+      prefer_primary_backend: False
   glance:
     name: glance
     type: image
@@ -32,6 +36,10 @@ endpoints:
     port:
       backend_api: 9393
       haproxy_api: 9292
+    haproxy:
+      health_check: 'httpchk GET /versions'
+      balance: 'source'
+      prefer_primary_backend: True
   cinder:
     name: cinder
     type: volume
@@ -45,6 +53,10 @@ endpoints:
     port:
       backend_api: 8778
       haproxy_api: 8776
+    haproxy:
+      health_check: 'httpchk /'
+      balance: 'source'
+      prefer_primary_backend: False
   cinderv2:
     name: cinderv2
     type: volume
@@ -67,14 +79,26 @@ endpoints:
     port:
       backend_api: 5002
       haproxy_api: 5000
+    haproxy:
+      health_check: 'httpchk /'
+      balance: 'roundrobin'
+      prefer_primary_backend: False
   keystone_admin:
     port:
       backend_api: 35358
       haproxy_api: 35357
+    haproxy:
+      health_check: 'httpchk /'
+      balance: 'roundrobin'
+      prefer_primary_backend: False
   keystone_legacy:
     port:
       backend_api: 5002
       haproxy_api: 5001
+    haproxy:
+      health_check: 'httpchk /'
+      balance: 'roundrobin'
+      prefer_primary_backend: False
   keystonev3:
     name: keystonev3
     type: identity
@@ -87,6 +111,10 @@ endpoints:
     port:
       backend_api: 5002
       haproxy_api: 5000
+    haproxy:
+      health_check: 'httpchk /'
+      balance: 'roundrobin'
+      prefer_primary_backend: False
   novnc:
     url:
       admin: https://{{ fqdn }}:6080
@@ -95,6 +123,10 @@ endpoints:
     port:
       backend_api: 6081
       haproxy_api: 6080
+    haproxy:
+      health_check: 'tcp-check /'
+      balance: 'source'
+      prefer_primary_backend: True
   neutron:
     name: neutron
     type: network
@@ -106,6 +138,10 @@ endpoints:
     port:
       backend_api: 9797
       haproxy_api: 9696
+    haproxy:
+      health_check: 'httpchk /'
+      balance: 'source'
+      prefer_primary_backend: False
   heat:
     name: heat
     type: orchestration
@@ -119,6 +155,10 @@ endpoints:
     port:
       backend_api: 8005
       haproxy_api: 8004
+    haproxy:
+      health_check: 'httpchk /'
+      balance: 'source'
+      prefer_primary_backend: False
   heat_cfn:
     name: heat-cfn
     type: cloudformation
@@ -131,6 +171,10 @@ endpoints:
     port:
       backend_api: 8001
       haproxy_api: 8000
+    haproxy:
+      health_check: 'httpchk /'
+      balance: 'source'
+      prefer_primary_backend: False
   ceilometer:
     name: ceilometer
     type: metering
@@ -142,6 +186,10 @@ endpoints:
     port:
       backend_api: 9777
       haproxy_api: 8777
+    haproxy:
+      health_check: 'tcp-check /'
+      balance: 'source'
+      prefer_primary_backend: False
   ironic:
     name: ironic
     type: baremetal
@@ -153,6 +201,10 @@ endpoints:
     port:
       backend_api: 6384
       haproxy_api: 6385
+    haproxy:
+      health_check: 'httpchk GET /v1'
+      balance: 'source'
+      prefer_primary_backend: False
   swift:
     name: swift
     type: object-storage
@@ -168,3 +220,7 @@ endpoints:
       haproxy_api: 8090
       cinder_backup: 8091
       proxy_api: 8080
+    haproxy:
+      health_check: 'httpchk HEAD /healthcheck HTTP/1.0'
+      balance: 'source'
+      prefer_primary_backend: False

--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -1,28 +1,109 @@
-# Legend: name, clear_port, enc_port, prefer_primary_backend
+# Legend: name, clear_port, enc_port, prefer_primary_backend, health_check, balance
 {% set haproxy_services = [
-    [ 'horizon', 8080, 443, false ],
-    [ 'keystone', endpoints.keystone.port.backend_api , endpoints.keystone.port.haproxy_api , false ],
-    [ 'keystone-admin', endpoints.keystone_admin.port.backend_api, endpoints.keystone_admin.port.haproxy_api, false ],
-    [ 'keystone_legacy', endpoints.keystone_legacy.port.backend_api , endpoints.keystone_legacy.port.haproxy_api , false ],
-    [ 'nova', endpoints.nova.port.backend_api, endpoints.nova.port.haproxy_api, false ],
-    [ 'novnc', endpoints.novnc.port.backend_api, endpoints.novnc.port.haproxy_api, true ],
-    [ 'glance', endpoints.glance.port.backend_api, endpoints.glance.port.haproxy_api, true ],
-    [ 'neutron', endpoints.neutron.port.backend_api, endpoints.neutron.port.haproxy_api, false ],
-    [ 'cinder', endpoints.cinder.port.backend_api, endpoints.cinder.port.haproxy_api, false ],
+    [ 'horizon', 8080, 443, false, 'httpchk /', 'source' ],
+    [
+      'keystone',
+      endpoints.keystone.port.backend_api,
+      endpoints.keystone.port.haproxy_api,
+      endpoints.keystone.haproxy.prefer_primary_backend,
+      endpoints.keystone.haproxy.health_check,
+      endpoints.keystone.haproxy.balance
+    ],
+    [
+      'keystone-admin',
+      endpoints.keystone_admin.port.backend_api,
+      endpoints.keystone_admin.port.haproxy_api,
+      endpoints.keystone_admin.haproxy.prefer_primary_backend,
+      endpoints.keystone_admin.haproxy.health_check,
+      endpoints.keystone_admin.haproxy.balance
+    ],
+    [
+      'keystone_legacy',
+      endpoints.keystone_legacy.port.backend_api,
+      endpoints.keystone_legacy.port.haproxy_api,
+      endpoints.keystone_legacy.haproxy.prefer_primary_backend,
+      endpoints.keystone_legacy.haproxy.health_check,
+      endpoints.keystone_legacy.haproxy.balance
+    ],
+    [
+      'nova',
+      endpoints.nova.port.backend_api,
+      endpoints.nova.port.haproxy_api,
+      endpoints.nova.haproxy.prefer_primary_backend,
+      endpoints.nova.haproxy.health_check,
+      endpoints.nova.haproxy.balance
+    ],
+    [
+      'novnc',
+      endpoints.novnc.port.backend_api,
+      endpoints.novnc.port.haproxy_api,
+      endpoints.novnc.haproxy.prefer_primary_backend,
+      endpoints.novnc.haproxy.health_check,
+      endpoints.novnc.haproxy.balance
+    ],
+    [
+      'glance',
+      endpoints.glance.port.backend_api,
+      endpoints.glance.port.haproxy_api,
+      endpoints.glance.haproxy.prefer_primary_backend,
+      endpoints.glance.haproxy.health_check,
+      endpoints.glance.haproxy.balance
+    ],
+    [
+      'neutron',
+      endpoints.neutron.port.backend_api,
+      endpoints.neutron.port.haproxy_api,
+      endpoints.neutron.haproxy.prefer_primary_backend,
+      endpoints.neutron.haproxy.health_check,
+      endpoints.neutron.haproxy.balance
+    ],
+    [
+      'cinder',
+      endpoints.cinder.port.backend_api,
+      endpoints.cinder.port.haproxy_api,
+      endpoints.cinder.haproxy.prefer_primary_backend,
+      endpoints.cinder.haproxy.health_check,
+      endpoints.cinder.haproxy.balance
+    ]
   ]
 -%}
 {% if ceilometer.enabled|default('False')|bool -%}
-    {% set _ = haproxy_services.append(['ceilometer', endpoints.ceilometer.port.backend_api, endpoints.ceilometer.port.haproxy_api, false]) %}
+    {% set _ = haproxy_services.append(['ceilometer',
+                                        endpoints.ceilometer.port.backend_api,
+                                        endpoints.ceilometer.port.haproxy_api,
+                                        endpoints.ceilometer.haproxy.prefer_primary_backend,
+                                        endpoints.ceilometer.haproxy.health_check,
+                                        endpoints.ceilometer.haproxy.balance ]) %}
 {% endif -%}
 {% if magnum.enabled|default('False')|bool -%}
-    {% set _ = haproxy_services.append(['magnum', 9512, 9511, false]) %}
+    {% set _ = haproxy_services.append(['magnum',
+                                        9512,
+                                        9511,
+                                        false,
+                                        'httpchk /',
+                                        'source']) %}
 {% endif -%}
 {% if heat.enabled -%}
-    {% set _ = haproxy_services.append(['heat', endpoints.heat.port.backend_api, endpoints.heat.port.haproxy_api, false]) %}
-    {% set _ = haproxy_services.append(['heat-cfn', endpoints.heat_cfn.port.backend_api, endpoints.heat_cfn.port.haproxy_api, false]) %}
+    {% set _ = haproxy_services.append(['heat',
+                                        endpoints.heat.port.backend_api,
+                                        endpoints.heat.port.haproxy_api,
+                                        endpoints.heat.haproxy.prefer_primary_backend,
+                                        endpoints.heat.haproxy.health_check,
+                                        endpoints.heat.haproxy.balance ]) %}
+    {% set _ = haproxy_services.append(['heat-cfn',
+                                        endpoints.heat_cfn.port.backend_api,
+                                        endpoints.heat_cfn.port.haproxy_api,
+                                        endpoints.heat_cfn.haproxy.prefer_primary_backend,
+                                        endpoints.heat_cfn.haproxy.health_check,
+                                        endpoints.heat_cfn.haproxy.balance ]) %}
 {% endif -%}
 {% if ironic.enabled -%}
-    {% set _ = haproxy_services.append(['ironic', endpoints.ironic.port.backend_api, endpoints.ironic.port.haproxy_api, false]) %}
+    {% set _ = haproxy_services.append(['ironic',
+                                        endpoints.ironic.port.backend_api,
+                                        endpoints.ironic.port.haproxy_api,
+                                        endpoints.ironic.haproxy.prefer_primary_backend,
+                                        endpoints.ironic.haproxy.health_check,
+                                        endpoints.ironic.haproxy.balance ]) %}
 {% endif -%}
 
 global
@@ -54,7 +135,7 @@ defaults
   stats uri /haproxy_stats
   stats auth admin:{{ secrets.admin_password }}
 
-{% for name, clear_port, enc_port, prefer_primary_backend in haproxy_services -%}
+{% for name, clear_port, enc_port, prefer_primary_backend, health_check, balance in haproxy_services -%}
 frontend {{ name }}
   # Require TLS with AES
   bind :::{{ enc_port }} ssl crt /etc/haproxy/openstack.pem no-sslv3 ciphers AES128-SHA:AES256-SHA
@@ -68,20 +149,12 @@ frontend {{ name }}
 
 backend {{ name }}
 
-  {% if name == "novnc" -%}
-  option tcp-check /
-  {% elif name == "ironic" -%}
-  option httpchk GET /v1
-  {% elif name == "ceilometer" -%}
-  option tcp-check /
-  {% elif name == "magnum" -%}
-  # option httpchk /
-  {% elif name == "glance" -%}
-  option httpchk GET /versions
+  {% if name == "magnum" -%}
+  # option {{ health_check }}
   {% else -%}
-  option httpchk /
+  option {{ health_check }}
   {% endif -%}
-  balance source
+  balance {{ balance }}
   {% for host in groups['controller'] -%}
 
   {% if not prefer_primary_backend or hostvars[host][primary_interface]['ipv4']['address'] == primary_ip -%}

--- a/roles/haproxy/templates/etc/haproxy/haproxy_swift.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_swift.cfg
@@ -34,11 +34,10 @@ frontend cinder-backup-swift
 
 backend swift
   mode    http
-  balance source
-  option  httpchk HEAD /healthcheck HTTP/1.0
+  balance {{ endpoints.swift.haproxy.balance }}
+  option  {{ endpoints.swift.haproxy.health_check }}
   option  forwardfor
   option  httpclose
   {% for host in groups['swiftnode'] -%}
   server proxy{{ loop.index }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ endpoints.swift.port.proxy_api }} weight 5 check inter 2000
   {% endfor -%}
-


### PR DESCRIPTION
Allowing round-robin mode for nova and keystone in haproxy to support higher number of concurrent VM deployments. 