### PR TITLE
Fix rabbitmq serverspec false positive

### DIFF
--- a/roles/rabbitmq/templates/etc/serverspec/rabbitmq_spec.rb
+++ b/roles/rabbitmq/templates/etc/serverspec/rabbitmq_spec.rb
@@ -68,6 +68,6 @@ describe command('rabbitmqctl environment | grep log') do
             "      {ssl_cert_login_from,distinguished_name},\n",
             "          [{backlog,128},\n",
             "     [{http_log_dir,none},\n {sasl,[{errlog_type,error},{sasl_error_logger,false}]},\n"].join()
-  its(:stdout){ should eq output }
+  its(:stdout){ should match (output) }
 end
 


### PR DESCRIPTION
We were getting a false positive because the should match
paradigm uses regular expressions (who would have guessed)
We need it to match the expression exactly, so we threw parens
around the string.