### PR TITLE
Added defaults for grub and serial_console

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -14,6 +14,9 @@ common:
   ntpd:
     servers: []
     #  - servertime.service.softlayer.com
+  serial_console:
+    enabled: True
+    name: ttyS0
   ssh_private_keys: []
   ssh:
     allow_from:
@@ -43,7 +46,6 @@ common:
   logging:
     debug: False
     verbose: True
-  serial_console: ttyS0
   monitoring:
     sensu_checks:
       check_raid:

--- a/roles/common/tasks/kernel-tuning.yml
+++ b/roles/common/tasks/kernel-tuning.yml
@@ -22,10 +22,14 @@
   notify:
     - apply-sysctl
 
+- stat: path=/etc/default/grub
+  register: grub_defaults
+
 - name: "Kernel boot parameters: disable quiet boot"
   lineinfile: dest=/etc/default/grub
               regexp="^GRUB_CMDLINE_LINUX_DEFAULT="
               line="GRUB_CMDLINE_LINUX_DEFAULT=\"\""
+  when: grub_defaults.stat.exists
   notify: update grub config
 
 #
@@ -41,6 +45,7 @@
   lineinfile: dest=/etc/default/grub
               regexp="^GRUB_CMDLINE_LINUX="
               line="GRUB_CMDLINE_LINUX=\"consoleblank=0 nmi_watchdog=1 {{ serial_console_cmdline|default('') }} console=tty0 biosdevname=0 {{- ' maxcpus=%s' % cpulimit if cpulimit is defined else '' }} {{- 'smt-enabled=off' if ansible_architecture == 'ppc64le' else '' }} \""
+  when: grub_defaults.stat.exists
   notify: update grub config
 
 # This was removed in later distributions, but is in grub-common and if present
@@ -54,6 +59,7 @@
 - name: "Disable GRUB OS prober so we don't try to boot instance's cinder volumes"
   lineinfile: dest=/etc/default/grub
               line="GRUB_DISABLE_OS_PROBER=true"
+  when: grub_defaults.stat.exists
   notify: update grub config
 
 - name: Remove any forced boot kernel

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -68,7 +68,8 @@
   tags: ntp
 
 # Include serial console before kernel-tuning to build serial_console_cmdline
-- include: serial-console.yml tty={{ common.serial_console }}
+- include: serial-console.yml tty={{ common.serial_console.name }}
+  when: common.serial_console.enabled | bool
   tags: ['prereboot']
 
 - include: ipmi.yml


### PR DESCRIPTION
When deploying ursula to SoftLayer virtual servers it was discovered that the
/etc/default/grub file did not exist and there was no serial console on the
virtual servers. The changes made in this commit allowed the ursula deploy
to proceed.