### PR TITLE
Disables cinder vg in role and enables in example for CI

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -176,6 +176,7 @@ cinder:
   volume_type: file
   volume_file: /opt/stack/cinder-volumes
   volume_file_size: 5G
+  create_vg: True
   #fixed_key: 6a5c55db5e250f234b6af7807dafda77433dddcf372b6d04801a45f578a35aa7
   logging:
     debug: True

--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -11,7 +11,7 @@ cinder:
   state_path: "{{ state_path_base }}/cinder"
   volume_type: file
   volume_group: cinder-volumes
-  create_vg: true
+  create_vg: False
   alternatives:
       - cinder-all
       - cinder-api


### PR DESCRIPTION
Previously reviewed by JLK; will backport to 2.0 once checks pass