### PR TITLE
Check ceilometer process on controller nodes only

### DIFF
--- a/roles/ceilometer-common/templates/etc/serverspec/ceilometer_spec.rb
+++ b/roles/ceilometer-common/templates/etc/serverspec/ceilometer_spec.rb
@@ -20,6 +20,7 @@ files.each do |file|
   end
 end
 
+{% if inventory_hostname in groups['controller'] %}
 processes = ['ceilometer-api',
   'ceilometer-collector',
   'ceilometer-agent-notification',
@@ -31,6 +32,7 @@ processes.each do |process|
     its(:user) { should eq 'ceilometer' }
   end
 end
+{% endif %}
 
 files = Dir['/var/log/ceilometer/*']
 files.each do |file|


### PR DESCRIPTION
The process checked for by the ceilometer serverspec only exist
on controller nodes. We should only drop those checks on the node
ceilometer role is being run on if it is in the controller group.