### PR TITLE
Fix syntax in ceph_integration.yml

### DIFF
--- a/roles/cinder-common/tasks/ceph_integration.yml
+++ b/roles/cinder-common/tasks/ceph_integration.yml
@@ -24,7 +24,7 @@
   when: openstack_install_method == 'package'
 
 - name: fetch rbd.py
-  get_url: url= {{ ceph.rbd_url }}
+  get_url: url={{ ceph.rbd_url }}
            dest="{{ lookup('items', 'openstack_package.virtualenv_base') }}/cinder/lib/python2.7/site-packages/rbd.py"
            owner=root
            group=root


### PR DESCRIPTION
There is an unneeded space is ceph_integration.yml that will throw `msg: this module requires key=value arguments` errors when deploying cinder on package installs.