### PR TITLE
Revert "pre-deploy: remove unnecessary kernel upgrade"

### DIFF
--- a/playbooks/ci-allinone/tasks/pre-deploy.yml
+++ b/playbooks/ci-allinone/tasks/pre-deploy.yml
@@ -50,3 +50,28 @@
   handlers:
   - name: bounce eth0
     shell: ifdown eth0; ifup eth0
+
+- name: compute and network tasks
+  hosts: network:compute
+  serial: 10
+  tasks:
+  - name: Upgrade kernel to support VXLAN
+    apt: pkg={{ item }}
+    with_items:
+      - linux-generic-lts-trusty
+      - linux-tools-lts-trusty
+    when: neutron.plugin == 'ml2'
+    notify: restart machine
+
+  - meta: flush_handlers
+
+  - name: waiting for server to come back
+    local_action: wait_for host={{ inventory_hostname }} port=22 state=started
+    sudo: false
+
+  handlers:
+  - name: restart machine
+    command: shutdown -r now
+    async: 0
+    poll: 0
+    failed_when: False

--- a/playbooks/ci-full/tasks/pre-deploy.yml
+++ b/playbooks/ci-full/tasks/pre-deploy.yml
@@ -80,3 +80,28 @@
   handlers:
   - name: bounce eth0
     shell: ifdown eth0; ifup eth0
+
+- name: compute and network tasks
+  hosts: network:compute
+  serial: 10
+  tasks:
+  - name: Upgrade kernel to support VXLAN
+    apt: pkg={{ item }}
+    with_items:
+      - linux-generic-lts-trusty
+      - linux-tools-lts-trusty
+    when: neutron.plugin == 'ml2'
+    notify: restart machine
+
+  - meta: flush_handlers
+
+  - name: waiting for server to come back
+    local_action: wait_for host={{ inventory_hostname }} port=22 state=started
+    sudo: false
+
+  handlers:
+  - name: restart machine
+    command: shutdown -r now
+    async: 0
+    poll: 0
+    failed_when: False


### PR DESCRIPTION
Reverts blueboxgroup/ursula#1574

This was the last change to pass CI.  We're getting a lot of these errors now:

```
TASK: [wait for instance to boot] *********************************************
Monday 15 February 2016  17:55:20 +0000 (0:00:18.050)       0:01:54.992 *******
skipping: [173.247.105.15] => (item={u'skipped': True, u'changed': False})
failed: [173.247.105.15] => (item={'invocation': {'module_name': u'os_floating_ip', 'module_args': ''}, 'item': {'OS-EXT-IPS-MAC:mac_addr': 'fa:16:3e:b8:9e:84', 'version': 4, 'addr': '172.16.255.4', 'OS-EXT-IPS:type': 'fixed'}, 'changed': True, 'floating_ip': {'status': 'DOWN', 'fixed_ip_address': '172.16.255.4', 'floating_ip_address': '192.168.255.3', 'network': '503e6577-3831-4e71-9812-7d080e9c104c', 'attached': True, 'id': '133409e0-5e65-4012-8e21-24a06fc45308'}}) => {"elapsed": 180, "failed": true, "item": {"changed": true, "floating_ip": {"attached": true, "fixed_ip_address": "172.16.255.4", "floating_ip_address": "192.168.255.3", "id": "133409e0-5e65-4012-8e21-24a06fc45308", "network": "503e6577-3831-4e71-9812-7d080e9c104c", "status": "DOWN"}, "invocation": {"module_args": "", "module_name": "os_floating_ip"}, "item": {"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:b8:9e:84", "OS-EXT-IPS:type": "fixed", "addr": "172.16.255.4", "version": 4}}}
msg: Timeout when waiting for 192.168.255.3:22

FATAL: all hosts have already failed -- aborting
```

Looking to see if reverting this change fixes this particular issue.  It may be that we need to keep the "restart" handler and just discard the upgrade bit?