### PR TITLE
Use private IPs only for CI

### DIFF
--- a/playbooks/ci-full/tasks/create.yml
+++ b/playbooks/ci-full/tasks/create.yml
@@ -39,6 +39,7 @@
           - net-name: internal
         auto_floating_ip: false
       with_items: "{{ testenv_instance_names }}"
+      register: instances
 
     - name: associate a floating IP to instances
       os_floating_ip:
@@ -48,11 +49,22 @@
         wait: true
       with_items: "{{ testenv_instance_names }}"
       register: testenv_floating_ips
+      when: not use_private_ips|default('False')|bool
 
-    - name: wait for instances to boot
+    - name: wait for instances to boot using public ip
       wait_for:
         port: 22
         delay: 5
         timeout: 600
         host: "{{ item.floating_ip.floating_ip_address }}"
       with_items: "{{ testenv_floating_ips.results }}"
+      when: not use_private_ips|default('False')|bool
+
+    - name: wait for instances to boot using private ip
+      wait_for:
+        port: 22
+        delay: 5
+        timeout: 600
+        host: "{{ item.openstack.addresses.internal.0.addr }}"
+      with_items: "{{ instances.results }}"
+      when: use_private_ips|default('False')|bool

--- a/test/setup
+++ b/test/setup
@@ -4,6 +4,7 @@
 # to allow concurrent runs.
 if [[ "$CI" == "jenkins" ]]; then
     VENV=$WORKSPACE/venv
+    USE_PRIVATE_IPS="true"
     virtualenv $VENV
     source $VENV/bin/activate
     pip install -U pip
@@ -11,6 +12,8 @@ if [[ "$CI" == "jenkins" ]]; then
 fi
 
 source $(dirname $0)/common
+
+USE_PRIVATE_IPS=${USE_PRIVATE_IPS:-"false"}
 
 ${ROOT}/test/check-deps
 
@@ -33,7 +36,7 @@ echo "destroying: ${VMS}"
 ${ROOT}/test/cleanup
 
 echo "booting ${VMS}"
-ursula "envs/test" ${ROOT}/playbooks/${TEST_ENV}/tasks/create.yml
+ursula "envs/test" ${ROOT}/playbooks/${TEST_ENV}/tasks/create.yml --extra-vars="use_private_ips=${USE_PRIVATE_IPS}"
 
 echo "building config"
 CONTROLLER_IP=$(private_ip ${testenv_instance_prefix}-controller-0)
@@ -83,37 +86,43 @@ rm -rf ${CERT_DIR}
 
 echo "writing inventory file"
 if [[ ${TEST_ENV} == "ci-full" ]]; then
+  shopt -s expand_aliases
   CONTROLLER_IP=$(private_ip ${testenv_instance_prefix}-controller-0)
+  if [[ ${USE_PRIVATE_IPS} == "true" ]]; then
+    alias get_ip=private_ip
+  else
+    alias get_ip=public_ip
+  fi
   cat > ${ROOT}/envs/test/hosts <<eof
 [db]
-$(public_ip "${testenv_instance_prefix}-controller-0")
-$(public_ip "${testenv_instance_prefix}-controller-1")
+$(get_ip "${testenv_instance_prefix}-controller-0")
+$(get_ip "${testenv_instance_prefix}-controller-1")
 
 [db_arbiter]
-$(public_ip "${testenv_instance_prefix}-compute-0")
+$(get_ip "${testenv_instance_prefix}-compute-0")
 
 [mongo_db]
-$(public_ip "${testenv_instance_prefix}-controller-0")
-$(public_ip "${testenv_instance_prefix}-controller-1")
+$(get_ip "${testenv_instance_prefix}-controller-0")
+$(get_ip "${testenv_instance_prefix}-controller-1")
 
 [mongo_arbiter]
-$(public_ip "${testenv_instance_prefix}-compute-0")
+$(get_ip "${testenv_instance_prefix}-compute-0")
 
 [controller]
-$(public_ip "${testenv_instance_prefix}-controller-0")
-$(public_ip "${testenv_instance_prefix}-controller-1")
+$(get_ip "${testenv_instance_prefix}-controller-0")
+$(get_ip "${testenv_instance_prefix}-controller-1")
 
 [compute]
-$(public_ip "${testenv_instance_prefix}-compute-0")
-$(public_ip "${testenv_instance_prefix}-controller-0")
-$(public_ip "${testenv_instance_prefix}-controller-1")
+$(get_ip "${testenv_instance_prefix}-compute-0")
+$(get_ip "${testenv_instance_prefix}-controller-0")
+$(get_ip "${testenv_instance_prefix}-controller-1")
 
 [network]
-$(public_ip "${testenv_instance_prefix}-controller-0")
-$(public_ip "${testenv_instance_prefix}-controller-1")
+$(get_ip "${testenv_instance_prefix}-controller-0")
+$(get_ip "${testenv_instance_prefix}-controller-1")
 
 [cinder_volume]
-$(public_ip "${testenv_instance_prefix}-compute-0")
+$(get_ip "${testenv_instance_prefix}-compute-0")
 eof
 else
   CONTROLLER_IP=$(private_ip ${testenv_instance_prefix}-allinone)


### PR DESCRIPTION
Because the test VMs share a private subnet with the Jenkins server, we
do not need to access them using public IP addresses.