### PR TITLE
WIP: Extend glance-store http location driver to retain uri  querystring

### DIFF
--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -28,6 +28,7 @@ glance:
       - { name: functools32 }
       - { name: ipaddr }
       - { name: simplegeneric }
+      - { name: "git+https://github.com/blueboxgroup/bbc-openstack-plugins.git#egg=bbc_openstack_plugins" }
     system_dependencies:
       - libxml2-dev
       - libmysqlclient-dev

--- a/roles/glance/templates/etc/glance/glance-api.conf
+++ b/roles/glance/templates/etc/glance/glance-api.conf
@@ -34,7 +34,7 @@ show_multiple_locations = {{ glance.show_multiple_locations }}
       glance.store_swift|bool  %}
 [glance_store]
 stores = glance.store.swift.Store,
-         glance.store.http.Store
+         bbchttp
 default_swift_reference = ref1
 swift_store_config_file = /etc/glance/glance-swift-store.conf
 swift_store_create_container_on_put = True
@@ -48,7 +48,7 @@ show_image_direct_url = True
 
 [glance_store]
 stores = glance.store.rbd.Store,
-         glance.store.http.Store
+         bbchttp
 
 rbd_store_ceph_conf = /etc/ceph/ceph.conf
 rbd_store_chunk_size = {{ glance.rbd_store_chunk_size }}
@@ -59,7 +59,7 @@ default_store = rbd
 {% elif glance.store_smart|bool or glance.store_file|bool %}
 [glance_store]
 stores = glance.store.filesystem.Store,
-         glance.store.http.Store
+         bbchttp
 
 filesystem_store_datadir = {{ glance.state_path }}/images/
 


### PR DESCRIPTION
When using http location where url contains the query string, glance-store http driver is cutting out the querystring when making the request to download the image.

This PR will point glance-store to extended bbchttp driver that will retain the queryparameter.