### PR TITLE
Use keystone-manage to bootstrap a cloud

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -376,12 +376,6 @@ keystone:
       tenant: demo
       role: heat_stack_owner
   services:
-    - name: keystone
-      type: identity
-      description: 'Identity Service'
-      public_url: "{{ endpoints.keystone.url.public }}/{{ endpoints.keystone.version }}"
-      internal_url: "{{ endpoints.keystone.url.internal }}/{{ endpoints.keystone.version }}"
-      admin_url: "{{ endpoints.keystone.url.admin }}/{{ endpoints.keystone.version }}"
     - name: keystonev3
       type: identityv3
       description: 'Identity Service v3'

--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -78,3 +78,9 @@ keystone:
               any_one_of: ['user@someprovider.com']
     protocols:
       - { name: oidc, mapping: someprovider-admins, identity_provider: someprovider }
+
+  bootstrap:
+    user: admin
+    password: "{{ secrets.admin_password }}"
+    project: admin
+    role: admin

--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: keystone tenants
   keystone_user: tenant={{ item }}
                  tenant_description="{{ item }} tenant"
-                 auth_url="http://127.0.0.1:5002"
+                 endpoint="http://127.0.0.1:5002"
                  login_tenant_name=admin
                  login_username=admin
                  login_password={{ secrets.admin_password }}
@@ -34,7 +34,7 @@
   keystone_user: user={{ item.name }}
                  password={{ item.password }}
                  tenant={{ item.tenant }}
-                 auth_url="http://127.0.0.1:5002"
+                 endpoint="http://127.0.0.1:5002"
                  login_tenant_name=admin
                  login_username=admin
                  login_password={{ secrets.admin_password }}
@@ -42,7 +42,7 @@
 
 - name: keystone roles
   keystone_user: role={{ item }}
-                 auth_url="http://127.0.0.1:5002"
+                 endpoint="http://127.0.0.1:5002"
                  login_tenant_name=admin
                  login_username=admin
                  login_password={{ secrets.admin_password }}
@@ -52,7 +52,7 @@
   keystone_user: role={{ item.role }}
                  user={{ item.user }}
                  tenant={{ item.tenant }}
-                 auth_url="http://127.0.0.1:5002"
+                 endpoint="http://127.0.0.1:5002"
                  login_tenant_name=admin
                  login_username=admin
                  login_password={{ secrets.admin_password }}
@@ -62,7 +62,7 @@
   keystone_user: user=heat_stack_user
                  password="{{ secrets.service_password }}"
                  tenant=admin
-                 auth_url="http://127.0.0.1:5002"
+                 endpoint="http://127.0.0.1:5002"
                  login_tenant_name=admin
                  login_username=admin
                  login_password={{ secrets.admin_password }}
@@ -72,7 +72,7 @@
   keystone_user: role=heat_stack_user
                  user=heat_stack_user
                  tenant=admin
-                 auth_url="http://127.0.0.1:5002"
+                 endpoint="http://127.0.0.1:5002"
                  login_tenant_name=admin
                  login_username=admin
                  login_password={{ secrets.admin_password }}

--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: keystone tenants
   keystone_user: tenant={{ item }}
                  tenant_description="{{ item }} tenant"
-                 auth_url={{ endpoints.auth_uri }}
+                 auth_url="http://127.0.0.1:5002"
                  login_tenant_name=admin
                  login_username=admin
                  login_password={{ secrets.admin_password }}
@@ -34,7 +34,7 @@
   keystone_user: user={{ item.name }}
                  password={{ item.password }}
                  tenant={{ item.tenant }}
-                 auth_url={{ endpoints.auth_uri }}
+                 auth_url="http://127.0.0.1:5002"
                  login_tenant_name=admin
                  login_username=admin
                  login_password={{ secrets.admin_password }}
@@ -42,7 +42,7 @@
 
 - name: keystone roles
   keystone_user: role={{ item }}
-                 auth_url={{ endpoints.auth_uri }}
+                 auth_url="http://127.0.0.1:5002"
                  login_tenant_name=admin
                  login_username=admin
                  login_password={{ secrets.admin_password }}
@@ -52,7 +52,7 @@
   keystone_user: role={{ item.role }}
                  user={{ item.user }}
                  tenant={{ item.tenant }}
