### PR TITLE
Add a couple missing useful schedule filters (2.0.x)

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -18,7 +18,7 @@ nova:
   novnc_repo: https://github.com/kanaka/noVNC.git
   novnc_rev: 292f6a5d
   novnc_url: https://github.com/kanaka/noVNC/archive/v0.5.1.tar.gz
-  scheduler_default_filters: RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,CoreFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter
+  scheduler_default_filters: RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,CoreFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,AggregateInstanceExtraSpecsFilter,DiskFilter
   libvirt_bin_version: 1.2.2-0ubuntu13.1.9~cloud0
   python_libvirt_version: 1.2.2-0ubuntu2~cloud0
   qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.16~cloud0


### PR DESCRIPTION
DiskFilter prevents trying a build on a system without sufficient disk
space.

AggregateInstanceExtraSpecsFilter allows creating flavors with extra
specs and maping those flavors to host aggregates that have those extra
specs.

(cherry picked from commit 8ec2decc1a7bcbe52ee25751569b7b282268465f)