### PR TITLE
Always bootstrap rings for scaling support

### DIFF
--- a/roles/swift-ring/handlers/main.yml
+++ b/roles/swift-ring/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: setup swift rings
+  command: sudo -u swiftops /usr/local/bin/swifttool -i /home/swiftops/.ssh/id_rsa
+           bootstrap --config /etc/swift/ring_definition.yml --outdir /etc/swift
+

--- a/roles/swift-ring/tasks/main.yml
+++ b/roles/swift-ring/tasks/main.yml
@@ -1,15 +1,6 @@
 ---
-- name: register whether we need to boostrap rings
-  shell: /usr/bin/test -f /etc/swift/account.ring.gz || /usr/bin/test -f /etc/swift/container.ring.gz || /usr/bin/test -f /etc/swift/object.ring.gz
-  failed_when: False
-  register: should_boostrap
-
 - name: drop our ring configuration
   copy: src={{ swift_ring.ring_definition_file }} owner=root group=root
         dest=/etc/swift/ring_definition.yml mode=644 backup=yes
-  when: not should_boostrap|success
+  notify: setup swift rings
 
-- name: setup swift rings
-  command: sudo -u swiftops /usr/local/bin/swifttool -i /home/swiftops/.ssh/id_rsa
-           bootstrap --config /etc/swift/ring_definition.yml --outdir /etc/swift
-  when: not should_boostrap|success


### PR DESCRIPTION
Once https://github.com/blueboxgroup/swifttool/pull/8 is merged, swifttool would support modifying existing rings by adding/removing devices in current ring.

When the weights don't change, it will set weights to previous weights. However, this operation will not cause any data to reassign.
