### PR TITLE
ansible.cfg: set log_path for easier debugging

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -11,6 +11,7 @@ connection_plugins = plugins/connection
 callback_plugins = plugins/callbacks
 filter_plugins = plugins/filters
 var_defaults_file = ../defaults-2.0.yml
+log_path=ursula.log
 forks = 25
 gathering = smart
 


### PR DESCRIPTION
Simple change, profound effect. (In the midst of trouble-shooting, at least.)