### PR TITLE
Fix OpenID Connect handshake redirection issue

### DIFF
--- a/roles/endpoints/defaults/main.yml
+++ b/roles/endpoints/defaults/main.yml
@@ -83,6 +83,7 @@ endpoints:
       health_check: 'httpchk /'
       balance: 'roundrobin'
       prefer_primary_backend: False
+      oidc_cookie: 'mod_auth_openidc_session prefix'
   keystone_admin:
     port:
       backend_api: 35358

--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -154,11 +154,17 @@ backend {{ name }}
   {% else -%}
   option {{ health_check }}
   {% endif -%}
+
   balance {{ balance }}
   {% for host in groups['controller'] -%}
 
   {% if not prefer_primary_backend or hostvars[host][primary_interface]['ipv4']['address'] == primary_ip -%}
+    {% if  name == "keystone" -%}
+    cookie {{ endpoints.keystone.haproxy.oidc_cookie }}
+    server {{ host }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ clear_port }} cookie check maxconn 40
+    {% else -%}
     server {{ host }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ clear_port }} check maxconn 40
+    {% endif -%}
   {% else -%}
     server {{ host }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ clear_port }} backup check maxconn 40
   {% endif -%}


### PR DESCRIPTION
For the keystone the haproxy is set to the balancing scheme is set to round robin. During the OpenID connect handshake, the OP redirects back to the keystone URI. As the round robin scheme is setup on the haproxy for the keystone endpoint, the redirect may end up on the keystone instance (apache) from which the initial request did not originate. This could end up being redirected indefinitely. The cookie check added with this change makes the haproxy send the keystone redirect from the OP to the correct keystone endpoint. This makes it stick only for the OIDC handshake. API calls continue to be serviced in a round robin fashion.