### PR TITLE
Serialize cinder service (re)starts

### DIFF
--- a/roles/cinder-common/handlers/main.yml
+++ b/roles/cinder-common/handlers/main.yml
@@ -1,12 +1,26 @@
 ---
+# some ugly bit to serialize restarts, and only restart on impacted
+# hosts.
+# This works in ansible 1.9 as play_hosts value is ONLY the hosts that have
+# triggered each particular notification handler. Re-test with 2.0
 - name: restart cinder services
-  service: name={{ item }} state=restarted must_exist=false
+  service:
+    name: "{{ item[1] }}"
+    state: restarted
+    must_exist: false
+  run_once: True
+  delegate_to: "{{ item[0] }}"
   when: restart|default('True')
-  with_items:
-    - cinder-api
-    - cinder-scheduler
-    - cinder-volume
+  with_nested:
+    - "{{ play_hosts }}"
+    - ['cinder-api', 'cinder-scheduler', 'cinder-volume']
 
 - name: restart cinder backup service
-  service: name=cinder-backup state=restarted must_exist=false
+  service:
+    name: cinder-backup
+    state: restarted
+    must_exist: false
+  run_once: True
+  delegate_to: "{{ item }}"
   when: restart|default('True') and swift.enabled|default('False')
+  with_items: "{{ play_hosts }}"

--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -67,11 +67,21 @@
 - meta: flush_handlers
 
 - name: start cinder-volume
-  service: name=cinder-volume state=started
+  service:
+    name: cinder-volume
+    state: started
+  delegate_to: "{{ item }}"
+  run_once: True
+  with_items: "{{ play_hosts }}"
 
 - name: start cinder backup
-  service: name=cinder-backup state=started
+  service:
+    name: cinder-backup
+    state: started
+  delegate_to: "{{ item }}"
+  run_once: True
   when: swift.enabled|default("false")|bool
+  with_items: "{{ play_hosts }}"
 
 - include: monitoring.yml
   when: monitoring.enabled|default('True')|bool


### PR DESCRIPTION
When using a common host name for shared backend scenarios (like ceph),
starting two services at once with the same name can lead to a race
condition. We want to serialize at least the initial start up of the
service, but since that could be via a handler OR the role task we need
to serialize both.