### PR TITLE
Do not create default project_admin user for demo tenant

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -22,7 +22,6 @@ secrets:
   monitor_password: asdf
   telemetry_secret: asdf
   cloud_admin_password: asdf
-  project_admin_password: asdf
 
 fqdn: openstack.example.com
 swift_fqdn: "{{ fqdn }}"
@@ -318,9 +317,6 @@ keystone:
     - name: cloud_admin
       password: "{{ secrets.cloud_admin_password }}"
       tenant: demo
-    - name: project_admin
-      password: "{{ secrets.project_admin_password }}"
-      tenant: demo
   user_roles:
     - user: admin
       tenant: admin
@@ -379,9 +375,6 @@ keystone:
     - user: cloud_admin
       tenant: demo
       role: heat_stack_owner
-    - user: project_admin
-      tenant: demo
-      role: project_admin
   services:
     - name: keystone
       type: identity

--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -20,6 +20,8 @@ keystone:
     - keystone-manage
     - keystone-all
   jellyroll: False # custom middleware for password compliance
+  roles:
+    - project_admin
   logs:
     - paths:
       - /var/log/keystone/keystone-all.log

--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -38,6 +38,12 @@
   with_items: keystone.users
 
 - name: keystone roles
+  keystone_user: role={{ item }}
+                 token={{ admin_token }}
+                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
+  with_items: keystone.roles
+
+- name: keystone user roles
   keystone_user: role={{ item.role }}
                  user={{ item.user }}
                  tenant={{ item.tenant }}


### PR DESCRIPTION
cloud_admin user has enough authority to create a project_admin user for the out of the box "demo" tenant. This PR is removing out the box creation of the project_admin user to ease the customer onboarding.