### PR TITLE
No need to specify pid file when using init.d to start rsync

### DIFF
--- a/roles/swift-common/templates/etc/rsyncd.conf
+++ b/roles/swift-common/templates/etc/rsyncd.conf
@@ -1,7 +1,6 @@
 uid = swift
 gid = swift
 log file = /var/log/rsyncd.log
-pid file = /var/run/rsyncd.pid
 address = {{ primary_ip }}
 
 [account]


### PR DESCRIPTION
Per rsync documentation: For pid file, do not use /var/run/rsync.pid if you are going to run rsync out of the init.d script. The init.d script does its own pid file handling, so omit the "pid file" line completely in that case.

