### PR TITLE
Use trusty hwraid when on trusty

### DIFF
--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -10,7 +10,12 @@ dependencies:
     repos:
       - repo: 'deb {{ apt_repos.hwraid.repo }} precise main'
         key_url: '{{ apt_repos.hwraid.key_url }}'
-    when: common.hwraid.enabled|bool
+    when: common.hwraid.enabled|bool and ansible_distribution_version == "12.04"
+  - role: apt-repos
+    repos:
+      - repo: 'deb {{ apt_repos.hwraid.repo }} trusty main'
+        key_url: '{{ apt_repos.hwraid.key_url }}'
+    when: common.hwraid.enabled|bool and ansible_distribution_version == "14.04"
   - role: apt-repos
     repos:
       - repo: 'deb {{ apt_repos.sensu.repo }} {{ apt_repos.sensu.distribution }} {{ apt_repos.sensu.components }}'


### PR DESCRIPTION
No sense in continuing to use precise.