### PR TITLE
Add system CA to stackrc

### DIFF
--- a/roles/client/templates/root/stackrc
+++ b/roles/client/templates/root/stackrc
@@ -4,6 +4,8 @@ export OS_USERNAME=admin
 export OS_TENANT_NAME=admin
 {% if client.self_signed_cert -%}
 export OS_CACERT=/opt/stack/ssl/openstack.crt
+{% else %}
+export OS_CACERT=/etc/ssl/certs/ca-certificates.crt
 {% endif -%}
 export OS_NO_CACHE=True
 export OS_VOLUME_API_VERSION=2


### PR DESCRIPTION
When using predefined certificates any client operations that are
performed on a client installed inside a virtualenv and so requests
doesn't acknowledge the installed system CA. This fails particularly in
the case of heat-keystone-setup-domain where it doesn't follow the
system CA.

We could fix this purely for the heat case however everything relying
upon the stackrc file will have this same problem so add the system CA
there.