### PR TITLE
Remove deprecated network monitoring check (2.0.x)

### DIFF
--- a/roles/common/tasks/monitoring.yml
+++ b/roles/common/tasks/monitoring.yml
@@ -134,7 +134,7 @@
   notify: restart sensu-client
 
 - name: network interface traffic check
-  sensu_check: name=network_interface_traffic plugin=check-netif.rb args="-c 500 -w 350 --interfaces eth0,eth1,bond0,bond1"
+  sensu_check: name=network_interface_traffic plugin=check-netif.rb state=absent 
   notify: restart sensu-client
 
 - name: disk check


### PR DESCRIPTION
(cherry picked from commit a4c084a906680ccf1e0e8ae5b42a14c4d92aba40)