-                 auth_url={{ endpoints.auth_uri }}
+                 auth_url="http://127.0.0.1:5002"
                  login_tenant_name=admin
                  login_username=admin
                  login_password={{ secrets.admin_password }}
@@ -62,7 +62,7 @@
   keystone_user: user=heat_stack_user
                  password="{{ secrets.service_password }}"
                  tenant=admin
-                 auth_url={{ endpoints.auth_uri }}
+                 auth_url="http://127.0.0.1:5002"
                  login_tenant_name=admin
                  login_username=admin
                  login_password={{ secrets.admin_password }}
@@ -72,7 +72,7 @@
   keystone_user: role=heat_stack_user
                  user=heat_stack_user
                  tenant=admin
-                 auth_url={{ endpoints.auth_uri }}
+                 auth_url="http://127.0.0.1:5002"
                  login_tenant_name=admin
                  login_username=admin
                  login_password={{ secrets.admin_password }}

--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -6,16 +6,16 @@
     OS_BOOTSTRAP_PASSWORD: "{{ keystone.bootstrap.password }}"
     OS_BOOTSTRAP_PROJECT_NAME: "{{ keystone.bootstrap.project }}"
     OS_BOOTSTRAP_ROLE_NAME: "{{ keystone.bootstrap.role }}"
-    OS_BOOTSTRAP_ADMIN_URL: "{{ endpoints.keystone.url.admin }}"
-    OS_BOOTSTRAP_INTERNAL_URL: "{{ endpoints.keystone.url.internal }}"
-    OS_BOOTSTRAP_PUBLIC_URL: "{{ endpoints.keystone.url.public }}"
+    OS_BOOTSTRAP_ADMIN_URL: "{{ endpoints.keystone.url.admin }}/{{ endpoints.keystone.version }}"
+    OS_BOOTSTRAP_INTERNAL_URL: "{{ endpoints.keystone.url.internal }}/{{ endpoints.keystone.version }}"
+    OS_BOOTSTRAP_PUBLIC_URL: "{{ endpoints.keystone.url.public }}/{{ endpoints.keystone.version }}"
     OS_BOOTSTRAP_SERVICE_NAME: "{{ 'keystone' }}"  # otherwise it uses the keystone variable
     OS_BOOTSTRAP_REGION_ID: "RegionOne"
 
 - name: keystone tenants
   keystone_user: tenant={{ item }}
                  tenant_description="{{ item }} tenant"
-                 endpoint=http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v2.0
+                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
                  login_tenant_name={{ keystone.bootstrap.project }}
                  login_user={{ keystone.bootstrap.user }}
                  login_password={{ secrets.admin_password }}
@@ -25,7 +25,7 @@
   keystone_user: user={{ item.name }}
                  password={{ item.password }}
                  tenant={{ item.tenant }}
-                 endpoint=http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v2.0
+                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
                  login_tenant_name={{ keystone.bootstrap.project }}
                  login_user={{ keystone.bootstrap.user }}
                  login_password={{ secrets.admin_password }}
@@ -33,7 +33,7 @@
 
 - name: keystone roles
   keystone_user: role={{ item }}
-                 endpoint=http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v2.0
+                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
                  login_tenant_name={{ keystone.bootstrap.project }}
                  login_user={{ keystone.bootstrap.user }}
                  login_password={{ secrets.admin_password }}
@@ -43,7 +43,7 @@
   keystone_user: role={{ item.role }}
                  user={{ item.user }}
                  tenant={{ item.tenant }}
-                 endpoint=http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v2.0
+                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
                  login_tenant_name={{ keystone.bootstrap.project }}
                  login_user={{ keystone.bootstrap.user }}
                  login_password={{ secrets.admin_password }}
@@ -53,7 +53,7 @@
   keystone_user: user=heat_stack_user
                  password={{ secrets.service_password }}
                  tenant=admin
-                 endpoint=http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v2.0
+                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
                  login_tenant_name={{ keystone.bootstrap.project }}
                  login_user={{ keystone.bootstrap.user }}
                  login_password={{ secrets.admin_password }}
@@ -63,7 +63,7 @@
   keystone_user: role=heat_stack_user
                  user=heat_stack_user
                  tenant=admin
