### PR TITLE
fix keystone uwsgi logrotate

### DIFF
--- a/roles/keystone/tasks/logging.yml
+++ b/roles/keystone/tasks/logging.yml
@@ -8,3 +8,4 @@
       - missingok
       - compress
       - minsize 100k
+      - copytruncate


### PR DESCRIPTION
add copytruncate command to log rotation. 

if in the future this turns out to be problematic or undesireable, use https://uwsgi-docs.readthedocs.org/en/latest/MasterFIFO.html instead w/ postrotate