### PR TITLE
Keystone to Keystone Federation

### DIFF
--- a/library/keystone_federation_mapping.py
+++ b/library/keystone_federation_mapping.py
@@ -77,7 +77,7 @@ def main():
                 params = {
                     'client': keystone,
                     'mapping_id': module.params['name'],
-                    'rules': yaml.load(module.params['rules'])
+                    'rules': module.params['rules']
                 }
                 _create_federation_mapping(**params)
                 changed = True

--- a/library/keystone_service_provider.py
+++ b/library/keystone_service_provider.py
@@ -1,0 +1,188 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2016, IBM
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+try:
+    import shade
+    HAS_SHADE = True
+except ImportError:
+    HAS_SHADE = False
+
+DOCUMENTATION = '''
+---
+author: Elvin Tubillara
+module: keystone_service_provider
+short_description: register sp on keystone idp
+description:
+  - This module registers a keystone service provider on the keystone
+    identity provider.
+options:
+  service_provider_id:
+    description:
+        - A globally unique id to identify the service provider
+          example -sp.id
+    required: true
+  service_provider_url:
+    description:
+        - URL that is found in the service provider's metadata
+          (Which is usually found
+          in https://keystone.sp/Shibboleth.sso/metadata)
+          example -https://keystone.sp/Shibboleth.sso/SAML2/ECP
+    required: true
+  service_provider_auth_url:
+    description:
+        - URL that is used to authenticate with the identity provider
+          This URL should be available once the idp registered on the sp
+          example -'http://keystone.sp/v3/OS-FEDERATION/'
+                 'identity_providers/keystone-idp/protocols/saml2/auth'
+    required: true
+  enabled:
+    description:
+      - A value of True enables the service provider and False disables it.
+    default: True
+  description:
+    description:
+      The description of the service provider.
+  state:
+    description:
+       - Indicate desired state of the resource
+    choices: ['present', 'absent']
+    default: present
+'''
+
+
+def _needs_update(module, service_provider):
+    """Check for differences in the updatable values.
+
+    Note: Names cannot be updated.
+    """
+    params_dict = dict(sp_url='service_provider_url',
+                       auth_url='service_provider_auth_url',
+                       enabled='enabled', description='description')
+    for sp_attr, module_attr in params_dict.items():
+        module_val = module.params.get(module_attr, None)
+        if module_val != getattr(service_provider, sp_attr, None):
+            return True
+    return False
+
+
+def _system_state_change(module, service_provider):
+    state = module.params['state']
+    if state == 'present':
+        if not service_provider:
+            return True
+        return _needs_update(module, service_provider)
+    if state == 'absent' and service_provider:
+        return True
+    return False
+
+
+def _get_cloud(**kwargs):
+    cloud_shade = shade.openstack_cloud(**kwargs)
+    cloud_shade.cloud_config.config['identity_api_version'] = '3'
+    cloud = ShadePlaceholder(cloud_shade.keystone_client)
+    return cloud
+
+
+class ShadePlaceholder(object):
+    def __init__(self, keystone_client):
+        self.client = keystone_client
+
+    def get_service_provider(self, sp_id):
+        for sp in self.client.federation.service_providers.list():
+            if getattr(sp, 'id') == sp_id:
+                return sp
+        return None
+
+    def create_service_provider(
+            self, sp_id, sp_url, sp_auth_url, enabled, description):
+        service_provider = self.client.federation.service_providers.create(
+            id=sp_id, sp_url=sp_url, auth_url=sp_auth_url,
+            enabled=enabled, description=description)
+        return service_provider
+
+    def update_service_provider(
+            self, sp_id, sp_url, sp_auth_url, enabled, description):
+        service_provider = self.client.federation.service_providers.update(
+            service_provider=sp_id, sp_url=sp_url, auth_url=sp_auth_url,
+            enabled=enabled, description=description)
+        return service_provider
+
+    def delete_service_provider(self, sp_id):
+        self.client.federation.service_providers.delete(service_provider=sp_id)
+
+
+def main():
+    argument_spec = openstack_full_argument_spec(
+        service_provider_id=dict(required=True),
+        service_provider_url=dict(required=True),
+        service_provider_auth_url=dict(required=True),
+        enabled=dict(required=False, default=True),
+        description=dict(required=False, default=None),
+        state=dict(default='present', choices=['absent', 'present']),
+    )
+    module_kwargs = openstack_module_kwargs()
+    module = AnsibleModule(argument_spec,
+                           supports_check_mode=True,
+                           **module_kwargs)
+
+    if not HAS_SHADE:
+        module.fail_json(msg='shade is required for this module')
+
+    sp_id = module.params['service_provider_id']
+    sp_url = module.params['service_provider_url']
+    sp_auth_url = module.params['service_provider_auth_url']
+    enabled = module.params['enabled']
+    description = module.params['description']
+
+    state = module.params['state']
+    try:
+        cloud = _get_cloud(**module.params)
+        service_provider = cloud.get_service_provider(sp_id)
+
+        if module.check_mode:
+            changed = _system_state_change(module, service_provider)
+            module.exit_json(changed=changed)
+
+        changed = False
+        if state == 'present':
+            if not service_provider:
+                service_provider = cloud.create_service_provider(
+                    sp_id, sp_url, sp_auth_url, enabled, description)
+                changed = True
+            else:
+                if _needs_update(module, service_provider):
+                    service_provider = cloud.update_service_provider(
+                        sp_id, sp_url, sp_auth_url, enabled, description)
+                    changed = True
+        module.exit_json(
+            changed=changed,
+            service_provider=[service_provider.id, service_provider.sp_url,
+                              service_provider.auth_url, enabled, description])
+        if state == 'absent':
+            if service_provider:
+                cloud.delete_service_provider(sp_id)
+                changed = True
+            module.exit_json(changed=changed)
+
+    except Exception as e:
+        module.fail_json(msg="identity provider failed: %s" % str(e))
+
+# this is magic, see lib/ansible/module_common.py
+from ansible.module_utils.basic import *
+from ansible.module_utils.openstack import *
+
+if __name__ == '__main__':
+    main()

