### PR TITLE
Fork and use our nova kilo branch

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -43,7 +43,7 @@ nova:
       git_mirror: https://github.com/stackforge/nova-docker.git
       dest: /opt/stack/novadocker
   source:
-    rev: 'stable/kilo'
+    rev: 'kilo-bbg'
     python_dependencies:
       - { name: mysql-python }
       - { name: python-memcached }

--- a/roles/nova-common/meta/main.yml
+++ b/roles/nova-common/meta/main.yml
@@ -13,6 +13,7 @@ dependencies:
     service: nova
     logdata: "{{ nova.logs }}"
   - role: openstack-source
+    git_mirror: "https://github.com/blueboxgroup"
     project_name: nova
     project_rev: "{{ nova.source.rev }}"
     rootwrap: True


### PR DESCRIPTION
This is needed to fix a nova <-> cinder interaction with availability
zones.