### PR TITLE
Fix smt-enabled flag and optimize SMT at runtime

### DIFF
--- a/roles/common/tasks/kernel-tuning.yml
+++ b/roles/common/tasks/kernel-tuning.yml
@@ -47,7 +47,7 @@
 - name: "Kernel boot parameters: disable console screen blanking, enabled serial console on IPMI serial over LAN, optional maxcpus"
   lineinfile: dest=/etc/default/grub
               regexp="^GRUB_CMDLINE_LINUX="
-              line="GRUB_CMDLINE_LINUX=\"consoleblank=0 nmi_watchdog=1 {{ serial_console_cmdline|default('') }} console=tty0 biosdevname=0 {{- ' maxcpus=%s' % cpulimit if cpulimit is defined else '' }} {{- 'smt-enabled=off' if ansible_architecture == 'ppc64le' else '' }} \""
+              line="GRUB_CMDLINE_LINUX=\"consoleblank=0 nmi_watchdog=1 {{ serial_console_cmdline|default('') }} console=tty0 biosdevname=0 {{- ' maxcpus=%s' % cpulimit if cpulimit is defined else '' }} {{- ' smt-enabled=off' if ansible_architecture == 'ppc64le' else '' }} \""
   when: grub_defaults.stat.exists
   notify: update grub config
 

--- a/roles/nova-data/tasks/main.yml
+++ b/roles/nova-data/tasks/main.yml
@@ -39,6 +39,10 @@
   command: "ppc64_cpu --smt=off"
   when: ansible_architecture == "ppc64le" and not smt.stdout|search("SMT is off")
 
+- name: ensure that SMT is off at runtime before we startup libvirt (ppc64)
+  lineinfile: dest=/etc/default/libvirt-bin line="ppc64_cpu --smt=off"
+  when: ansible_architecture == "ppc64le"
+
 - name: enable cinder encryption
   template: src=etc/nova/nova.cinder_encryption.conf dest=/etc/nova/nova.cinder_encryption.conf mode=0640
             owner=root group=nova


### PR DESCRIPTION
First, there should be a space between smt-enabled and any other
kernel parameters. Second, even if this is incorrect, ensure that
we disable SMT at runtime.

Also, needs backport to 2.0.1