### PR TITLE
[WIP] Set up host aggregate/AZs based on compute types

### DIFF
--- a/envs/example/ci/group_vars/compute.yml
+++ b/envs/example/ci/group_vars/compute.yml
@@ -1,4 +1,5 @@
 ---
+compute_ag: ci
 logs_to_scan:
 - nova-compute
 - cinder-volume

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -33,6 +33,7 @@ nova:
   block_device_allocate_retries: 200
   block_device_allocate_retries_interval: 3
   heartbeat_timeout_threshold: 30
+  default_availability_zone: nova
   install_packages:
     - python-numpy
     - virt-top

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -20,6 +20,8 @@ enabled_apis = ec2,osapi_compute,metadata
 
 scheduler_default_filters={{ nova.scheduler_default_filters }}
 
+default_availability_zone = {{ nova.default_availability_zone }}
+
 {% if ironic.enabled -%}
 scheduler_host_manager=nova.scheduler.ironic_host_manager.IronicHostManager
 compute_manager=ironic.nova.compute.manager.ClusteredComputeManager

--- a/roles/openstack-setup/tasks/computes.yml
+++ b/roles/openstack-setup/tasks/computes.yml
@@ -1,0 +1,28 @@
+---
+- name: create host aggs
+  os_nova_host_agg:
+    name: "{{ hostvars[item]['compute_ag'] }}"
+    az: "{{ hostvars[item]['compute_ag'] }}"
+    state: present 
+    auth:
+      auth_url: "{{ endpoints.auth_uri }}"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
+  run_once: True
+  when: hostvars[item]['compute_ag'] is defined
+  with_items: "{{ groups['compute'] }}"
+
+- name: assign hosts to aggs
+  os_nova_host_agg_host:
+    name: "{{ hostvars[item]['compute_ag'] }}"
+    host: "{{ hostvars[item]['ansible_nodename'] }}"
+    state: present 
+    auth:
+      auth_url: "{{ endpoints.auth_uri }}"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
+  run_once: True
+  when: hostvars[item]['compute_ag'] is defined
+  with_items: "{{ groups['compute'] }}"

--- a/roles/openstack-setup/tasks/main.yml
+++ b/roles/openstack-setup/tasks/main.yml
@@ -12,3 +12,6 @@
   when: cinder.enabled|default('True')|bool
 
 - include: flavors.yml
+
+- include: computes.yml
+  tags: hostagg

--- a/test/setup
+++ b/test/setup
@@ -62,6 +62,10 @@ cat >> ${ROOT}/envs/test/group_vars/all.yml <<eof
 neutron:
    enable_external_interface: True
 eof
+cat >> ${ROOT}/envs/test/group_vars/all.yml <<eof
+nova:
+   default_availability_zone: ci
+eof
 UNDERCLOUD_CIDR="$(python -c 'import shade; cloud = shade.openstack_cloud(); print cloud.search_subnets("internal")[0]["cidr"]')"
 cat >> ${ROOT}/envs/test/defaults-2.0.yml <<eof
 logging:


### PR DESCRIPTION
Every compute node will define a type, which will be turned into a host
aggregate, that is exposed as an Availability Zone. A default
availability zone will be set based on the type of cluster being
deployed, or default to "nova".