### PR TITLE
Reference the hosts primary_interface

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -27,7 +27,7 @@ secrets:
 fqdn: openstack.example.com
 swift_fqdn: "{{ fqdn }}"
 floating_ip: "{{ controller_primary }}"
-undercloud_floating_ip: "{{ hostvars[groups['controller'][0]][primary_interface]['ipv4']['address'] }}"
+undercloud_floating_ip: "{{ hostvars[groups['controller'][0]][hostvars[groups['controller'][0]]['primary_interface']['ipv4']['address'] }}"
 
 etc_hosts:
   - name: "{{ fqdn }}"

--- a/roles/aodh/templates/etc/aodh/aodh.conf
+++ b/roles/aodh/templates/etc/aodh/aodh.conf
@@ -11,9 +11,9 @@ rest_notifier_ssl_verify = False
 {% macro rabbitmq_hosts() -%}
 {% for host in groups['controller'] -%}
    {% if loop.last -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }}
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ rabbitmq.port }}
    {%- else -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }},
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ rabbitmq.port }},
    {%- endif -%}
 {% endfor -%}
 {% endmacro -%}
@@ -32,7 +32,7 @@ port = {{ endpoints.aodh.port.backend_api }}
 
 [database]
 connection = mysql+pymysql://aodh:{{ secrets.db_password }}@{{ endpoints.db }}/aodh
-alarm_history_time_to_live = {{ aodh.alarm_history_time_to_live }} 
+alarm_history_time_to_live = {{ aodh.alarm_history_time_to_live }}
 
 [keystone_authtoken]
 signing_dir = /var/cache/aodh/api

--- a/roles/ceilometer-common/templates/etc/ceilometer/ceilometer.conf
+++ b/roles/ceilometer-common/templates/etc/ceilometer/ceilometer.conf
@@ -14,9 +14,9 @@ rpc_backend = rabbit
 {% macro rabbitmq_hosts() -%}
 {% for host in groups['controller'] -%}
    {% if loop.last -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }}
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ rabbitmq.port }}
    {%- else -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }},
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ rabbitmq.port }},
    {%- endif -%}
 {% endfor -%}
 {% endmacro -%}
@@ -38,9 +38,9 @@ enable_proxy_headers_parsing = True
 {% macro ceilometer_hosts() -%}
 {% for host in groups['controller'] -%}
    {% if loop.last -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ mongodb.port }}
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ mongodb.port }}
    {%- else -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ mongodb.port }},
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ mongodb.port }},
    {%- endif -%}
 {% endfor -%}
 {% endmacro -%}

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -106,9 +106,9 @@ lock_path = {{ cinder.state_path }}/lock
 {% macro rabbitmq_hosts() -%}
 {% for host in groups['controller'] -%}
    {% if loop.last -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }}
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ rabbitmq.port }}
    {%- else -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }},
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ rabbitmq.port }},
    {%- endif -%}
 {% endfor -%}
 {% endmacro -%}

--- a/roles/glance/templates/etc/cron.d/glance-image-sync
+++ b/roles/glance/templates/etc/cron.d/glance-image-sync
@@ -6,7 +6,7 @@ PATH=/bin:/usr/bin
 {% for host in groups['controller'] %}
 {% if host != inventory_hostname %}
 # Synchronize images from {{ host }}
-* * * * * glance  flock --nonblock /tmp/glance-image-sync.lock -c "nice ionice -c3 rsync --archive --update --xattrs --bwlimit=50000 rsync://{{ hostvars[host][primary_interface]['ipv4']['address'] }}/glance/????????-????-????-????-???????????? {{ glance.sync.dir }}/"
+* * * * * glance  flock --nonblock /tmp/glance-image-sync.lock -c "nice ionice -c3 rsync --archive --update --xattrs --bwlimit=50000 rsync://{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}/glance/????????-????-????-????-???????????? {{ glance.sync.dir }}/"
 {% endif %}
 {% endfor %}
 # Remove all deleted glance images

--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -169,15 +169,15 @@ backend {{ name }}
   balance {{ balance }}
   {% for host in groups['controller'] -%}
 
-  {% if not prefer_primary_backend or hostvars[host][primary_interface]['ipv4']['address'] == primary_ip -%}
+  {% if not prefer_primary_backend or hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] == primary_ip -%}
     {% if  name == "keystone" -%}
     cookie {{ endpoints.keystone.haproxy.oidc_cookie }}
