### PR TITLE
Run dispersion as part of openstack-setup

### DIFF
--- a/roles/openstack-setup/tasks/dispersion.yml
+++ b/roles/openstack-setup/tasks/dispersion.yml
@@ -1,0 +1,13 @@
+---
+- name: run insecure swift dispersion populate
+  command: swift-dispersion-populate --insecure
+  when: client.self_signed_cert == True
+  run_once: True
+  delegate_to: "{{ groups['swiftnode_primary'][0] }}"
+
+- name: run swift dispersion populate
+  command: swift-dispersion-populate
+  when: client.self_signed_cert == False
+  run_once: True
+  delegate_to: "{{ groups['swiftnode_primary'][0] }}"
+

--- a/roles/openstack-setup/tasks/main.yml
+++ b/roles/openstack-setup/tasks/main.yml
@@ -15,3 +15,7 @@
 
 - include: computes.yml
   tags: hostagg
+
+- include: dispersion.yml
+  when: services_setup.changed and swift.enabled|default('False')|bool
+

--- a/roles/openstack-setup/tasks/users.yml
+++ b/roles/openstack-setup/tasks/users.yml
@@ -14,3 +14,4 @@
   with_items: "{{ keystone.services }}"
   when: "{{item.name}}.enabled is undefined or {{item.name}}.enabled|bool"
   run_once: true
+  register: services_setup

--- a/roles/swift-ring/tasks/main.yml
+++ b/roles/swift-ring/tasks/main.yml
@@ -1,24 +1,6 @@
 ---
-  # swift-dispersion-populate needs to be run only once when rings are copied for first time
-- name: register whether rings are present
-  # ansible command doesn't return the right return code for this
-  shell: /usr/bin/test -f /etc/swift/account.ring.gz || /usr/bin/test -f /etc/swift/container.ring.gz || /usr/bin/test -f /etc/swift/object.ring.gz
-  failed_when: False
-  register: rings_present
-
 - name: drop our ring configuration
   copy: src={{ swift_ring.ring_definition_file }} owner=root group=root
         dest=/etc/swift/ring_definition.yml mode=644 backup=yes
   notify: setup swift rings
-
-- name: make sure rings are built if needed by flushing handlers
-  meta: flush_handlers
-
-- name: run insecure swift dispersion populate
-  command: swift-dispersion-populate --insecure 
-  when: rings_present|failed and client.self_signed_cert == True
-
-- name: run swift dispersion populate
-  command: swift-dispersion-populate
-  when: rings_present|failed and client.self_signed_cert == False
 


### PR DESCRIPTION
Ideally openstack-setup will only be run once. Adding extra guard around dispersion run that it is only run when services are first created