### PR TITLE
add endpoints role as dependency to mongodb-common

### DIFF
--- a/roles/mongodb-common/meta/main.yml
+++ b/roles/mongodb-common/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: endpoints
   - role: monitoring-common
     when: monitoring.enabled|default(True)|bool
   - role: apt-repos


### PR DESCRIPTION
mongodb-common needs to pull in the endpoints role as a result of defaults-2.0.yml cleanup. Without it, ursula will throw undefined variable errors when installing mongodb config files, as it will not have the endpoint defined.