### PR TITLE
Only install hosts file when etc_hosts defined

### DIFF
--- a/roles/common/tasks/networking.yml
+++ b/roles/common/tasks/networking.yml
@@ -16,6 +16,7 @@
 - name: hosts file
   template: src=etc/hosts dest=/etc/hosts owner=root group=root mode=0644
             backup=yes
+  when: etc_hosts is defined
   tags: etc_hosts
 
 - name: netfilter tuning


### PR DESCRIPTION
Don't run the hosts template if etc_hosts are not defined.