### PR TITLE
Add neutron to etc alternatives

### DIFF
--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -49,6 +49,7 @@ neutron:
       - neutron-sriov-nic-agent
       - neutron-usage-audit
       - neutron-vpn-agent
+      - neutron
 
   package:
     console_scripts:
@@ -81,6 +82,7 @@ neutron:
       - neutron-sriov-nic-agent
       - neutron-usage-audit
       - neutron-vpn-agent
+      - neutron
 
   logs:
     - paths:


### PR DESCRIPTION
There are 2 lists (?)

This is due to a potential bug with neutron-client not using the venv pip setup in /opt/openstack like everything else