### PR TITLE
Stop using "copy-from" to load glance images (2.0.x)

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -266,6 +266,7 @@ glance:
   images:
     - name: cirros
       url: https://file-mirror.openstack.blueboxgrid.com/cloud-images/cirros-0.3.3-x86_64-disk.img
+      filename: cirros-0.3.3-x86_64-disk.img
 
 keystone:
   token_expiration_in_seconds: 86400

--- a/roles/openstack-setup/tasks/images.yml
+++ b/roles/openstack-setup/tasks/images.yml
@@ -1,7 +1,12 @@
 ---
+# NOTE: Glance does not know how to proxy copy-from URLs, so we should instead
+# download the image files locally and create images using the file method.
+- name: download images locally
+  get_url: url={{ item.url }} dest=/tmp/{{ item.filename }}
+  with_items: glance.images
 - name: default images
   glance_image: name={{ item.name }}
-                copy_from={{ item.url }}
+                file=/tmp/{{ item.filename }}
                 container_format=bare
                 disk_format=qcow2
                 auth_url={{ endpoints.auth_uri }}
@@ -12,3 +17,6 @@
                 timeout=12000
   with_items: glance.images
   run_once: true
+- name: remove local images
+  file: path=/tmp/{{ item.filename }} state=absent
+  with_items: glance.images


### PR DESCRIPTION
Glance does not know how to proxy `copy-from` URLs.  To workaround this
issue we simply download the images locally and then create glance
images using the `file` method.

(cherry picked from commit 3b8b07d19d37389327e42fe4095d659763a72a32)