### PR TITLE
No need to specify pid file when using init.d to start rsync (2.0.x)

### DIFF
--- a/roles/swift-common/templates/etc/rsyncd.conf
+++ b/roles/swift-common/templates/etc/rsyncd.conf
@@ -1,7 +1,6 @@
 uid = swift
 gid = swift
 log file = /var/log/rsyncd.log
-pid file = /var/run/rsyncd.pid
 address = {{ primary_ip }}
 
 [account]


### PR DESCRIPTION
(cherry picked from commit b721967347807c813d242479b69213789f23444e)