### PR TITLE
Check for serverspec flag in keystone

### DIFF
--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -170,3 +170,4 @@
 - include: serverspec.yml
   tags:
     - serverspec
+  when: serverspec.enabled|default('False')|bool


### PR DESCRIPTION
Don't want to drop a serverspec file for keystone if serverspec is turned off.