### PR TITLE
Add the audit pyCADF middleware for audit logging

### DIFF
--- a/roles/ceilometer-common/defaults/main.yml
+++ b/roles/ceilometer-common/defaults/main.yml
@@ -66,3 +66,6 @@ ceilometer:
     sensu_checks:
       check_ceilometer_api:
         criticality: 'critical'
+  auditing:
+    enabled: False
+    logging: False

--- a/roles/ceilometer-common/tasks/main.yml
+++ b/roles/ceilometer-common/tasks/main.yml
@@ -22,6 +22,7 @@
     - event_definitions.yaml
     - event_pipeline.yaml
     - pipeline.yaml
+    - ceilometer_api_audit_map.conf
 
 - include: logging.yml
   tags:

--- a/roles/ceilometer-common/templates/etc/ceilometer/api_paste.ini
+++ b/roles/ceilometer-common/templates/etc/ceilometer/api_paste.ini
@@ -5,10 +5,18 @@
 
 # Remove authtoken from the pipeline if you don't want to use keystone authentication
 [pipeline:main]
+{% if ceilometer.auditing.enabled|bool %}
+pipeline = authtoken audit api-server
+{% else %}
 pipeline = authtoken api-server
+{% endif %}
 
 [app:api-server]
 paste.app_factory = ceilometer.api.app:app_factory
 
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+
+[filter:audit]
+paste.filter_factory = keystonemiddleware.audit:filter_factory
+audit_map_file = /etc/ceilometer/ceilometer_api_audit_map.conf

--- a/roles/ceilometer-common/templates/etc/ceilometer/ceilometer.conf
+++ b/roles/ceilometer-common/templates/etc/ceilometer/ceilometer.conf
@@ -1,6 +1,11 @@
 [DEFAULT]
 debug = {{ ceilometer.logging.debug }}
 verbose = {{ ceilometer.logging.verbose }}
+{% if ceilometer.auditing.enabled|bool and ceilometer.auditing.logging|bool %}
+# Store pyCADF audit events in log #
+notification_driver = log
+{% endif %}
+
 log_dir = /var/log/ceilometer
 policy_file = /etc/ceilometer/policy.json
 rpc_backend = ceilometer.openstack.common.rpc.impl_kombu

--- a/roles/ceilometer-common/templates/etc/ceilometer/ceilometer_api_audit_map.conf
+++ b/roles/ceilometer-common/templates/etc/ceilometer/ceilometer_api_audit_map.conf
@@ -1,0 +1,22 @@
+[DEFAULT]
+# default target endpoint type
+# should match the endpoint type defined in service catalog
+target_endpoint_type = None
+
+# possible end path of api requests
+[path_keywords]
+meters = meter_name
+resources = resource_id
+statistics = None
+samples = sample_id
+capabilities = None
+alarms = alarm_id
+history = None
+state = None
+event_types = event_type
+traits = event_type
+events = message_id
+
+# map endpoint type defined in service catalog to CADF typeURI
+[service_endpoints]
+metering = service/metering

--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -64,3 +64,6 @@ cinder:
     sensu_checks:
       check_cinder_services:
         criticality: 'critical'
+  auditing:
+    enabled: False
+    logging: False

--- a/roles/cinder-common/templates/etc/cinder/api-paste.ini
+++ b/roles/cinder-common/templates/etc/cinder/api-paste.ini
@@ -11,14 +11,24 @@ use = call:cinder.api:root_app_factory
 [composite:openstack_volume_api_v1]
 use = call:cinder.api.middleware.auth:pipeline_factory
 noauth = request_id faultwrap sizelimit osprofiler noauth apiv1
+{% if cinder.auditing.enabled|bool %}
+keystone = request_id faultwrap sizelimit osprofiler authtoken keystonecontext audit apiv1
+keystone_nolimit = request_id faultwrap sizelimit osprofiler authtoken keystonecontext audit apiv1
+{% else %}
 keystone = request_id faultwrap sizelimit osprofiler authtoken keystonecontext apiv1
 keystone_nolimit = request_id faultwrap sizelimit osprofiler authtoken keystonecontext apiv1
+{% endif %}
 
 [composite:openstack_volume_api_v2]
 use = call:cinder.api.middleware.auth:pipeline_factory
 noauth = request_id faultwrap sizelimit osprofiler noauth apiv2
