### PR TITLE
Grant cloud_admin and admin user heat_stack_onwer role

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -326,8 +326,14 @@ keystone:
       tenant: admin
       role: admin
     - user: admin
+      tenant: admin
+      role: heat_stack_owner
+    - user: admin
       tenant: demo
       role: cloud_admin
+    - user: admin
+      tenant: demo
+      role: heat_stack_owner
     - user: admin
       tenant: service
       role: admin
@@ -370,6 +376,9 @@ keystone:
     - user: cloud_admin
       tenant: demo
       role: cloud_admin
+    - user: cloud_admin
+      tenant: demo
+      role: heat_stack_owner
     - user: project_admin
       tenant: demo
       role: project_admin


### PR DESCRIPTION
Enable cloud_admin and admin user to able to deploy heat stack out of the box.