### PR TITLE
Pin ironic/heat client versions

### DIFF
--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -8,9 +8,9 @@ client:
     - python-novaclient<2.27.0
     - python-neutronclient<4.0.0
     - python-cinderclient
-    - python-heatclient
+    - python-heatclient<0.9.0
     - python-ceilometerclient
-    - python-ironicclient
+    - python-ironicclient<0.9.0
     - python-swiftclient
     - python-magnumclient
   apt_packages:


### PR DESCRIPTION
When both heat client and ironic client are >=0.9.0 they pull in a new nova client which has issues with api version discovery in kilo. 