-    server {{ host }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ clear_port }} check maxconn 40 cookie {{ host }}
+    server {{ host }} {{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ clear_port }} check maxconn 40 cookie {{ host }}
     {% else -%}
-    server {{ host }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ clear_port }} check maxconn 40
+    server {{ host }} {{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ clear_port }} check maxconn 40
     {% endif -%}
   {% else -%}
-    server {{ host }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ clear_port }} backup check maxconn 40
+    server {{ host }} {{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ clear_port }} backup check maxconn 40
   {% endif -%}
   {% endfor %}
 

--- a/roles/haproxy/templates/etc/haproxy/haproxy_swift.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_swift.cfg
@@ -39,5 +39,5 @@ backend swift
   option  forwardfor
   option  httpclose
   {% for host in groups['swiftnode'] -%}
-  server proxy{{ loop.index }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ endpoints.swift.port.proxy_api }} weight 5 check inter 2000
+  server proxy{{ loop.index }} {{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ endpoints.swift.port.proxy_api }} weight 5 check inter 2000
   {% endfor -%}

--- a/roles/heat/templates/etc/heat/heat.conf
+++ b/roles/heat/templates/etc/heat/heat.conf
@@ -73,9 +73,9 @@ ca_file = {{ heat.cafile }}
 {% macro rabbitmq_hosts() -%}
 {% for host in groups['controller'] -%}
    {% if loop.last -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }}
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ rabbitmq.port }}
    {%- else -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }},
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ rabbitmq.port }},
    {%- endif -%}
 {% endfor -%}
 {% endmacro -%}

--- a/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
+++ b/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
@@ -137,9 +137,9 @@ SECRET_KEY = "{{ secrets.horizon_secret_key }}"
 {% macro memcached_hosts() -%}
 {% for host in groups['controller'] -%}
    {% if loop.last -%}
-'{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ memcached.port }}'
+'{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ memcached.port }}'
    {%- else -%}
-'{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ memcached.port }}',
+'{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ memcached.port }}',
    {%- endif -%}
 {% endfor -%}
 {% endmacro -%}

--- a/roles/keystone/templates/etc/keystone/keystone.conf
+++ b/roles/keystone/templates/etc/keystone/keystone.conf
@@ -38,9 +38,9 @@ expiration = {{ keystone.token_expiration_in_seconds }}
 {% macro memcached_hosts() -%}
 {% for host in groups['controller'] -%}
    {% if loop.last -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ memcached.port }}
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ memcached.port }}
    {%- else -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ memcached.port }},
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ memcached.port }},
    {%- endif -%}
 {% endfor -%}
 {% endmacro -%}

--- a/roles/keystone/templates/etc/shibboleth/shibboleth2.xml
+++ b/roles/keystone/templates/etc/shibboleth/shibboleth2.xml
@@ -1,9 +1,9 @@
 {% macro memcached_hosts() -%}
 {% for host in groups['controller'] -%}
    {%- if loop.last -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ memcached.port }}
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ memcached.port }}
    {%- else -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ memcached.port }}, {% endif -%}
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ memcached.port }}, {% endif -%}
 {% endfor -%}
 {% endmacro -%}
 <SPConfig xmlns="urn:mace:shibboleth:2.0:native:sp:config"

--- a/roles/magnum/templates/etc/magnum/magnum.conf
+++ b/roles/magnum/templates/etc/magnum/magnum.conf
@@ -185,9 +185,9 @@ cafile = {{ magnum.cafile }}
 {% macro rabbitmq_hosts() -%}
 {% for host in groups['controller'] -%}
    {% if loop.last -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }}
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ rabbitmq.port }}
    {%- else -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }},
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ rabbitmq.port }},
    {%- endif -%}
 {% endfor -%}
 {% endmacro -%}

--- a/roles/mongodb-common/defaults/main.yml
+++ b/roles/mongodb-common/defaults/main.yml
@@ -9,5 +9,5 @@ mongodb:
     debug: False
     verbose: True
   cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"
