### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ $ source /usr/local/bin/virtualenvwrapper.sh
 $ mkvirtualenv ursula
 ```
 
+Note: If you're using OSX El Capitan, you need to use ```pip install --ignore-installed six virtualenvwrapper``` to get pip to not attempt to uninstall the existing version of six which the system will not allow.
+
 You will want to add `source /usr/local/bin/virtualenvwrapper.sh` to your shell startup file, changing the path to virtualenvwrapper.sh
 depending on where it was installed by pip.
 


### PR DESCRIPTION
In El-Capitan, installing virtualenvwrapper will attempt to uninstall six and reinstall it which the system will not allow due to System Integrity Protection. Telling pip to ignore six will allow the install to succeed.