### PR TITLE
fix keystone-setup checks so that it runs once

### DIFF
--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -1,13 +1,4 @@
 ---
-- name: discover keystone setup status
-  command: mysql --batch --silent keystone -e "select type from service where type = 'compute'"
-  failed_when: false
-  register: keystone_setup
-
-- name: set keystone_configured fact
-  set_fact: keystone_configured=True
-  when: keystone_setup.stdout|search("compute")
-
 - name: generate admin_token
   set_fact: admin_token="{{ 'asdf' * 9|random(start=2) }}"
             insert_token=True

--- a/site.yml
+++ b/site.yml
@@ -192,11 +192,23 @@
 - name: keystone setup
   hosts: controller[0]
   any_errors_fatal: true
+  tags: ['openstack', 'setup', 'keystone-setup']
+  pre_tasks:
+    # These pre-tasks determine if keystone has been setup before. If so, the
+    # keystone-setup role tasks are skipped.
+    - name: discover keystone setup status
+      command: mysql --batch --silent keystone -e "select type from service where type = 'compute'"
+      failed_when: false
+      changed_when: false
+      register: keystone_setup
+
+    - name: set keystone_configured fact
+      set_fact: keystone_configured=True
+      when: keystone_setup.stdout|search("compute")
+
   roles:
     - role: keystone-setup
-      keystone_configured: false
-      tags: ['openstack', 'setup', 'keystone-setup']
-      when: not keystone_configured
+      when: not hostvars[inventory_hostname].keystone_configured | default(False)
   environment: "{{ env_vars|default({}) }}"
 
 - name: glance code and config


### PR DESCRIPTION
`keystone-setup` was previously running on each iteration due to:

1. var registration was happening in-role _after_ the var was evaluated; now done in pre_tasks to ensure it evaluates before, not after
2. parameterized variable (`keystone_configured: false`) being passed into role, not needed anymore
3. var when checked was evaluating false, so be more explicit (`keystone_configured` vs `hostvars[inventory_hostname].keystone_configured`)
4. use a default to be ultra clear that we by default assume keystone to be unconfigured, unless checks indicate otherwise