### PR TITLE
Restart rsyslog on haproxy install

### DIFF
--- a/roles/haproxy/handlers/main.yml
+++ b/roles/haproxy/handlers/main.yml
@@ -1,3 +1,10 @@
 ---
 - name: reload haproxy
-  service: name=haproxy state=reloaded
+  service:
+    name: haproxy
+    state: reloaded
+
+- name: restart rsyslog
+  service:
+    name: rsyslog
+    state: restarted 

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -4,7 +4,9 @@
   notify: reload haproxy
 
 - name: install haproxy
-  apt: pkg=haproxy
+  apt:
+    pkg: haproxy
+  notify: restart rsyslog 
 
 # WORKAROUND: `service haproxy stop` fails due to incorrect `start-stop-daemon --pid`
 - name: fix haproxy init script


### PR DESCRIPTION
This ensures that haproxy logging goes where the config file it lays
down says to go (/var/log/haproxy.log)