### PR TITLE
ceph conf tcp parameter and fstab option

### DIFF
--- a/library/ceph_bcache.py
+++ b/library/ceph_bcache.py
@@ -92,7 +92,7 @@ def main():
         rc, out, err = module.run_command(cmd, check_rc=True)
 
         with open("/etc/fstab", "a") as fstab:
-          fstab.write('UUID=' + uuids_in_order[i] + ' /var/lib/ceph/osd/ceph-' + osd_id + ' xfs defaults 0 0\n')
+          fstab.write('UUID=' + uuids_in_order[i] + ' /var/lib/ceph/osd/ceph-' + osd_id + ' xfs defaults,noatime,largeio,inode64,swalloc 0 0\n')
 
     module.exit_json(changed=changed)
 

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -70,6 +70,9 @@ ceph:
   mon_pg_warn_max_per_osd: 0 # disable complains about low pgs numbers per osd
   mon_osd_allow_primary_affinity: "true"
 
+  # TCP options
+  ms_tcp_rcvbuff: 16777216
+
   # OSD options
   journal_size: 10000 # 10 GB
   pool_name: default

--- a/roles/ceph-common/templates/etc/ceph/ceph.conf
+++ b/roles/ceph-common/templates/etc/ceph/ceph.conf
@@ -20,6 +20,7 @@
   osd pool default size = {{ ceph.pool_default_size }}
   osd pool default min size = {{ ceph.pool_default_min_size }}
   osd pool default crush rule = {{ ceph.pool_default_crush_rule }}
+  ms tcp rcvbuf = {{ ceph.ms_tcp_rcvbuff }}
 {% if groups['ceph_osds'][1] is not defined %}
   osd crush chooseleaf type = 0
 {% endif %}


### PR DESCRIPTION
- /etc/fstab entry matching osd mount options in ceph.conf
- Adding tcp rcvbuff parameter in ceph.conf to resolve performance issues.