### PR TITLE
Trigger service restarts on openstack code change

### DIFF
--- a/roles/ceilometer-control/tasks/main.yml
+++ b/roles/ceilometer-control/tasks/main.yml
@@ -15,6 +15,14 @@
     - ceilometer-alarm-notifier
   notify: restart ceilometer services
 
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart ceilometer services
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
 - name: create ceilometer user in mongodb
   mongodb_user: database={{ ceilometer.mongodb_database }} name={{ ceilometer.mongodb_user }} password={{ ceilometer.mongodb_password }} roles='readWrite,dbAdmin' state=present
   when: inventory_hostname in groups['controller'][0]

--- a/roles/ceilometer-data/tasks/main.yml
+++ b/roles/ceilometer-data/tasks/main.yml
@@ -15,6 +15,14 @@
   notify: restart ceilometer services
   when: openstack_install_method == 'source'
 
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart ceilometer services
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
 - meta: flush_handlers
 
 - name: start ceilometer-compute service

--- a/roles/cinder-control/tasks/main.yml
+++ b/roles/cinder-control/tasks/main.yml
@@ -25,6 +25,14 @@
   # we want this to always be changed so that it can notify the service restart
   tags: db-migrate
 
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart cinder services
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
 - meta: flush_handlers
 
 - name: start cinder controller services

--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -47,15 +47,26 @@
                    cmd=/usr/local/bin/cinder-volume
                    config_dirs=/etc/cinder
 
-- name: start cinder-volume
-  service: name=cinder-volume state=started
-
 - name: install cinder backup service
   upstart_service: name=cinder-backup
                    user=cinder
                    cmd=/usr/local/bin/cinder-backup
                    config_dirs=/etc/cinder
   when: swift.enabled|default("false")|bool
+
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart cinder services
+  notify: restart cinder backup service
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
+- meta: flush_handlers
+
+- name: start cinder-volume
+  service: name=cinder-volume state=started
 
 - name: start cinder backup
   service: name=cinder-backup state=started

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -85,6 +85,14 @@
 - include: ceph_integration.yml
   when: ceph.enabled|bool
 
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart glance services
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
 - meta: flush_handlers
 
 - name: start glance services

--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -72,6 +72,14 @@
   # we want this to always be changed so that it can notify the service restart
   tags: db-migrate
 
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart heat services
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
 - meta: flush_handlers
 
 - name: start heat services

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -116,6 +116,16 @@
     - "{{ openstack_source.virtualenv_base }}/horizon/bin/django-admin.py compress"
   when: openstack_install_method == 'source'
 
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart apache
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
+- meta: flush_handlers
+
 - name: ensure apache started
   service: name=apache2 state=started
 

--- a/roles/ironic-control/tasks/main.yml
+++ b/roles/ironic-control/tasks/main.yml
@@ -54,6 +54,14 @@
   # we want this to always be changed so that it can notify the service restart
   tags: db-migrate
 
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart ironic services
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
 - meta: flush_handlers
 
 - name: start ironic controller services

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -57,6 +57,14 @@
   # we want this to always be changed so that it can notify the service restart
   tags: db-migrate
 
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart keystone services
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
 - meta: flush_handlers
 
 - name: start keystone

--- a/roles/magnum/tasks/main.yml
+++ b/roles/magnum/tasks/main.yml
@@ -38,6 +38,14 @@
   notify: restart magnum services
   # we want this to always be changed so that it can notify the service restart
 
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart magnum services
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
 - meta: flush_handlers
 
 - name: restart magum services

--- a/roles/neutron-control/tasks/main.yml
+++ b/roles/neutron-control/tasks/main.yml
@@ -39,6 +39,14 @@
   # we want this to always be changed so that it can notify the service restart
   tags: db-migrate
 
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart neutron services
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
 - meta: flush_handlers
 
 - name: start neutron-server

--- a/roles/neutron-data-network/tasks/main.yml
+++ b/roles/neutron-data-network/tasks/main.yml
@@ -95,6 +95,20 @@
         - /etc/neutron/services/loadbalancer/haproxy/lbaas_agent.ini
         - /etc/neutron/neutron_lbaas.conf
 