--- a/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
+++ b/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
@@ -176,7 +176,7 @@ OPENSTACK_KEYSTONE_DEFAULT_ROLE = "_member_"
 SESSION_TIMEOUT = {{ horizon.session_timeout }}
 
 #TODO: parameterize strings that get shown on the login page
-{% if keystone.federation.enabled|bool -%}
+{% if keystone.federation.enabled|bool and keystone.federation.sp.oidc.enabled|bool -%}
 WEBSSO_ENABLED = True
 WEBSSO_CHOICES = (
     ("credentials", _("{{ horizon.websso.choices.credentials }}")),

--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -41,7 +41,28 @@ keystone:
         criticality: 'critical'
   federation:
     enabled: False
+    idp:
+      # Enable keystone to be an identity provider
+      # for keystone to keystone federation
+      k2k:
+        enabled: False
+        service_providers: []
+        saml_signing_cert: ""
+        saml_signing_key: ""
     sp:
+      # Enable keystone to be a service provider
+      # for keystone to keystone federation
+      k2k:
+        enabled: False
+        sp_id: "default-service-provider-id"
+        shibboleth_crt: None
+        shibboleth_key: None
+        support_contact: ""
+        idp_id: "default-identity-provider-id"
+        idp_metadata_url: "default-keystone-idp-url"
+        idp_metadata_min_refresh_delay: 600
+        idp_metadata_max_refresh_delay: 3600
+        idp_metadata_factor_refresh_delay: 0.75
       oidc:
         enabled: False
         download:

--- a/roles/keystone-setup/tasks/federation.yml
+++ b/roles/keystone-setup/tasks/federation.yml
@@ -7,6 +7,20 @@
   when: keystone.federation.sp.oidc.enabled|bool
   notify: restart keystone services
 
+- name: Register keystone sp info on keystone idp
+  keystone_service_provider:
+    auth:
+      auth_url: "http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v3"
+      project_name: admin
+      domain_id: Default
+      username: admin
+      password: "{{ secrets.admin_password }}"
+    service_provider_id: "{{ item.id }}"
+    service_provider_url: "{{ item.service_provider_url }}"
+    service_provider_auth_url: "{{ item.service_provider_auth_url }}"
+  with_items: "{{ keystone.federation.idp.k2k.service_providers }}"
+  when: keystone.federation.idp.k2k.enabled|bool
+
 - name: create keystone identity providers
   keystone_identity_provider: auth_url="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v3"
                               username="admin"
@@ -62,4 +76,3 @@
                                 identity_provider="{{ item.identity_provider }}"
                                 mapping="{{ item.mapping }}"
   with_items: "{{ keystone.federation.protocols }}"
-

--- a/roles/keystone/handlers/main.yml
+++ b/roles/keystone/handlers/main.yml
@@ -2,3 +2,7 @@
 - name: restart keystone services
   service: name=keystone state=restarted must_exist=false
   when: restart|default('True')
+
+- name: restart shibboleth
+  service: name=shibd state=restarted
+  when: restart|default('True')

--- a/roles/keystone/tasks/k2k-idp.yml
+++ b/roles/keystone/tasks/k2k-idp.yml
@@ -1,0 +1,22 @@
+---
+- name: install keystone saml signing public cert
+  template:
+    src: etc/keystone/keystone-saml.crt
+    dest: /etc/keystone/keystone-saml.crt
+    owner: keystone
+    group: keystone
+    mode: 0644
+
+- name: install saml signing key
+  template:
+    src: etc/keystone/keystone-saml.pem
+    dest: /etc/keystone/keystone-saml.pem
+    owner: keystone
+    group: keystone
+
+- name: install xmlsec1 command
+  apt: name=xmlsec1 state=present
+
+- name: setup keystone idp metadata
+  shell: keystone-manage saml_idp_metadata > /etc/keystone/keystone_idp_metadata.xml
+  notify: restart keystone services

--- a/roles/keystone/tasks/k2k-sp.yml
+++ b/roles/keystone/tasks/k2k-sp.yml
@@ -1,0 +1,29 @@
+---
+- name: install libapache2-mod-shib2
+  apt: name=libapache2-mod-shib2 state=present
+
+- name: install shibboleth private key
+  template: src=etc/shibboleth/sp-key.pem dest=/etc/shibboleth/sp-key.pem
+            owner=_shibd group=_shibd mode=0600
+  notify: restart shibboleth
+
+- name: install shibboleth public certificate
+  template: src=etc/shibboleth/sp-cert.pem dest=/etc/shibboleth/sp-cert.pem
+            owner=_shibd group=_shibd mode=0644
+  notify: restart shibboleth
+
+- name: configure shibboleth identity attributes
+  template: src=etc/shibboleth/attribute-map.xml
+            dest=/etc/shibboleth/attribute-map.xml mode=0600
+            owner=_shibd group=_shibd
+  notify: restart shibboleth
+
+- name: configure shibboleth settings
+  template: src=etc/shibboleth/shibboleth2.xml
+            dest=/etc/shibboleth/shibboleth2.xml mode=0644
+            owner=_shibd group=_shibd
+  notify: restart shibboleth
+
+- name: enable apache mod shib2
+  apache2_module: name=shib2
+  notify: reload apache

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -34,7 +34,7 @@
 - name: set uwsgi path (source install)
   set_fact: uwsgi_path={{ openstack_source.virtualenv_base }}/keystone/bin/uwsgi
   when: openstack_install_method == 'source'
-  
+
 - name: set uwsgi path (package install)
   set_fact:
     uwsgi_path: "{{ openstack_package.virtualenv_base }}/keystone/bin/uwsgi"
@@ -43,7 +43,7 @@
 - name: install keystone uwsgi service
   template: src=etc/init/keystone.conf
             dest=/etc/init/keystone.conf mode=0644
-  
+
 - name: Creates keystone uwsgi and httpd directories
   file: path={{ item }} state=directory
         owner=keystone group=keystone mode=0775
@@ -67,8 +67,11 @@
   template: src=etc/apache2/sites-available/keystone.conf
             dest=/etc/apache2/sites-available/keystone.conf
   notify:
-    - reload apache  
+    - reload apache
   tags: keystone-federation
+
+- include: k2k-sp.yml
+  when: keystone.federation.enabled|bool and keystone.federation.sp.k2k.enabled|bool
 
 - name: configure keystone
   template: src={{ item }} dest=/etc/keystone/
@@ -78,16 +81,19 @@
   notify:
     - restart keystone services
 
+- include: k2k-idp.yml
+  when: keystone.federation.enabled|bool and keystone.federation.idp.k2k.enabled|bool    
+
 - name: stop keystone service before db sync
   service: name=keystone state=stopped
   when: database_create.changed or force_sync|default('false')|bool
   tags: db-migrate
-  
+
 - name: disable keystone apache site before db sync
   apache2_site: name=keystone state=absent
   when: database_create.changed or force_sync|default('false')|bool
   tags: db-migrate
-  
+
 - name: reload apache to disable keystone before db sync
   service: name=apache2 state=reloaded
   register: reloaded
@@ -110,19 +116,23 @@
   notify: restart keystone services
   when: code_has_changed | default('False') | bool and
         upgrade | default('False') | bool
-  
+
 - name: enable keystone apache site
   apache2_site: name=keystone state=present
   notify:
     - reload apache
-    
+
 - meta: flush_handlers
 
 - name: start keystone
   service: name=keystone state=started
-  
+
 - name: start keystone (apache)
   service: name=apache2 state=started
+
+- name: start shibboleth service
+  service: name=shibd state=started enabled=true
+  when: keystone.federation.enabled|bool and keystone.federation.sp.k2k.enabled|bool
 
 - name: permit access to keystone
   ufw: rule=allow to_port={{ item }} proto=tcp

--- a/roles/keystone/templates/etc/apache2/sites-available/keystone.conf
+++ b/roles/keystone/templates/etc/apache2/sites-available/keystone.conf
@@ -1,5 +1,18 @@
+
 Listen {{ endpoints.keystone_admin.port.backend_api }}
 Listen {{ endpoints.keystone.port.backend_api }}
+{% macro setup_k2k_sp() -%}
+<Location /Shibboleth.sso>
+    SetHandler shib
+</Location>
+
+<LocationMatch /v3/OS-FEDERATION/identity_providers/.*?/protocols/saml2/auth>
+    ShibRequestSetting requireSession 1
+    AuthType shibboleth
+    ShibExportAssertion Off
+    Require valid-user
+</LocationMatch>
+{% endmacro -%}
 
 {% macro setup_oidc() -%}
     OIDCClaimPrefix "OIDC_CLAIM_"
@@ -43,6 +56,7 @@ Listen {{ endpoints.keystone.port.backend_api }}
 {% endmacro -%}
 
 <VirtualHost *:{{ endpoints.keystone_admin.port.backend_api }}>
+ServerName https://{{ fqdn }}
 
 {% if keystone.federation.sp.oidc.enabled|bool -%}
     {{ setup_oidc() }}
@@ -58,18 +72,24 @@ Listen {{ endpoints.keystone.port.backend_api }}
 </VirtualHost>
 
 <VirtualHost *:{{ endpoints.keystone.port.backend_api }}>
+ServerName https://{{ fqdn }}
 
 {% if keystone.federation.sp.oidc.enabled|bool -%}
     {{ setup_oidc() }}
 {% endif -%}
+
     <Location />
         Options FollowSymLinks Indexes
         SetHandler uwsgi-handler
         uWSGImaxVars 255
         uWSGISocket /run/uwsgi/keystone-main.socket
     </Location>
+
+{% if keystone.federation.sp.k2k.enabled|bool -%}
+    {{ setup_k2k_sp() }}
+{% endif -%}
+
     ErrorLog ${APACHE_LOG_DIR}/error.log
     LogLevel error
+
 </VirtualHost>
-
-

--- a/roles/keystone/templates/etc/keystone/keystone-saml.crt
+++ b/roles/keystone/templates/etc/keystone/keystone-saml.crt
@@ -1,0 +1,1 @@
+{{ keystone.federation.idp.k2k.saml_signing_cert }}

--- a/roles/keystone/templates/etc/keystone/keystone-saml.pem
+++ b/roles/keystone/templates/etc/keystone/keystone-saml.pem
@@ -1,0 +1,2 @@
+{{ keystone.federation.idp.k2k.saml_signing_cert }}
+{{ keystone.federation.idp.k2k.saml_signing_key }}

--- a/roles/keystone/templates/etc/keystone/keystone.conf
+++ b/roles/keystone/templates/etc/keystone/keystone.conf
@@ -73,15 +73,33 @@ driver = keystone.contrib.revoke.backends.sql.Revoke
 
 {% if keystone.federation.enabled|bool -%}
 [auth]
-methods = external,password,token{{ ',oidc' if keystone.federation.sp.oidc.enabled|bool else '' }}
+methods = external,password,token{{ ',oidc' if keystone.federation.sp.oidc.enabled|bool else '' }}{{ ',saml2' if keystone.federation.sp.k2k.enabled|bool else '' }}
 {{ 'oidc = keystone.auth.plugins.mapped.Mapped' if keystone.federation.sp.oidc.enabled|bool else '' }}
+{{ 'saml2 = keystone.auth.plugins.mapped.Mapped' if keystone.federation.sp.k2k.enabled|bool  else '' }}
 
 [federation]
 driver = sql
 trusted_dashboard = http://{{ fqdn }}/auth/websso/
+
 {% if keystone.federation.sp.oidc.enabled|bool -%}
 
 [oidc]
 remote_id_attribute = HTTP_OIDC_CLAIM_ISS
 {% endif -%}
+{% if keystone.federation.sp.k2k.enabled|bool -%}
+
+[saml]
+remote_id_attribute = Shib-Identity-Provider
+{% endif -%}
+
+{% if keystone.federation.idp.k2k.enabled|bool -%}
+
+[saml]
+certfile=/etc/keystone/keystone-saml.crt
+keyfile=/etc/keystone/keystone-saml.pem
+idp_entity_id=https://{{ fqdn }}/v3/OS-FEDERATION/saml2/idp
+idp_sso_endpoint=https://{{ fqdn }}/v3/OS-FEDERATION/saml2/sso
+idp_metadata_path=/etc/keystone/keystone_idp_metadata.xml
+{% endif -%}
+
 {% endif -%}

--- a/roles/keystone/templates/etc/shibboleth/attribute-map.xml
+++ b/roles/keystone/templates/etc/shibboleth/attribute-map.xml
@@ -1,0 +1,7 @@
+<Attributes xmlns="urn:mace:shibboleth:2.0:attribute-map" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Attribute name="openstack_user" id="openstack_user"/>
+    <Attribute name="openstack_roles" id="openstack_roles"/>
+    <Attribute name="openstack_project" id="openstack_project"/>
+    <Attribute name="openstack_user_domain" id="openstack_user_domain"/>
+    <Attribute name="openstack_project_domain" id="openstack_project_domain"/>
+</Attributes>

--- a/roles/keystone/templates/etc/shibboleth/shibboleth2.xml
+++ b/roles/keystone/templates/etc/shibboleth/shibboleth2.xml
@@ -1,0 +1,43 @@
+<SPConfig xmlns="urn:mace:shibboleth:2.0:native:sp:config"
+    xmlns:conf="urn:mace:shibboleth:2.0:native:sp:config"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+    clockSkew="180">
+
+    <ApplicationDefaults entityID="{{ keystone.federation.sp.k2k.sp_id }}">
+        <Sessions lifetime="28800" timeout="3600" relayState="ss:mem"
+                  checkAddress="false" handlerSSL="false" cookieProps="http">
+            <SSO entityID="{{ keystone.federation.sp.k2k.idp_id }}" ECP="true">
+              SAML2 SAML1
+            </SSO>
+
+            <Logout>SAML2 Local</Logout>
+
+            <Handler type="MetadataGenerator" Location="/Metadata" signing="false"/>
+            <Handler type="Status" Location="/Status" acl="127.0.0.1 ::1"/>
+            <Handler type="Session" Location="/Session" showAttributeValues="true"/>
+            <Handler type="DiscoveryFeed" Location="/DiscoFeed"/>
+        </Sessions>
+
+        <Errors supportContact="{{ keystone.federation.sp.k2k.support_contact }}"
+            helpLocation="/about.html"
+            styleSheet="/shibboleth-sp/main.css"/>
+
+        <MetadataProvider type="XML" uri="{{ keystone.federation.sp.k2k.idp_metadata_url }}"
+          backingFilePath="idp-metadata-provider-backup.xml"
+          minRefreshDelay="{{ keystone.federation.sp.k2k.idp_metadata_min_refresh_delay }}"
+          maxRefreshDelay="{{ keystone.federation.sp.k2k.idp_metadata_max_refresh_delay }}"
+          refreshDelayFactor="{{ keystone.federation.sp.k2k.idp_metadata_factor_refresh_delay }}">
+          <TransportOption provider="CURL" option="64">1</TransportOption>
+          <TransportOption provider="CURL" option="81">2</TransportOption>
+          <TransportOption provider="CURL" option="10065">/etc/ssl/certs/ca-certificates.crt</TransportOption>
+        </MetadataProvider>
+        <AttributeExtractor type="XML" validate="true" reloadChanges="false" path="attribute-map.xml"/>
+        <AttributeResolver type="Query" subjectMatch="true"/>
+        <AttributeFilter type="XML" validate="true" path="attribute-policy.xml"/>
+        <CredentialResolver type="File" key="sp-key.pem" certificate="sp-cert.pem"/>
+    </ApplicationDefaults>
+    <SecurityPolicyProvider type="XML" validate="true" path="security-policy.xml"/>
+    <ProtocolProvider type="XML" validate="true" reloadChanges="false" path="protocols.xml"/>
+</SPConfig>

--- a/roles/keystone/templates/etc/shibboleth/sp-cert.pem
+++ b/roles/keystone/templates/etc/shibboleth/sp-cert.pem
@@ -1,0 +1,1 @@
+{{ keystone.federation.sp.k2k.shibboleth_crt }}

--- a/roles/keystone/templates/etc/shibboleth/sp-key.pem
+++ b/roles/keystone/templates/etc/shibboleth/sp-key.pem
@@ -1,0 +1,2 @@
+{{ keystone.federation.sp.k2k.shibboleth_crt }}
+{{ keystone.federation.sp.k2k.shibboleth_key }}


### PR DESCRIPTION
Adds the feature to support keystone to keystone federation.
This feature enables:
1. Setting up keystone as an identity provider (idp) for another keystone
2. Setting up keystone as a service provider (sp) that takes assertions from
   a keystone identity provider.

The federation protocol used between the idp and sp is SAML 2.0.
Shibboleth is installed on the sp to process the SAML assertions.
```

To setup a k2k idp, you will need these variables in the all.yml:
keystone:
  federation:
    enabled: True
    idp:
      # Enable keystone to be an identity provider
      # for keystone to keystone federation
      k2k:
        enabled: True
        service_providers:
          - id: k2kf-sp
            service_provider_url: https://k2kf-sp.open-test.ibmcloud.com:5000/Shibboleth.sso/SAML2/ECP
            service_provider_auth_url: https://k2kf-sp.open-test.ibmcloud.com:5000/v3/OS-FEDERATION/identity_providers/k2kf-idp/protocols/saml2/auth
        saml_signing_cert: |
           ...long public cert for saml signing here....
        saml_signing_key: |
           ...long saml signing key here....
    identity_providers: []
    groups: []
    role: []
    mappings: []
    protocols: []
To setup an k2k sp, you will need these variables in the all.yml:
keystone:
  federation:
    enabled: True
    sp:
      # Enable keystone to be a service provider
      # for keystone to keystone federation
      k2k:
        enabled: True
        sp_id: "https://k2kf-sp.open-test.ibmcloud.com"
        shibboleth_crt: |
            ...long cert for shibboleth here.....
        shibboleth_key: |
            ...long cert for key here
        support_contact: "norealsupport@ibm.com"
        idp_id: "k2kf-idp"
        idp_metadata_url: "https://k2kf-idp.open-test.ibmcloud.com:5000/v3/OS-FEDERATION/saml2/metadata"
    identity_providers:
      - { name: k2kf-idp, remote_ids: "k2kf-idp.open-test.ibmcloud.com:5000/v3/OS-FEDERATION/saml2/idp" }
    groups:
      - { name: cloud_admin }
    role:
      - { group: cloud_admin, role: cloud_admin, project: demo }
    mappings:
      - name: mapping-for-k2k-federation
        rules:
          - local:
            - user:
                name: "{0}"
              group:
                name: cloud_admin
                domain:
                  name: Default
            remote:
              - type: openstack_user
              - type: openstack_user
                any_one_of: ['cloud_admin']
    protocols:
      - { name: saml2, mapping: mapping-for-k2k-federation, identity_provider: k2kf-idp }

```
packages that idp depends on:
sudo apt-get install xmlsec1
sudo pip install pysaml2

packages that sp depends on:
sudo apt-get install libapache2-mod-shib2

#TODO list:

- [x] 1. Use alternative cert location
- [x] 2. Integrate with the existing federation better. (There are two ansible modules that do the same thing for idps).
- [x] 3. Add default mapping and roles
- [x] 4. Review and Enable TLS/SSL verification between idp and sp when possible(Seems only item B needs to be done).
A. when idp gets metadata from sp (This does not seem to happen)
B. when sp gets metadata from idp (Need to add filter.
C. should we reject assertions not encrypted by TLS/SSL? There is TLS/SSL termination- We do this already by using tls on HAProxy and require connections to be HTTPS. 
- [x] 5. Apply fixes in regards to j2sol's comments.

Issues regarding this patch:
1. The apache module upon manual restart will spew out:
"AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 127.0.1.1. Set the 'ServerName' directive globally to suppress this message"
This is caused by setting the ServerName inside the vhost configuration. This was needed because the saml validation thought the recipient was the wrong host. There were error messages saying that  the validation was for "https" but a host with "http" got it instead. This was because ssl termination was happening at the HAProxy level and apache was using http. I think this should be fixed in another PR since I think we should introduce another apache module called fqdn to manage the ServerName. 
2. For the keystone to keystone federation feature, the first few requests will fail. This is because it appears that shibboleth on the sp does not get the Metadata until the first request. I think that more investigation is needed regarding this issue but I think it can be fixed in another PR.