### PR TITLE
Add a ufw tag to all ufw commands

### DIFF
--- a/roles/ceilometer-control/tasks/main.yml
+++ b/roles/ceilometer-control/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: permit access to ceilometer
   ufw: rule=allow to_port={{ endpoints.ceilometer.port.haproxy_api }} proto=tcp
+  tags: ufw
 
 - name: install ceilometer controller services
   upstart_service: name={{ item }}

--- a/roles/cinder-control/tasks/main.yml
+++ b/roles/cinder-control/tasks/main.yml
@@ -35,6 +35,7 @@
 
 - name: Permit access to Cinder
   ufw: rule=allow to_port={{ endpoints.cinder.port.haproxy_api }} proto=tcp
+  tags: ufw
 
 - include: monitoring.yml tags=monitoring,common
   when: monitoring.enabled|default('True')|bool

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -62,6 +62,7 @@
 - include: system-file-permissions.yml
 
 - include: ufw.yml
+  tags: ufw
 
 - include: ntp.yml
   tags: ntp

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -45,6 +45,7 @@
 
 - name: permit access to glance
   ufw: rule=allow to_port={{ item }} proto=tcp
+  tags: ufw
   with_items:
     - "{{ endpoints.glance.port.haproxy_api }}"
     - "{{ endpoints.glance.port.backend_api }}"

--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -15,6 +15,7 @@
 
 - name: permit access to heat
   ufw: rule=allow to_port={{ item }} proto=tcp
+  tags: ufw
   with_items:
     - "{{ endpoints.heat.port.haproxy_api }}"
     - "{{ endpoints.heat_cfn.port.haproxy_api }}"

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -121,6 +121,7 @@
 
 - name: Permit HTTP and HTTPS
   ufw: rule=allow to_port={{ item }} proto=tcp
+  tags: ufw
   with_items:
   - 80
   - 443

--- a/roles/ironic-control/tasks/main.yml
+++ b/roles/ironic-control/tasks/main.yml
@@ -65,13 +65,16 @@
 - name: permit access to ironic
   ufw: rule=allow port={{ ironic.api_url.port }} proto=tcp
        to_ip={{ ironic.api_url.host }}
+  tags: ufw
 
 - name: permit access to tftpd
   ufw: rule=allow port=69 proto=udp
        to_ip={{ ironic.tftp_server }}
+  tags: ufw
 
 - name: permit access to dns
   ufw: rule=allow port=53
        to_ip={{ ironic.dns_server }}
+  tags: ufw
 
 - meta: flush_handlers

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -64,6 +64,7 @@
 
 - name: permit access to keystone
   ufw: rule=allow to_port={{ item }} proto=tcp
+  tags: ufw
   with_items:
     - "{{ endpoints.keystone.port.haproxy_api }}"
     - "{{ endpoints.keystone_admin.port.haproxy_api }}"

--- a/roles/magnum/tasks/main.yml
+++ b/roles/magnum/tasks/main.yml
@@ -48,6 +48,7 @@
 
 - name: permit access to magnum
   ufw: rule=allow to_port={{ item }} proto=tcp
+  tags: ufw
   with_items:
     - 9511
 

--- a/roles/neutron-control/tasks/main.yml
+++ b/roles/neutron-control/tasks/main.yml
@@ -46,6 +46,7 @@
 
 - name: Permit access to Neutron
   ufw: rule=allow to_port={{ endpoints.neutron.port.haproxy_api }} proto=tcp
+  tags: ufw
 
 - include: monitoring.yml tags=monitoring,common
   when: monitoring.enabled|default('True')|bool

--- a/roles/neutron-data/tasks/main.yml
+++ b/roles/neutron-data/tasks/main.yml
@@ -10,6 +10,7 @@
 
 - name: permit VXLAN traffic
   ufw: rule=allow to_port=4789 proto=udp
+  tags: ufw
   when: neutron.plugin == 'ml2' and 'vxlan' in neutron.tunnel_types
 
 - name: ml2 dataplane config

--- a/roles/nova-control/tasks/main.yml
+++ b/roles/nova-control/tasks/main.yml
@@ -49,6 +49,7 @@
 
 - name: permit access to nova api
   ufw: rule=allow to_port={{ endpoints.nova.port.haproxy_api }} proto=tcp
+  tags: ufw
 
 - include: novnc.yml tags=novnc
 

--- a/roles/nova-control/tasks/novnc.yml
+++ b/roles/nova-control/tasks/novnc.yml
@@ -32,3 +32,4 @@
 
 - name: Permit access to NoVNC
   ufw: rule=allow to_port={{ endpoints.novnc.port.haproxy_api }} proto=tcp
+  tags: ufw

--- a/roles/swift-proxy/tasks/main.yml
+++ b/roles/swift-proxy/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: permit swift proxy from anywhere
   ufw: rule=allow to_port=8090 proto=tcp
+  tags: ufw
 
 - name: swift-proxy service script
   template: src=roles/swift-common/templates/etc/init/swift-service.conf


### PR DESCRIPTION
Tag all ufw operations so they can be ran independently. This was needed only because i made a mistake but it may still be useful to others. 