-                 endpoint=http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v2.0
+                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
                  login_tenant_name={{ keystone.bootstrap.project }}
                  login_user={{ keystone.bootstrap.user }}
                  login_password={{ secrets.admin_password }}

--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -1,13 +1,4 @@
 ---
-- name: discover keystone setup status
-  command: mysql --batch --silent keystone -e "select type from service where type = 'compute'"
-  failed_when: false
-  register: keystone_setup
-
-- name: set keystone_configured fact
-  set_fact: keystone_configured=True
-  when: keystone_setup.stdout|search("compute")
-
 - name: keystone bootstrap user
   command: keystone-manage bootstrap
   environment:

--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -1,99 +1,82 @@
 ---
-- name: generate admin_token
-  set_fact: admin_token="{{ 'asdf' * 9|random(start=2) }}"
-            insert_token=True
+- name: discover keystone setup status
+  command: mysql --batch --silent keystone -e "select type from service where type = 'compute'"
+  failed_when: false
+  register: keystone_setup
 
-- name: add admin_token to keystone conf
-  lineinfile: dest=/etc/keystone/keystone.conf
-              line="admin_token = {{ admin_token }}"
-              regexp="^admin_token"
-              insertafter='\[DEFAULT\]'
-              state=present
+- name: set keystone_configured fact
+  set_fact: keystone_configured=True
+  when: keystone_setup.stdout|search("compute")
 
-- name: add admin_token_auth to keystone pipeline
-  template: dest=/etc/keystone/keystone-paste.ini
-            src='{{ role_path }}/../keystone/templates/etc/keystone/keystone-paste.ini'
-
-- name: restart keystone api
-  service: name=keystone state=restarted
-
-- name: wait for keystone to be functional
-  pause: seconds=3
-  # this could wait for a service uri to be up, but a 3 second sleep
-  # works fine. Service uri may need auth to validate.
+- name: keystone bootstrap user
+  command: keystone-manage bootstrap
+  environment:
+    OS_BOOTSTRAP_USERNAME: "{{ keystone.bootstrap.user }}"
+    OS_BOOTSTRAP_PASSWORD: "{{ keystone.bootstrap.password }}"
+    OS_BOOTSTRAP_PROJECT_NAME: "{{ keystone.bootstrap.project }}"
+    OS_BOOTSTRAP_ROLE_NAME: "{{ keystone.bootstrap.role }}"
+    OS_BOOTSTRAP_ADMIN_URL: "{{ endpoints.keystone.url.public }}"
+    OS_BOOTSTRAP_INTERNAL_URL: "{{ endpoints.keystone.url.internal }}"
+    OS_BOOTSTRAP_PUBLIC_URL: "{{ endpoints.keystone.url.public }}"
+    OS_BOOTSTRAP_SERVICE_NAME: "keystone"
+    OS_BOOTSTRAP_REGION_NAME: "RegionOne"
 
 - name: keystone tenants
   keystone_user: tenant={{ item }}
                  tenant_description="{{ item }} tenant"
-                 token={{ admin_token }}
-                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
+                 auth_url={{ endpoints.auth_uri }}
+                 login_tenant_name=admin
+                 login_username=admin
+                 login_password={{ secrets.admin_password }}
   with_items: "{{ keystone.tenants }}"
 
 - name: keystone users
   keystone_user: user={{ item.name }}
                  password={{ item.password }}
                  tenant={{ item.tenant }}
-                 token={{ admin_token }}
-                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
+                 auth_url={{ endpoints.auth_uri }}
+                 login_tenant_name=admin
+                 login_username=admin
+                 login_password={{ secrets.admin_password }}
   with_items: "{{ keystone.users }}"
 
 - name: keystone roles
   keystone_user: role={{ item }}
-                 token={{ admin_token }}
-                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
+                 auth_url={{ endpoints.auth_uri }}
+                 login_tenant_name=admin
+                 login_username=admin
+                 login_password={{ secrets.admin_password }}
   with_items: "{{ keystone.roles }}"
 
 - name: keystone user roles
   keystone_user: role={{ item.role }}
                  user={{ item.user }}
                  tenant={{ item.tenant }}
-                 token={{ admin_token }}
-                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
+                 auth_url={{ endpoints.auth_uri }}
+                 login_tenant_name=admin
+                 login_username=admin
+                 login_password={{ secrets.admin_password }}
   with_items: "{{ keystone.user_roles }}"
 
 - name: heat stack user
   keystone_user: user=heat_stack_user
                  password="{{ secrets.service_password }}"
                  tenant=admin
