### PR TITLE
Add logging.follow to defaults-2.0

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -457,6 +457,11 @@ keystone:
   federation:
     enabled: False
 
+logging:
+  follow:
+    global_fields:
+      cluster_name: "example-dev"
+
 ssl:
   crt: |
     -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
While trying to split the roles logging and logging-config
we accidentally broke the allinone build process. This PR
will be a quick fix until we can get a more proper role
separation.