### PR TITLE
Revert "Grant admin and cloud_admin heat_stack_owner role"

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -22,6 +22,7 @@ secrets:
   monitor_password: asdf
   telemetry_secret: asdf
   cloud_admin_password: asdf
+  project_admin_password: asdf
 
 fqdn: openstack.example.com
 swift_fqdn: "{{ fqdn }}"
@@ -317,19 +318,16 @@ keystone:
     - name: cloud_admin
       password: "{{ secrets.cloud_admin_password }}"
       tenant: demo
+    - name: project_admin
+      password: "{{ secrets.project_admin_password }}"
+      tenant: demo
   user_roles:
     - user: admin
       tenant: admin
       role: admin
     - user: admin
-      tenant: admin
-      role: heat_stack_owner
-    - user: admin
       tenant: demo
       role: cloud_admin
-    - user: admin
-      tenant: demo
-      role: heat_stack_owner
     - user: admin
       tenant: service
       role: admin
@@ -372,9 +370,9 @@ keystone:
     - user: cloud_admin
       tenant: demo
       role: cloud_admin
-    - user: cloud_admin
+    - user: project_admin
       tenant: demo
-      role: heat_stack_owner
+      role: project_admin
   services:
     - name: keystone
       type: identity


### PR DESCRIPTION
Reverts blueboxgroup/ursula#1678

The project_admin role is getting created when we are assigning project_admin user a project_admin role. Need to fix this dependency before removing logic to create project_admin user.
 