### PR TITLE
Increase number of rsync connections for object and container

### DIFF
--- a/roles/swift-common/defaults/main.yml
+++ b/roles/swift-common/defaults/main.yml
@@ -89,3 +89,10 @@ swift:
         criticality: 'critical'
       fstab_mounts:
         criticality: 'critical'
+  rsync:
+      object:
+        max_connections: 8
+      container:
+        max_connections: 4
+      account:
+        max_connections: 2

--- a/roles/swift-common/templates/etc/rsyncd.conf
+++ b/roles/swift-common/templates/etc/rsyncd.conf
@@ -5,19 +5,19 @@ pid file = /var/run/rsyncd.pid
 address = {{ primary_ip }}
 
 [account]
-max connections = 2
+max connections = {{ swift.rsync.account.max_connections }}
 path = /srv/node/
 read only = false
 lock file = /var/lock/account.lock
 
 [container]
-max connections = 2
+max connections = {{ swift.rsync.container.max_connections }}
 path = /srv/node/
 read only = false
 lock file = /var/lock/container.lock
 
 [object]
-max connections = 2
+max connections = {{ swift.rsync.object.max_connections }}
 path = /srv/node/
 read only = false
 lock file = /var/lock/object.lock


### PR DESCRIPTION
2 rsync connections for object/containers is relatively low. Setting the values according to https://github.com/openstack/swift/blob/master/etc/rsyncd.conf-sample which seems to work well during testing.