### PR TITLE
Use a lookup to resolve a variable within a var

### DIFF
--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -36,7 +36,8 @@
   when: openstack_install_method == 'source'
   
 - name: set uwsgi path (package install)
-  set_fact: uwsgi_path={{ openstack_package.virtualenv_base }}/keystone/bin/uwsgi
+  set_fact:
+    uwsgi_path: "{{ lookup('items', 'openstack_package.virtualenv_base') }}/keystone/bin/uwsgi"
   when: openstack_install_method == 'package'
   
 - name: install keystone uwsgi service


### PR DESCRIPTION
The openstack-package role defines virtualenv_base differently than
openstack_source, so we need a lookup to deep resolve variables.