+{% if cinder.auditing.enabled|bool %}
+keystone = request_id faultwrap sizelimit osprofiler authtoken keystonecontext audit apiv2
+keystone_nolimit = request_id faultwrap sizelimit osprofiler authtoken keystonecontext audit apiv2
+{% else %}
 keystone = request_id faultwrap sizelimit osprofiler authtoken keystonecontext apiv2
 keystone_nolimit = request_id faultwrap sizelimit osprofiler authtoken keystonecontext apiv2
+{% endif %}
 
 [filter:request_id]
 paste.filter_factory = cinder.openstack.common.middleware.request_id:RequestIdMiddleware.factory
@@ -63,3 +73,7 @@ admin_tenant_name = service
 admin_user = cinder
 admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/cinder/api
+
+[filter:audit]
+paste.filter_factory = keystonemiddleware.audit:filter_factory
+audit_map_file = /etc/cinder/cinder_api_audit_map.conf

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -1,6 +1,10 @@
 [DEFAULT]
 debug = {{ cinder.logging.debug }}
 verbose = {{ cinder.logging.verbose }}
+{% if cinder.auditing.enabled|bool and cinder.auditing.logging|bool %}
+# Store pyCADF audit events in log #
+notification_driver = log
+{% endif %}
 
 osapi_volume_workers = {{ cinder.api_workers }}
 osapi_volume_listen_port={{ endpoints.cinder.port.backend_api }}

--- a/roles/cinder-common/templates/etc/cinder/cinder_api_audit_map.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder_api_audit_map.conf
@@ -1,0 +1,27 @@
+[DEFAULT]
+# default target endpoint type
+# should match the endpoint type defined in service catalog
+target_endpoint_type = None
+
+# map urls ending with specific text to a unique action
+[custom_actions]
+associate = update/associate
+disassociate = update/disassociate
+disassociate_all = update/disassociate_all
+associations = read/list/associations
+
+# possible end path of api requests
+[path_keywords]
+defaults = None
+detail = None
+limits = None
+os-quota-specs = project
+qos-specs = qos-spec
+snapshots = snapshot
+types = type
+volumes = volume
+
+# map endpoint type defined in service catalog to CADF typeURI
+[service_endpoints]
+volume = service/storage/block
+volumev2 = service/storage/block

--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -69,3 +69,6 @@ glance:
         criticality: 'critical'
       check_glance_store:
         criticality: 'critical'
+  auditing:
+    enabled: False
+    logging: False

--- a/roles/glance/templates/etc/glance/glance-api-paste.ini
+++ b/roles/glance/templates/etc/glance/glance-api-paste.ini
@@ -12,15 +12,27 @@ pipeline = versionnegotiation osprofiler unauthenticated-context cache cachemana
 
 # Use this pipeline for keystone auth
 [pipeline:glance-api-keystone]
+{% if glance.auditing.enabled|bool %}
+pipeline = versionnegotiation osprofiler authtoken audit context rootapp
+{% else %}
 pipeline = versionnegotiation osprofiler authtoken context rootapp
+{% endif %}
 
 # Use this pipeline for keystone auth with image caching
 [pipeline:glance-api-keystone+caching]
+{% if glance.auditing.enabled|bool %}
+pipeline = versionnegotiation osprofiler authtoken audit context cache rootapp
+{% else %}
 pipeline = versionnegotiation osprofiler authtoken context cache rootapp
+{% endif %}
 
-# Use this pipeline for keystone auth with caching and cache management
+# Use this pipeline for keystone auth with caching audit and cache management
 [pipeline:glance-api-keystone+cachemanagement]
+{% if glance.auditing.enabled|bool %}
+pipeline = versionnegotiation osprofiler authtoken audit context cache cachemanage rootapp
+{% else %}
 pipeline = versionnegotiation osprofiler authtoken context cache cachemanage rootapp
+{% endif %}
 
 # Use this pipeline for authZ only. This means that the registry will treat a
 # user as authenticated without making requests to keystone to reauthenticate
@@ -67,6 +79,10 @@ paste.filter_factory = glance.api.middleware.context:UnauthenticatedContextMiddl
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory
 delay_auth_decision = true
+
+[filter:audit]
+paste.filter_factory = keystonemiddleware.audit:filter_factory
+audit_map_file = /etc/glance/glance_api_audit_map.conf
 
 [filter:gzip]
 paste.filter_factory = glance.api.middleware.gzip:GzipMiddleware.factory

--- a/roles/glance/templates/etc/glance/glance-api.conf
+++ b/roles/glance/templates/etc/glance/glance-api.conf
@@ -1,6 +1,10 @@
 [DEFAULT]
 debug = {{ glance.logging.debug }}
 verbose = {{ glance.logging.verbose }}
