### PR TITLE
Ensure the symlink target also on upgrade (2.0.x)

### DIFF
--- a/roles/openstack-package/tasks/main.yml
+++ b/roles/openstack-package/tasks/main.yml
@@ -7,15 +7,16 @@
   file: dest=/opt/openstack state=directory
 
 - name: test whether current {{ project_name }} symlink exists
-  shell: 'test -h /opt/openstack/current'
+  stat:
+    path: /opt/openstack/current
   register: symlink_exists
-  ignore_errors: True
 
-- name: setup current symlink if it doesnt exist
-  file: src="/opt/bbc/openstack-{{ openstack_package_version }}"
-        dest=/opt/openstack/current
-        state=link
-  when: symlink_exists.rc != 0
+- name: setup current symlink
+  file:
+    src: "{{ openstack_package.virtualenv_base }}"
+    dest: /opt/openstack/current
+    state: link
+  when: not symlink_exists.stat.exists or upgrade | default(false) | bool
 
 - name: ensure project config directory exists
   file: name="/etc/{{ project_name }}" state=directory

--- a/roles/openstack-source/tasks/main.yml
+++ b/roles/openstack-source/tasks/main.yml
@@ -54,20 +54,22 @@
   notify:
     - update ca-certs
 
-- name: setup current symlink if it doesnt exist
-  file: dest=/opt/openstack
-        state=directory
+- name: setup openstack current base path
+  file:
+    dest: /opt/openstack
+    state: directory
 
 - name: test whether current {{ project_name }} symlink exists
-  shell: 'test -h /opt/openstack/current'
+  stat:
+    path: /opt/openstack/current
   register: symlink_exists
-  ignore_errors: True
 
-- name: setup current symlink if it doesnt exist
-  file: src="{{ openstack_source.virtualenv_base }}"
-        dest=/opt/openstack/current
-        state=link
-  when: symlink_exists.rc != 0
+- name: setup current symlink
+  file:
+    src: "{{ openstack_source.virtualenv_base }}"
+    dest: /opt/openstack/current
+    state: link
+  when: not symlink_exists.stat.exists or upgrade | default(false) | bool
 
 - name: ensure project config directory exists
   file: name="/etc/{{ project_name }}" state=directory


### PR DESCRIPTION
If an operator passes "-e upgrade=true", then the symlink task will
trigger.

Also update tasks I'm touching to the desired format, and use the stat
module to check the link status.

(cherry picked from commit 40e7f8b8741ef9728e01564cf95443c7ac863e90)