### PR TITLE
Remove old python_requirements variable

### DIFF
--- a/roles/neutron-common/meta/main.yml
+++ b/roles/neutron-common/meta/main.yml
@@ -11,7 +11,6 @@ dependencies:
   - role: openstack-source
     project_name: neutron
     project_rev: "{{ neutron.source.rev }}"
-    python_requirements: "{{ neutron.source.python_requirements }}"
     rootwrap: True
     alternatives: "{{ neutron.alternatives }}"
     system_dependencies: "{{ neutron.source.system_dependencies }}"


### PR DESCRIPTION
python_requirements does not appear to be used anywhere with the
variable being python_dependencies. Having this left around makes it
confusing.