### PR TITLE
Gather facts forcefully on openstack-setup

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -402,6 +402,7 @@
 
 - name: openstack base setup
   hosts: controller
+  gather_facts: force
   any_errors_fatal: true
   roles:
     - role: 'openstack-setup'


### PR DESCRIPTION
We need info from every host, for ansible_nodename.