### PR TITLE
update role for ceph scaleout

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -91,7 +91,7 @@ ceph:
   filestore_split_multiple: 8
   osd_op_threads: 8
   filestore_op_threads: 8
-  filestore_max_sync_interval: 5
+  filestore_max_sync_interval: 30
   osd_max_scrubs: 1
 
   # OS tuning

--- a/roles/ceph-common/handlers/main.yml
+++ b/roles/ceph-common/handlers/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: restart ceph mons
   service: name=ceph-mon-all state=restarted
-  when: ceph_socket.rc == 0
+  when: ceph_socket.rc == 0 and not ceph.scaleout|default('False')|bool
 
 - name: restart ceph osds
   service: name=ceph-osd-all state=restarted
-  when: ceph_socket.rc == 0
+  when: ceph_socket.rc == 0 and not ceph.scaleout|default('False')|bool

--- a/roles/ceph-update/tasks/main.yml
+++ b/roles/ceph-update/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+# Wait for a max of 30 minutes
+- name: wait for ceph cluster to be in health ok state
+  shell: ceph health | egrep -q "HEALTH_OK"
+  register: result
+  until: result.rc == 0
+  retries: 30
+  delay: 60
+  delegate_to: "{{ groups['ceph_monitors'][0] }}"
+
+- name: restart ceph mons
+  service: name=ceph-mon-all state=restarted
+
+# Setting noout to prevent cluster from rebalancing after service restart
+- name: set osd noout
+  command: ceph osd set noout
+  delegate_to: "{{ groups['ceph_monitors'][0] }}"
+  when: inventory_hostname == groups['ceph_osds'][0]
+
+# Setting osd values for first osd to reduce performance degradation of client I/O
+- name: set osd noscrub
+  command: ceph osd set noscrub
+  delegate_to: "{{ groups['ceph_monitors'][0] }}"
+  when: inventory_hostname == groups['ceph_osds'][0]
+
+- name: set osd nodeep scrub
+  command: ceph osd set nodeep-scrub
+  delegate_to: "{{ groups['ceph_monitors'][0] }}"
+  when: inventory_hostname == groups['ceph_osds'][0]
+
+- name: restart ceph osds
+  service: name=ceph-osd-all state=restarted
+
+# Unset the osd values only after ceph on last osd node has restarted
+- name: unset osd noout
+  command: ceph osd unset noout
+  delegate_to: "{{ groups['ceph_monitors'][0] }}"
+  when: inventory_hostname == groups['ceph_osds'][-1]
+
+- name: unset osd noscrub
+  command: ceph osd unset noscrub
+  delegate_to: "{{ groups['ceph_monitors'][0] }}"
+  when: inventory_hostname == groups['ceph_osds'][-1]
+
+- name: unset osd nodeep scrub
+  command: ceph osd unset nodeep-scrub
+  delegate_to: "{{ groups['ceph_monitors'][0] }}"
+  when: inventory_hostname == groups['ceph_osds'][-1]

--- a/site.yml
+++ b/site.yml
@@ -350,3 +350,13 @@
       tags: ['openstack', 'setup', 'openstack-network']
       when: neutron.enable_external_interface|default('false')|bool
   environment: "{{ env_vars|default({}) }}"
+
+# This is the last role because ceph health checks can take up to 2 hours
+- name: ceph update
+  hosts: ceph_monitors:ceph_osds
+  serial: 1 # serial because tracking cluster osd count
+  roles:
+    - role: ceph-update
+      tags: ['ceph', 'ceph-update']
+      when: ceph.scaleout|default('False')|bool
+  environment: "{{ env_vars|default({}) }}"


### PR DESCRIPTION
Adding a new role that restarts the ceph services in a serialized manner after ceph expansion. The `noout`, `noscrub` and `nodeep-scrub` options are set when restarting ceph osd nodes in order to minimize the downfall in performance metrics observed in the ceph cluster. Those options are then unset after ceph services on _all_ of the osd nodes are restarted for the same reason above. Also updating the sync_interval field for `ceph.conf`. 