### PR TITLE
Update spec

### DIFF
--- a/roles/nova-data/templates/etc/serverspec/kvm_spec.rb
+++ b/roles/nova-data/templates/etc/serverspec/kvm_spec.rb
@@ -20,7 +20,7 @@ end
 
 describe file('/etc/libvirt/libvirtd.conf') do
   it { should contain "^listen_tls = 0" }
-  it { should contain "^listen_tcp = 1" }
+  it { should_not contain "^listen_tcp = 1" }
 end
 
 describe file('/etc/libvirt/qemu.conf') do


### PR DESCRIPTION
We no longer use tcp for live migration so this option should no longer listen.