### PR TITLE
Federation: Increase the uWSGI max vars to accomodate the oidc claims

### DIFF
--- a/roles/keystone/templates/etc/apache2/sites-available/keystone.conf
+++ b/roles/keystone/templates/etc/apache2/sites-available/keystone.conf
@@ -50,6 +50,7 @@ Listen {{ endpoints.keystone.port.backend_api }}
     <Location />
         Options FollowSymLinks Indexes
         SetHandler uwsgi-handler
+        uWSGImaxVars 255
         uWSGISocket /run/uwsgi/keystone-admin.socket
     </Location>
     ErrorLog ${APACHE_LOG_DIR}/error.log
@@ -64,6 +65,7 @@ Listen {{ endpoints.keystone.port.backend_api }}
     <Location />
         Options FollowSymLinks Indexes
         SetHandler uwsgi-handler
+        uWSGImaxVars 255
         uWSGISocket /run/uwsgi/keystone-main.socket
     </Location>
     ErrorLog ${APACHE_LOG_DIR}/error.log


### PR DESCRIPTION
The OIDC claims sent from the OP were being truncated. Not all headers were being setup in the context for a request. This caused the SSO to fail.