### PR TITLE
Use our fork of neutron

### DIFF
--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -51,7 +51,7 @@ neutron:
   service:
     envs: []
   source:
-    rev: 'stable/kilo'
+    rev: 'kilo-bbg'
     python_dependencies:
       - { name: mysql-python }
       - { name: "git+git://github.com/openstack/neutron-lbaas.git@stable/kilo#egg=neutron-lbaas" }

--- a/roles/neutron-common/meta/main.yml
+++ b/roles/neutron-common/meta/main.yml
@@ -10,6 +10,7 @@ dependencies:
     logdata: "{{ neutron.logs }}"
   - role: openstack-source
     project_name: neutron
+    git_mirror: "https://github.com/blueboxgroup"
     project_rev: "{{ neutron.source.rev }}"
     rootwrap: True
     alternatives: "{{ neutron.alternatives }}"


### PR DESCRIPTION
Which has backported fixes that upstream will not take (due to kilo
being security fixes only now)