### PR TITLE
Horizon config relies on keystone details

### DIFF
--- a/roles/horizon/meta/main.yml
+++ b/roles/horizon/meta/main.yml
@@ -19,3 +19,4 @@ dependencies:
     project_name: horizon
     when: openstack_install_method == 'package'
   - role: apache
+  - role: keystone-defaults


### PR DESCRIPTION
Good thing keystone-defaults is a info only role. Add that dep in.