+{% if glance.auditing.enabled|bool and glance.auditing.logging|bool %}
+# Store pyCADF audit events in log #
+notification_driver = log
+{% endif %}
 
 bind_host = 0.0.0.0
 bind_port = {{ endpoints.glance.port.backend_api }}

--- a/roles/glance/templates/etc/glance/glance_api_audit_map.conf
+++ b/roles/glance/templates/etc/glance/glance_api_audit_map.conf
@@ -1,0 +1,16 @@
+[DEFAULT]
+# default target endpoint type
+# should match the endpoint type defined in service catalog
+target_endpoint_type = None
+
+# possible end path of api requests
+[path_keywords]
+detail = None
+file = None
+images = image
+members = member
+tags = tag
+
+# map endpoint type defined in service catalog to CADF typeURI
+[service_endpoints]
+image = service/storage/image

--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -47,3 +47,6 @@ heat:
     sensu_checks:
       check_heat_api:
         criticality: 'critical'
+  auditing:
+    enabled: False
+    logging: False

--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -36,6 +36,7 @@
     - heat.conf
     - policy.json
     - api-paste.ini
+    - heat_api_audit_map.conf
   notify:
     - restart heat services
 

--- a/roles/heat/templates/etc/heat/api-paste.ini
+++ b/roles/heat/templates/etc/heat/api-paste.ini
@@ -1,7 +1,11 @@
 
 # heat-api pipeline
 [pipeline:heat-api]
+{% if heat.auditing.enabled|bool %}
+pipeline = request_id faultwrap ssl versionnegotiation authurl authtoken audit context apiv1app
+{% else %}
 pipeline = request_id faultwrap ssl versionnegotiation authurl authtoken context apiv1app
+{% endif %}
 
 # heat-api pipeline for standalone heat
 # ie. uses alternative auth backend that authenticates users against keystone
@@ -24,7 +28,11 @@ pipeline = request_id faultwrap versionnegotiation context custombackendauth api
 
 # heat-api-cfn pipeline
 [pipeline:heat-api-cfn]
+{% if heat.auditing.enabled|bool %}
+pipeline = cfnversionnegotiation ec2authtoken authtoken audit context apicfnv1app
+{% else %}
 pipeline = cfnversionnegotiation ec2authtoken authtoken context apicfnv1app
+{% endif %}
 
 # heat-api-cfn pipeline for standalone heat
 # relies exclusively on authenticating with ec2 signed requests
@@ -33,7 +41,11 @@ pipeline = cfnversionnegotiation ec2authtoken context apicfnv1app
 
 # heat-api-cloudwatch pipeline
 [pipeline:heat-api-cloudwatch]
+{% if heat.auditing.enabled|bool %}
+pipeline = versionnegotiation ec2authtoken authtoken audit context apicwapp
+{% else %}
 pipeline = versionnegotiation ec2authtoken authtoken context apicwapp
+{% endif %}
 
 # heat-api-cloudwatch pipeline for standalone heat
 # relies exclusively on authenticating with ec2 signed requests
@@ -85,6 +97,10 @@ paste.filter_factory = heat.common.auth_url:filter_factory
 # Auth middleware that validates token against keystone
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+
+[filter:audit]
+paste.filter_factory = keystonemiddleware.audit:filter_factory
+audit_map_file = /etc/heat/heat_api_audit_map.conf
 
 # Auth middleware that validates username/password against keystone
 [filter:authpassword]

--- a/roles/heat/templates/etc/heat/heat.conf
+++ b/roles/heat/templates/etc/heat/heat.conf
@@ -1,6 +1,10 @@
 [DEFAULT]
 debug = {{ heat.logging.debug }}
 verbose = {{ heat.logging.verbose }}
+{% if heat.auditing.enabled|bool and heat.auditing.logging|bool %}
+# Store pyCADF audit events in log #
+notification_driver = log
+{% endif %}
 
 log_dir = /var/log/heat
 
@@ -84,4 +88,3 @@ rabbit_port = 5672
 {% endif -%}
 rabbit_userid = {{ rabbitmq.user }}
 rabbit_password = {{ secrets.rabbit_password }}
-