-                 token="{{ admin_token }}"
-                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
+                 auth_url={{ endpoints.auth_uri }}
+                 login_tenant_name=admin
+                 login_username=admin
+                 login_password={{ secrets.admin_password }}
   when: heat.enabled|bool
 
 - name: heat stack user role
   keystone_user: role=heat_stack_user
                  user=heat_stack_user
                  tenant=admin
-                 token="{{ admin_token }}"
-                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
+                 auth_url={{ endpoints.auth_uri }}
+                 login_tenant_name=admin
+                 login_username=admin
+                 login_password={{ secrets.admin_password }}
   when: heat.enabled|bool
-
-- name: keystone endpoint
-  keystone_service: name={{ item.name }}
-                    type={{ item.type }}
-                    description='{{ item.description }}'
-                    public_url={{ item.public_url }}
-                    internal_url={{ item.internal_url }}
-                    admin_url={{ item.admin_url }}
-                    region=RegionOne
-                    token={{ admin_token }}
-  # TODO refactor keystone.services data to be easier to pull out individual services
-  with_items: "{{ keystone.services }}"
-  when: endpoints[item.name] is defined and item.name == 'keystone'
-
-- name: remove admin_token from keystone api
-  lineinfile: dest=/etc/keystone/keystone.conf
-              line="admin_token = {{ admin_token }}"
-              state=absent
-
-- name: set insert_token to false
-  set_fact: insert_token=False
-
-- name: remove admin_token_auth from keystone pipeline
-  template: dest=/etc/keystone/keystone-paste.ini
-            src='{{ role_path }}/../keystone/templates/etc/keystone/keystone-paste.ini'
-
-- name: restart keystone api
-  service: name=keystone state=restarted
 
 - include: federation.yml
   when: keystone.federation.enabled|bool

--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -15,18 +15,18 @@
     OS_BOOTSTRAP_PASSWORD: "{{ keystone.bootstrap.password }}"
     OS_BOOTSTRAP_PROJECT_NAME: "{{ keystone.bootstrap.project }}"
     OS_BOOTSTRAP_ROLE_NAME: "{{ keystone.bootstrap.role }}"
-    OS_BOOTSTRAP_ADMIN_URL: "{{ endpoints.keystone.url.public }}"
+    OS_BOOTSTRAP_ADMIN_URL: "{{ endpoints.keystone.url.admin }}"
     OS_BOOTSTRAP_INTERNAL_URL: "{{ endpoints.keystone.url.internal }}"
     OS_BOOTSTRAP_PUBLIC_URL: "{{ endpoints.keystone.url.public }}"
-    OS_BOOTSTRAP_SERVICE_NAME: "keystone"
-    OS_BOOTSTRAP_REGION_NAME: "RegionOne"
+    OS_BOOTSTRAP_SERVICE_NAME: "{{ 'keystone' }}"  # otherwise it uses the keystone variable
+    OS_BOOTSTRAP_REGION_ID: "RegionOne"
 
 - name: keystone tenants
   keystone_user: tenant={{ item }}
                  tenant_description="{{ item }} tenant"
-                 endpoint="http://127.0.0.1:5002"
-                 login_tenant_name=admin
-                 login_username=admin
+                 endpoint=http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v2.0
+                 login_tenant_name={{ keystone.bootstrap.project }}
+                 login_user={{ keystone.bootstrap.user }}
                  login_password={{ secrets.admin_password }}
   with_items: "{{ keystone.tenants }}"
 
@@ -34,17 +34,17 @@
   keystone_user: user={{ item.name }}
                  password={{ item.password }}
                  tenant={{ item.tenant }}
-                 endpoint="http://127.0.0.1:5002"
-                 login_tenant_name=admin
-                 login_username=admin
+                 endpoint=http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v2.0
+                 login_tenant_name={{ keystone.bootstrap.project }}
+                 login_user={{ keystone.bootstrap.user }}
                  login_password={{ secrets.admin_password }}
   with_items: "{{ keystone.users }}"
 
 - name: keystone roles
   keystone_user: role={{ item }}
