### PR TITLE
pre-deploy: remove unnecessary kernel upgrade

### DIFF
--- a/playbooks/ci-allinone/tasks/pre-deploy.yml
+++ b/playbooks/ci-allinone/tasks/pre-deploy.yml
@@ -50,28 +50,3 @@
   handlers:
   - name: bounce eth0
     shell: ifdown eth0; ifup eth0
-
-- name: compute and network tasks
-  hosts: network:compute
-  serial: 10
-  tasks:
-  - name: Upgrade kernel to support VXLAN
-    apt: pkg={{ item }}
-    with_items:
-      - linux-generic-lts-trusty
-      - linux-tools-lts-trusty
-    when: neutron.plugin == 'ml2'
-    notify: restart machine
-
-  - meta: flush_handlers
-
-  - name: waiting for server to come back
-    local_action: wait_for host={{ inventory_hostname }} port=22 state=started
-    sudo: false
-
-  handlers:
-  - name: restart machine
-    command: shutdown -r now
-    async: 0
-    poll: 0
-    failed_when: False

--- a/playbooks/ci-full/tasks/pre-deploy.yml
+++ b/playbooks/ci-full/tasks/pre-deploy.yml
@@ -80,28 +80,3 @@
   handlers:
   - name: bounce eth0
     shell: ifdown eth0; ifup eth0
-
-- name: compute and network tasks
-  hosts: network:compute
-  serial: 10
-  tasks:
-  - name: Upgrade kernel to support VXLAN
-    apt: pkg={{ item }}
-    with_items:
-      - linux-generic-lts-trusty
-      - linux-tools-lts-trusty
-    when: neutron.plugin == 'ml2'
-    notify: restart machine
-
-  - meta: flush_handlers
-
-  - name: waiting for server to come back
-    local_action: wait_for host={{ inventory_hostname }} port=22 state=started
-    sudo: false
-
-  handlers:
-  - name: restart machine
-    command: shutdown -r now
-    async: 0
-    poll: 0
-    failed_when: False


### PR DESCRIPTION
No need to upgrade the kernel to the backport of the Trusty kernel if we are
already deploying on Trusty.