### PR TITLE
Stop using bluebox gem mirror for now (2.0.x)

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -100,7 +100,7 @@ openstack:
   easy_install_mirror: https://pypi-mirror.openstack.blueboxgrid.com/root/pypi/+simple
   pip_trusted: pypi-mirror.openstack.blueboxgrid.com
   gem_sources:
-    - https://gem-mirror.openstack.blueboxgrid.com
+    - https://rubygems.org
   git_mirror:  https://github.com/openstack
   git_update: yes
   ubuntu_mirror: https://apt-mirror.openstack.blueboxgrid.com/archive.ubuntu.com/ubuntu


### PR DESCRIPTION
It's under a lot of pressure and needs some time off to sort through its
life.

(cherry picked from commit 116031a893a33fb502d09003550ee41cfec9e39e)