### PR TITLE
Add wait_for task for bcache directory to be created

### DIFF
--- a/roles/ceph-osd/tasks/bcache.yml
+++ b/roles/ceph-osd/tasks/bcache.yml
@@ -47,6 +47,11 @@
   with_items: ceph.disks
   when: ok_to_deploy
 
+- name: wait for bcache directories to be created before running next task
+  wait_for: path=/sys/block/bcache{{ item }}
+  with_sequence: start=0 end={{ ceph.disks|length - 1 }}
+  when: ok_to_deploy
+
 - name: set cache mode to writeback
   shell: echo writeback > /sys/block/bcache{{ item }}/bcache/cache_mode
   with_sequence: start=0 end={{ ceph.disks|length - 1 }}


### PR DESCRIPTION
Add wait_for task for bcache directory to be created before running next task. This will ensure /sys/block/bcacheX directory is present before writing into bcache/cache_mode file in that directory.