### PR TITLE
Force enable sensu-client

### DIFF
--- a/roles/common/tasks/monitoring.yml
+++ b/roles/common/tasks/monitoring.yml
@@ -66,6 +66,9 @@
 - name: enable and start sensu-client
   service: name=sensu-client state=started enabled=yes
 
+- name: override sensu-client startup
+  shell: update-rc.d sensu-client defaults
+
 - name: install sensu plugin pip modules
   pip: name=sensu_plugin version=0.1.0
 


### PR DESCRIPTION
 service: name=sensu-client state=started enabled=yes does not properly create symlink in /etc/rc_x_.d