### PR TITLE
Install the ceph repo only on x86

### DIFF
--- a/roles/ceph-common/meta/main.yml
+++ b/roles/ceph-common/meta/main.yml
@@ -10,3 +10,4 @@ dependencies:
     repos:
       - repo: 'deb {{ apt_repos.ceph.repo }}{{ ceph.stable_release }}/ {{ ansible_lsb.codename }} main'
         key_url: '{{ apt_repos.ceph.key_url }}'
+    when: ceph.enabled|bool and ansible_architecture != "ppc64le"

--- a/site.yml
+++ b/site.yml
@@ -249,7 +249,7 @@
   roles:
     - role: ceph-compute
       tags: ['ceph', 'ceph-compute']
-      when: ceph.enabled|bool and ansible_architecture != "ppc64le"
+      when: ceph.enabled|bool
   environment: "{{ env_vars|default({}) }}"
 
 - name: neutron control plane


### PR DESCRIPTION
On Power we are able to pull the ceph packages directly from Ubuntu.