### PR TITLE
2.0.ppc fixes for hwraid and mcelog

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -80,7 +80,7 @@
 - include: disable-swap.yml
 
 - include: hwraid.yml
-  when: common.hwraid.enabled
+  when: common.hwraid.enabled and ansible_architecture != "ppc64le"
   tags: hwraid
 
 - name: remove unwanted packages

--- a/roles/common/tasks/system-tools.yml
+++ b/roles/common/tasks/system-tools.yml
@@ -47,7 +47,7 @@
 
 - name: install mcelog package
   apt: pkg=mcelog
-  when: common.system_tools.mcelog|bool
+  when: common.system_tools.mcelog|bool and ansible_architecture != "ppc64le"
 
 # http://www.supermicro.com/support/faqs/faq.cfm?faq=14537
 - name: blacklist mei


### PR DESCRIPTION
prevent hwraid and mcelog from attempting install on ppc64el arch