--- a/roles/heat/templates/etc/heat/heat_api_audit_map.conf
+++ b/roles/heat/templates/etc/heat/heat_api_audit_map.conf
@@ -1,0 +1,32 @@
+[DEFAULT]
+# default target endpoint type
+# should match the endpoint type defined in service catalog
+target_endpoint_type = None
+
+# possible end path of api requests
+[path_keywords]
+stacks = stack
+resources = resource
+preview = None
+detail = None
+abandon = None
+snapshots = snapshot
+restore = None
+outputs = output
+metadata = server
+signal = None
+events = event
+template = None
+template_versions = template_version
+functions = None
+validate = None
+resource_types = resource_type
+build_info = None
+actions = None
+software_configs = software_config
+software_deployments = software_deployment
+services = None
+
+# map endpoint type defined in service catalog to CADF typeURI
+[service_endpoints]
+orchestration = service/orchestration

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -131,3 +131,6 @@ neutron:
         criticality: 'critical'
       check_neutron_agents_duplicate:
         criticality: 'critical'
+  auditing:
+    enabled: False
+    logging: False

--- a/roles/neutron-common/templates/etc/neutron/api-paste.ini
+++ b/roles/neutron-common/templates/etc/neutron/api-paste.ini
@@ -6,7 +6,11 @@ use = egg:Paste#urlmap
 [composite:neutronapi_v2_0]
 use = call:neutron.auth:pipeline_factory
 noauth = request_id catch_errors extensions neutronapiapp_v2_0
+{% if neutron.auditing.enabled|bool %}
+keystone = request_id catch_errors authtoken keystonecontext audit extensions neutronapiapp_v2_0
+{% else %}
 keystone = request_id catch_errors authtoken keystonecontext extensions neutronapiapp_v2_0
+{% endif %}
 
 [filter:request_id]
 paste.filter_factory = neutron.openstack.common.middleware.request_id:RequestIdMiddleware.factory
@@ -24,6 +28,10 @@ admin_tenant_name = service
 admin_user = neutron
 admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/neutron/api
+
+[filter:audit]
+paste.filter_factory = keystonemiddleware.audit:filter_factory
+audit_map_file = /etc/neutron/neutron_api_audit_map.conf
 
 [filter:extensions]
 paste.filter_factory = neutron.api.extensions:plugin_aware_extension_middleware_factory

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -1,6 +1,10 @@
 [DEFAULT]
 debug = {{ neutron.logging.debug }}
 verbose = {{ neutron.logging.verbose }}
+{% if neutron.auditing.enabled|bool and neutron.auditing.logging|bool %}
+# Store pyCADF audit events in log #
+notification_driver = log
+{% endif %}
 
 # Logging #
 log_dir = /var/log/neutron
@@ -104,4 +108,3 @@ rabbit_port = 5672
 rabbit_userid = {{ rabbitmq.user }}
 rabbit_password = {{ secrets.rabbit_password }}
 rpc_backend = neutron.openstack.common.rpc.impl_kombu
-

--- a/roles/neutron-common/templates/etc/neutron/neutron_api_audit_map.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron_api_audit_map.conf
@@ -1,0 +1,31 @@
+[DEFAULT]
+# default target endpoint type
+# should match the endpoint type defined in service catalog
+target_endpoint_type = None
+
+[custom_actions]
+add_router_interface = update/add
+remove_router_interface = update/remove
+
+# possible end path of api requests
+[path_keywords]
+floatingips = ip
+healthmonitors = healthmonitor
+health_monitors = health_monitor
+lb = None
+members = member
+metering-labels = label
+metering-label-rules = rule
+networks = network
+pools = pool
+ports = port
+routers = router
+quotas = quota
+security-groups = security-group
+security-group-rules = rule
+subnets = subnet
+vips = vip
+
+# map endpoint type defined in service catalog to CADF typeURI
+[service_endpoints]
+network = service/network

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -128,3 +128,6 @@ nova:
         criticality: 'critical'
       check_nova_services:
         criticality: 'critical'
+  auditing:
+    enabled: False
+    logging: False

--- a/roles/nova-common/templates/etc/nova/api-paste.ini
+++ b/roles/nova-common/templates/etc/nova/api-paste.ini
@@ -66,18 +66,31 @@ use = call:nova.api.openstack.urlmap:urlmap_factory
 [composite:openstack_compute_api_v2]
 use = call:nova.api.auth:pipeline_factory
 noauth = compute_req_id faultwrap sizelimit noauth ratelimit osapi_compute_app_v2
