### PR TITLE
Set the concurrency level as per recommendation by deployment guide

### DIFF
--- a/roles/swift-account/defaults/main.yml
+++ b/roles/swift-account/defaults/main.yml
@@ -2,4 +2,7 @@
 swift_account:
   ip: "{{ primary_ip }}"
   port: 6002
-  workers: 10
+  workers: "{{ swift.cluster.no_workers }}"
+  replicators: "{{ swift.cluster.no_replicators }}"
+  auditors: "{{ swift.cluster.no_auditors }}"
+  reapers: 1

--- a/roles/swift-account/templates/etc/swift/account-server.conf
+++ b/roles/swift-account/templates/etc/swift/account-server.conf
@@ -25,7 +25,10 @@ use = egg:swift#recon
 use = egg:swift#account
 
 [account-replicator]
+concurrency = {{ swift_account.replicators }}
 
 [account-auditor]
+concurrency = {{ swift_account.auditors }}
 
 [account-reaper]
+concurrency = {{ swift_account.reapers }}

--- a/roles/swift-common/defaults/main.yml
+++ b/roles/swift-common/defaults/main.yml
@@ -96,3 +96,8 @@ swift:
         max_connections: 4
       account:
         max_connections: 2
+  cluster:
+        no_workers: 10
+        no_replicators: 2
+        no_auditors: 1
+        no_updaters: 1

--- a/roles/swift-container/defaults/main.yml
+++ b/roles/swift-container/defaults/main.yml
@@ -2,4 +2,7 @@
 swift_container:
   ip: "{{ primary_ip }}"
   port: 6001
-  workers: 10
+  workers: "{{ swift.cluster.no_workers }}"
+  replicators: "{{ swift.cluster.no_replicators }}"
+  auditors: "{{ swift.cluster.no_auditors }}"
+  updaters: "{{ swift.cluster.no_updaters }}"

--- a/roles/swift-container/templates/etc/swift/container-server.conf
+++ b/roles/swift-container/templates/etc/swift/container-server.conf
@@ -26,9 +26,12 @@ use = egg:swift#healthcheck
 use = egg:swift#recon
 
 [container-replicator]
+concurrency = {{ swift_container.replicators }}
 
 [container-updater]
+concurrency = {{ swift_container.updaters}}
 
 [container-auditor]
+concurrency = {{ swift_container.auditors }}
 
 [container-sync]

--- a/roles/swift-object/defaults/main.yml
+++ b/roles/swift-object/defaults/main.yml
@@ -2,4 +2,7 @@
 swift_object:
   ip: "{{ primary_ip }}"
   port: 6000
-  workers: 10
+  workers: "{{ swift.cluster.no_workers }}"
+  replicators: "{{ swift.cluster.no_replicators }}"
+  auditors: "{{ swift.cluster.no_auditors }}"
+  updaters: "{{ swift.cluster.no_updaters }}"

--- a/roles/swift-object/templates/etc/swift/object-server.conf
+++ b/roles/swift-object/templates/etc/swift/object-server.conf
@@ -28,9 +28,10 @@ recon_cache_path = /var/cache/swift
 [object-replicator]
 recon_enable = yes
 recon_cache_path = /var/cache/swift
-concurrency = 2
+concurrency = {{ swift_object.replicators }}
 
 [object-updater]
-concurrency = 2
+concurrency = {{ swift_object.updaters }}
 
 [object-auditor]
+concurrency = {{ swift_object.auditors }}

--- a/roles/swift-proxy/defaults/main.yml
+++ b/roles/swift-proxy/defaults/main.yml
@@ -2,7 +2,7 @@
 swift_proxy:
   ip: "{{ primary_ip }}"
   port: "{{ endpoints.swift.port.proxy_api }}"
-  workers: 10
+  workers: "{{ swift.cluster.no_workers }}"
   operator_roles: Member,_member_,admin,cloud_admin,project_admin
   reseller_admin_role: cloud_admin
 


### PR DESCRIPTION
Deployment guide: http://docs.openstack.org/developer/swift/deployment_guide.html. During developer testing, these value solved the problems related to too many processes trying to access resource leading to EADDRNOTAVAIL errors.