### PR TITLE
logging: split logging from logging-config deps

### DIFF
--- a/roles/logging-config/handlers/main.yml
+++ b/roles/logging-config/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: restart logstash-forwarder
-  service: name=logstash-forwarder state=restarted
+  service: name=logstash-forwarder state=restarted must_exist=false

--- a/roles/logging-config/meta/main.yml
+++ b/roles/logging-config/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - role: logging

--- a/roles/logging-config/tasks/main.yml
+++ b/roles/logging-config/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: logstash-forwarder config directory
+  file: dest=/etc/logstash-forwarder.d state=directory mode=0755
+
 - name: install log template
   template: src=etc/logstash-forwarder.d/template.conf dest=/etc/logstash-forwarder.d/{{ service }}.conf
   notify: restart logstash-forwarder

--- a/site.yml
+++ b/site.yml
@@ -12,6 +12,8 @@
     - role: serverspec
       tags: ['common', 'serverspec']
       when: serverspec.enabled|default("False")|bool
+    - role: logging
+      tags: ['common', 'logging']
     - role: collectd-client
       tags: ['collectd-client','collectd']
       when: collectd.enabled|default('False')|bool


### PR DESCRIPTION
Split the `logging` role from being a dependency of the `logging-config` role just to pick up a directory and  handler. This will speed up end-to-end deployments due to keeping the `logging` role from being run by every role which uses the `logging-config` role.