### PR TITLE
Remove libvirt-bin from the installed pkgs in ceph-common

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -19,7 +19,6 @@ ceph:
     - python-pycurl
     - ntp
     - hdparm
-    - libvirt-bin
   ceph_pkgs:
     - ceph
     - ceph-common


### PR DESCRIPTION
This package is un-needed on the ceph node and will turn on IP forwarding if it is running.