### PR TITLE
setting serial for ceph_osd role 

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -165,6 +165,7 @@
 - name: ceph osds
   gather_facts: force
   hosts: ceph_osds
+  serial: 1
   any_errors_fatal: true
   roles:
     - role: ceph-osd


### PR DESCRIPTION
Setting serial: 1 for ceph_osd role to ensure successful deploy of hybrid ceph cluster