### PR TITLE
Remove un-needed socket require in rabbitmq spec

### DIFF
--- a/roles/rabbitmq/templates/etc/serverspec/rabbitmq_spec.rb
+++ b/roles/rabbitmq/templates/etc/serverspec/rabbitmq_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'socket'
 
 describe user('rabbitmq') do
     it { should exist }


### PR DESCRIPTION
I forgot to remove this last night when I made those one-liner changes.