+- name: kill neutron-ns-metdata-proxy on upgrade
+  command: pkill -f neutron-ns-metadata-proxy
+  failed_when: False
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart neutron services
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
 - meta: flush_handlers
 
 - name: start neutron-data-network services

--- a/roles/neutron-data/tasks/main.yml
+++ b/roles/neutron-data/tasks/main.yml
@@ -28,6 +28,16 @@
                    config_files=/etc/neutron/neutron.conf,/etc/neutron/plugins/ml2/ml2_plugin.ini,/etc/neutron/plugins/ml2/ml2_plugin_dataplane.ini
   when: neutron.plugin == 'ml2'
 
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart neutron services
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
+- meta: flush_handlers
+
 - name: start neutron-linuxbridge-agent
   service: name=neutron-linuxbridge-agent state=started
   when: neutron.plugin == 'ml2'

--- a/roles/nova-control/tasks/main.yml
+++ b/roles/nova-control/tasks/main.yml
@@ -36,6 +36,14 @@
   # we want this to always be changed so that it can notify the service restart
   tags: db-migrate
 
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart nova services
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
 - meta: flush_handlers
 
 - name: start nova controller services

--- a/roles/nova-data/tasks/main.yml
+++ b/roles/nova-data/tasks/main.yml
@@ -53,6 +53,16 @@
   upstart_service: name=nova-compute user=nova cmd=/usr/local/bin/nova-compute
                    config_dirs=/etc/nova
 
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart nova services
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
+- meta: flush_handlers
+
 - name: start nova-compute
   service: name=nova-compute state=started
 

--- a/roles/openstack-package/tasks/main.yml
+++ b/roles/openstack-package/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: "install {{ project_name }} package"
   apt: pkg="{{ package_name|default(openstack_package.package_name) }}"
        update_cache=yes cache_valid_time=3600
+  register: project_package
 
 - name: setup openstack current base path
   file: dest=/opt/openstack state=directory

--- a/roles/swift-account/tasks/main.yml
+++ b/roles/swift-account/tasks/main.yml
@@ -13,6 +13,14 @@
             dest=/etc/swift/account-server.conf owner=swift group=swift
   notify: restart swift-account service
 
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart swift-account service
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
 - meta: flush_handlers
 
 - name: start swift-account services

--- a/roles/swift-container/tasks/main.yml
+++ b/roles/swift-container/tasks/main.yml
@@ -14,6 +14,14 @@
             dest=/etc/swift/container-server.conf owner=swift group=swift
   notify: restart swift-container service
 
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart swift-container service
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
 - meta: flush_handlers
 
 - name: start swift-container services

--- a/roles/swift-object/tasks/main.yml
+++ b/roles/swift-object/tasks/main.yml
@@ -22,6 +22,14 @@
             owner=swift group=swift mode=0640
   notify: restart swift-object-expirer service
 
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart swift-object service
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
 - meta: flush_handlers
 
 - name: start swift-object services

--- a/roles/swift-proxy/tasks/main.yml
+++ b/roles/swift-proxy/tasks/main.yml
@@ -13,6 +13,14 @@
             owner=swift group=swift mode=0640
   notify: restart swift-proxy service
 
+- name: trigger restart on upgrades
+  debug:
+    msg: "Triggering service restart for upgrade"
+  changed_when: True
+  notify: restart swift-proxy service
+  when: (project_package.changed or git_result.changed) and
+        upgrade | default('False') | bool
+
 - meta: flush_handlers
 
 - name: start swift-proxy service


### PR DESCRIPTION
If we change the package or the git repo we want to restart the
services. Currently this also depends on 'upgrade' being set to True.

For neutron, we have to manually kill neutron-ns-metadata-proxy as it
doesn't get restarted when the l3 agent gets restarted. However we do
want it to be running from the new code.

(cherry picked from commit 42e49bdac8dbe489d230510f4dbb71f94ac072f9)