### PR TITLE
Logrotate changes the permissions on /var/log/wtmp

### DIFF
--- a/roles/common/templates/etc/serverspec/os_spec.rb
+++ b/roles/common/templates/etc/serverspec/os_spec.rb
@@ -107,7 +107,7 @@ files = ['syslog', 'wtmp', 'auth.log']
 files.each do |file|
   describe file ("/var/log/#{file}") do
     it {should exist}
-    it {should be_mode '[0-7][0-5][0-5]'}
+    it {should be_mode '[0-7][0-6][0-5]'}
   end
 end
 


### PR DESCRIPTION
Logrotate is rotating /var/log/wtmp to 664 from what we set it to 755. This serverspec change allows /var/log/wtmp to be 664.