### PR TITLE
Use individual project symlinks for current

### DIFF
--- a/roles/current_symlink/tasks/main.yml
+++ b/roles/current_symlink/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+- name: discover current link
+  stat:
+    path: /opt/openstack/current
+  register: current
+
+- name: discover packages
+  command: ls
+  args:
+    chdir: /opt/openstack/current
+  register: pkgs
+  when: current.stat.islnk|default(False)
+
+- name: remove current link
+  file:
+    path: /opt/openstack/current
+    state: absent
+  when: current.stat.islnk|default(False)
+
+- name: make current dir
+  file:
+    path: /opt/openstack/current
+    state: directory
+  when: current.stat.islnk|default(False)
+
+- name: make package links
+  file:
+    path: /opt/openstack/current/{{ item }}
+    src: "{{ current.stat.lnk_source }}/{{ item }}"
+    state: link
+  when: current.stat.islnk|default(False)
+  with_items: "{{ pkgs.stdout_lines|default([]) }}"

--- a/roles/openstack-package/tasks/main.yml
+++ b/roles/openstack-package/tasks/main.yml
@@ -5,17 +5,19 @@
   register: project_package
 
 - name: setup openstack current base path
-  file: dest=/opt/openstack state=directory
+  file:
+    dest: /opt/openstack/current
+    state: directory
 
-- name: test whether current {{ project_name }} symlink exists
+- name: test whether current project symlink exists
   stat:
-    path: /opt/openstack/current
+    path: /opt/openstack/current/{{ project_name }}
   register: symlink_exists
 
 - name: setup current symlink
   file:
-    src: "{{ openstack_package.virtualenv_base }}"
-    dest: /opt/openstack/current
+    src: "{{ openstack_package.virtualenv_base }}/{{ project_name }}"
+    dest: /opt/openstack/current/{{ project_name }}
     state: link
   when: not symlink_exists.stat.exists or upgrade | default(false) | bool
 

--- a/roles/openstack-source/tasks/main.yml
+++ b/roles/openstack-source/tasks/main.yml
@@ -56,18 +56,18 @@
 
 - name: setup openstack current base path
   file:
-    dest: /opt/openstack
+    dest: /opt/openstack/current
     state: directory
 
 - name: test whether current project symlink exists
   stat:
-    path: /opt/openstack/current
+    path: /opt/openstack/current/{{ project_name }}
   register: symlink_exists
 
 - name: setup current symlink
   file:
-    src: "{{ openstack_source.virtualenv_base }}"
-    dest: /opt/openstack/current
+    src: "{{ openstack_source.virtualenv_base }}/{{ project_name }}"
+    dest: /opt/openstack/current/{{ project_name }}
     state: link
   when: not symlink_exists.stat.exists or upgrade | default(false) | bool
 

--- a/site.yml
+++ b/site.yml
@@ -173,6 +173,17 @@
   environment: "{{ env_vars|default({}) }}"
 
 # OPENSTACK SERVICES
+# # this next play can go away after 2.1.0+ is everywhere
+- name: deal with current symlink
+  hosts: all
+  any_errors_fatal: true
+  gather_facts: false
+  roles:
+    - role: current_symlink
+      tags:
+        - openstack
+        - symlink
+
 - name: openstack client tools
   hosts: all
   any_errors_fatal: true


### PR DESCRIPTION
This allows having one package updated and restarted without disrupting
other packages while in an upgrade. NOT INTENDED FOR MIXED VERSIONS
OUTSIDE OF UPGRADES!

Also attempts to migrate an existing current symlink into the individual
symlinks based on the current target.