-                 endpoint="http://127.0.0.1:5002"
-                 login_tenant_name=admin
-                 login_username=admin
+                 endpoint=http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v2.0
+                 login_tenant_name={{ keystone.bootstrap.project }}
+                 login_user={{ keystone.bootstrap.user }}
                  login_password={{ secrets.admin_password }}
   with_items: "{{ keystone.roles }}"
 
@@ -52,19 +52,19 @@
   keystone_user: role={{ item.role }}
                  user={{ item.user }}
                  tenant={{ item.tenant }}
-                 endpoint="http://127.0.0.1:5002"
-                 login_tenant_name=admin
-                 login_username=admin
+                 endpoint=http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v2.0
+                 login_tenant_name={{ keystone.bootstrap.project }}
+                 login_user={{ keystone.bootstrap.user }}
                  login_password={{ secrets.admin_password }}
   with_items: "{{ keystone.user_roles }}"
 
 - name: heat stack user
   keystone_user: user=heat_stack_user
-                 password="{{ secrets.service_password }}"
+                 password={{ secrets.service_password }}
                  tenant=admin
-                 endpoint="http://127.0.0.1:5002"
-                 login_tenant_name=admin
-                 login_username=admin
+                 endpoint=http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v2.0
+                 login_tenant_name={{ keystone.bootstrap.project }}
+                 login_user={{ keystone.bootstrap.user }}
                  login_password={{ secrets.admin_password }}
   when: heat.enabled|bool
 
@@ -72,9 +72,9 @@
   keystone_user: role=heat_stack_user
                  user=heat_stack_user
                  tenant=admin
-                 endpoint="http://127.0.0.1:5002"
-                 login_tenant_name=admin
-                 login_username=admin
+                 endpoint=http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v2.0
+                 login_tenant_name={{ keystone.bootstrap.project }}
+                 login_user={{ keystone.bootstrap.user }}
                  login_password={{ secrets.admin_password }}
   when: heat.enabled|bool
 

--- a/roles/keystone/templates/etc/keystone/keystone-paste.ini
+++ b/roles/keystone/templates/etc/keystone/keystone-paste.ini
@@ -79,7 +79,7 @@ use = egg:keystone#admin_service
 pipeline = cors sizelimit url_normalize request_id build_auth_context token_auth json_body ec2_extension{{ ' passval unauthlog' if keystone.jellyroll|bool else '' }} public_service
 
 [pipeline:admin_api]
-pipeline = cors sizelimit url_normalize request_id{{ ' admin_token_auth' if insert_token|default(boolean=False) else '' }} build_auth_context token_auth json_body ec2_extension s3_extension{{ ' passval unauthlog' if keystone.jellyroll|bool else '' }} admin_service
+pipeline = cors sizelimit url_normalize request_id build_auth_context token_auth json_body ec2_extension s3_extension{{ ' passval unauthlog' if keystone.jellyroll|bool else '' }} admin_service
 
 [pipeline:api_v3]
 pipeline = cors sizelimit url_normalize request_id build_auth_context token_auth json_body ec2_extension_v3 s3_extension{{ ' rbac_filter passval unauthlog' if keystone.jellyroll|bool else '' }} service_v3

--- a/site.yml
+++ b/site.yml
@@ -202,22 +202,9 @@
   hosts: controller[0]
   any_errors_fatal: true
   tags: ['openstack', 'setup', 'keystone-setup']
-  pre_tasks:
-    # These pre-tasks determine if keystone has been setup before. If so, the
-    # keystone-setup role tasks are skipped.
-    - name: discover keystone setup status
-      command: mysql --batch --silent keystone -e "select type from service where type = 'compute'"
-      failed_when: false
-      changed_when: false
-      register: keystone_setup
-
-    - name: set keystone_configured fact
-      set_fact: keystone_configured=True
-      when: keystone_setup.stdout|search("compute")
 
   roles:
     - role: keystone-setup
-      when: not hostvars[inventory_hostname].keystone_configured | default(False)
   environment: "{{ env_vars|default({}) }}"
 
 - name: glance code and config


### PR DESCRIPTION
This obviates the need for admin_token usage, which we've never liked. It also removes a keystone service restart when doing the boot strapping. Everything is nice and idemotent.

This cherry picks (with modifications) a few commits that were used to implement this from another dev team.