### PR TITLE
Enable force copy for custom horizon logo images

### DIFF
--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -70,6 +70,7 @@
 - name: custom horizon logo
   get_url: url={{ item.url }}
            dest=/etc/openstack-dashboard/static/dashboard/{{ item.name }}
+           force=True
   with_items:
     - { name: img/logo.png, url: "{{ horizon.logo_url }}"  }
     - { name: img/logo-splash.png, url: "{{ horizon.logo_url }}" }


### PR DESCRIPTION
When updating a cluster, get_url would skip replacing the updated logo image as logo.png was already present. Given, we always copy the custom logo image to dest as fixed file name (logo,png) we must enforce force copy on get_url.