-  endpoint_addr: "{{ hostvars[groups['mongo_db'][0]][primary_interface]['ipv4']['address'] }}"
-  
+  endpoint_addr: "{{ hostvars[groups['mongo_db'][0]][hostvars[groups['mongo_db'][0]]['primary_interface']]['ipv4']['address'] }}"
+

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -103,9 +103,9 @@ topics = notifications
 {% macro rabbitmq_hosts() -%}
 {% for host in groups['controller'] -%}
    {% if loop.last -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }}
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ rabbitmq.port }}
    {%- else -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }},
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ rabbitmq.port }},
    {%- endif -%}
 {% endfor -%}
 {% endmacro -%}

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -179,9 +179,9 @@ lock_path = {{ nova.state_path }}/lock
 {% macro rabbitmq_hosts() -%}
 {% for host in groups['controller'] -%}
    {% if loop.last -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }}
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ rabbitmq.port }}
    {%- else -%}
-{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ rabbitmq.port }},
+{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}:{{ rabbitmq.port }},
    {%- endif -%}
 {% endfor -%}
 {% endmacro -%}

--- a/roles/nova-data/templates/var/lib/nova/bin/verify-ssh
+++ b/roles/nova-data/templates/var/lib/nova/bin/verify-ssh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ips="{% for host in groups['compute'] -%}{{ hostvars[host][primary_interface]['ipv4']['address'] }} {% endfor -%}"
+ips="{% for host in groups['compute'] -%}{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }} {% endfor -%}"
 
 for ip in $ips; do
   echo testing ssh to $ip ...

--- a/roles/nova-data/templates/var/lib/nova/ssh/known_hosts
+++ b/roles/nova-data/templates/var/lib/nova/ssh/known_hosts
@@ -1,3 +1,3 @@
 {% for host in groups['compute'] %}
-{{ hostvars[host].ansible_nodename }},{{ hostvars[host][primary_interface].ipv4.address }} ssh-rsa {{ hostvars[host].ansible_ssh_host_key_rsa_public }}
+{{ hostvars[host].ansible_nodename }},{{ hostvars[host][hostvars[host]['primary_interface']].ipv4.address }} ssh-rsa {{ hostvars[host].ansible_ssh_host_key_rsa_public }}
 {% endfor %}

--- a/roles/percona-arbiter/templates/etc/default/garbd
+++ b/roles/percona-arbiter/templates/etc/default/garbd
@@ -1,5 +1,5 @@
 {% macro garbd_hosts() -%}
-{% for host in groups['db'] -%} {{ hostvars[host][primary_interface]['ipv4']['address'] -}}:4567 {% endfor -%}
+{% for host in groups['db'] -%} {{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] -}}:4567 {% endfor -%}
 {% endmacro -%}
 GALERA_NODES="{{ garbd_hosts() }}"
 GALERA_GROUP="mstack_db_cluster"

--- a/roles/percona-server/tasks/main.yml
+++ b/roles/percona-server/tasks/main.yml
@@ -146,7 +146,7 @@
   when: percona.replication and not already_bootstrapped.rc == 0
 
 - name: register replication databases
-  command: echo {% for host in groups['db'] %}{% if not loop.last %}{{ hostvars[host][primary_interface]['ipv4']['address'] }},{% else %}{{ hostvars[host][primary_interface]['ipv4']['address'] }}{% endif %}{% endfor %}
+  command: echo {% for host in groups['db'] %}{% if not loop.last %}{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }},{% else %}{{ hostvars[host][hostvars[host]['primary_interface']]['ipv4']['address'] }}{% endif %}{% endfor %}
   register: percona_replication_nodes
   when: percona.replication
 

--- a/roles/rabbitmq/tasks/cluster.yml
+++ b/roles/rabbitmq/tasks/cluster.yml
@@ -6,7 +6,7 @@
 - name: add controllers to /etc/hosts
   lineinfile: dest=/etc/hosts
               regexp='.*{{ hostvars[item]['ansible_hostname'] }}$'
-              line='{{ hostvars[item][primary_interface]["ipv4"]["address"] }} {{ hostvars[item]['ansible_hostname'] }}'
+              line='{{ hostvars[item][hostvars[item]['primary_interface']]]["ipv4"]["address"] }} {{ hostvars[item]['ansible_hostname'] }}'
   with_items: "{{ groups['controller'] }}"
 
 - name: add rabbitmq erlang cookie


### PR DESCRIPTION
When you have multiple machines with different interfaces you can't
assume that the primary_interface is the same everywhere. The default
undercloud_floating_ip uses the current hosts primary_interface value to
lookup something on another host. This fails when these are different so
use the primary_interface specific to that host when looking these up.
