### PR TITLE
Reduce MTU to 1400

### DIFF
--- a/roles/neutron-data-network/templates/etc/dnsmasq.conf
+++ b/roles/neutron-data-network/templates/etc/dnsmasq.conf
@@ -1,3 +1,4 @@
 {% for server in neutron.dhcp_dns_servers -%}
 server={{ server }}
 {% endfor -%}
+dhcp-option-force=26,1400


### PR DESCRIPTION
We are no longer able to `ssh` into the test VM `Ursula_Test_PRs` boots
in the cloud it deploys to perform integration tests.  What's weird is
`ping` still worked and we could *connect* to port 22 (via telnet), but
that was about it.  After doing a little reading I decided that maybe
adjusting the MTU down was something worth trying and sure enough, once
I did this, subsequent VMs that I booted, were accessible over `ssh`.
I do not yet know *why* this failure mode occurred.  Nothing obvious
changed in ursula from the last time it successfully built
`Ursula_Test_PRs` so perhaps some other change?  Did MTU change any
where else in the network stack?

I've submitted this patch, not with the intention of merging this "fix",
but to see CI go green again.

I'll probably need to work with someone who's more knowledgeable about
networking to get a root cause.