### PR TITLE
Add a callback to fail on unreachable hosts

### DIFF
--- a/plugins/callbacks/fail_on_unreachable.py
+++ b/plugins/callbacks/fail_on_unreachable.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+# Copyright 2016, IBM
+# Copyright 2016, Jesse Keating <jkeating@j2solutions.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class CallbackModule(object):
+
+    def runner_on_unreachable(self, host, res):
+        # Truncate the play_hosts to an empty set to fail quickly
+        self.play._play_hosts = []


### PR DESCRIPTION
In 1.9, particularly in gather_facts, an unreachable host doesn't count
as a failed host for any_errors_fatal type settings. So this callback
will trigger when a host is unreachable and just truncate the play hosts
to an empty set, which will abort the play on the very next task.