+{% if nova.auditing.enabled|bool %}
+keystone = compute_req_id faultwrap sizelimit authtoken keystonecontext audit ratelimit osapi_compute_app_v2
+keystone_nolimit = compute_req_id faultwrap sizelimit authtoken keystonecontext audit osapi_compute_app_v2
+{% else %}
 keystone = compute_req_id faultwrap sizelimit authtoken keystonecontext ratelimit osapi_compute_app_v2
 keystone_nolimit = compute_req_id faultwrap sizelimit authtoken keystonecontext osapi_compute_app_v2
+{% endif %}
 
 [composite:openstack_compute_api_v21]
 use = call:nova.api.auth:pipeline_factory_v21
 noauth = request_id faultwrap sizelimit noauth osapi_compute_app_v21
+{% if nova.auditing.enabled|bool %}
+keystone = request_id faultwrap sizelimit authtoken keystonecontext audit osapi_compute_app_v21
+{% else %}
 keystone = request_id faultwrap sizelimit authtoken keystonecontext osapi_compute_app_v21
+{% endif %}
 
 [composite:openstack_compute_api_v3]
 use = call:nova.api.auth:pipeline_factory_v21
 noauth = request_id faultwrap sizelimit noauth_v3 osapi_compute_app_v3
+{% if nova.auditing.enabled|bool %}
+keystone = request_id faultwrap sizelimit authtoken keystonecontext audit osapi_compute_app_v3
+{% else %}
 keystone = request_id faultwrap sizelimit authtoken keystonecontext osapi_compute_app_v3
+{% endif %}
 
 [filter:request_id]
 paste.filter_factory = nova.openstack.common.middleware.request_id:RequestIdMiddleware.factory
@@ -129,3 +142,7 @@ admin_password = {{ secrets.service_password }}
 admin_tenant_name = service
 admin_user = nova
 signing_dir = /var/cache/nova/api
+
+[filter:audit]
+paste.filter_factory = keystonemiddleware.audit:filter_factory
+audit_map_file = /etc/nova/nova_api_audit_map.conf

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -1,6 +1,10 @@
 [DEFAULT]
 debug = {{ nova.logging.debug }}
 verbose = {{ nova.logging.verbose }}
+{% if nova.auditing.enabled|bool and nova.auditing.logging|bool %}
+# Store pyCADF audit events in log #
+notification_driver = log
+{% endif %}
 
 osapi_compute_listen_port={{ endpoints.nova.port.backend_api }}
 

--- a/roles/nova-common/templates/etc/nova/nova_api_audit_map.conf
+++ b/roles/nova-common/templates/etc/nova/nova_api_audit_map.conf
@@ -1,0 +1,71 @@
+[DEFAULT]
+# default target endpoint type
+# should match the endpoint type defined in service catalog
+target_endpoint_type = None
+
+[custom_actions]
+enable = enable
+disable = disable
+delete = delete
+startup = start/startup
+shutdown = stop/shutdown
+reboot = start/reboot
+os-migrations/get = read
+os-server-password/post = update
+
+# possible end path of api requests
+[path_keywords]
+add = None
+action = None
+enable = None
+disable = None
+configure-project = None
+defaults = None
+delete = None
+detail = None
+diagnostics = None
+entries = entry
+extensions = alias
+flavors = flavor
+images = image
+ips = label
+limits = None
+metadata = key
+os-agents = os-agent
+os-aggregates = os-aggregate
+os-availability-zone = None
+os-certificates = None
+os-cloudpipe = None
+os-fixed-ips = ip
+os-extra_specs = key
+os-flavor-access = None
+os-floating-ip-dns = domain
+os-floating-ips-bulk = host
+os-floating-ip-pools = None
+os-floating-ips = floating-ip
+os-hosts = host
+os-hypervisors = hypervisor
+os-instance-actions = instance-action
+os-keypairs = keypair
+os-migrations = None
+os-networks = network
+os-quota-sets = tenant
+os-security-groups = security_group
+os-security-group-rules = rule
+os-server-password = None
+os-services = None
+os-simple-tenant-usage = tenant
+os-virtual-interfaces = None
+os-volume_attachments = attachment
+os-volumes = volume
+os-volume-types = volume-type
+os-snapshots = snapshot
+reboot = None
+servers = server
+shutdown = None
+startup = None
+statistics = None
+
+# map endpoint type defined in service catalog to CADF typeURI
+[service_endpoints]
+compute = service/compute


### PR DESCRIPTION
The pyCADF middleware will be enabled by default to have audit events logged
in the API logs for the following services:
    ceilometer, cinder, glance, heat, neutron, and nova