### PR TITLE
Remove use of lookup for finding virtualenvbase

### DIFF
--- a/roles/cinder-common/tasks/ceph_integration.yml
+++ b/roles/cinder-common/tasks/ceph_integration.yml
@@ -17,7 +17,7 @@
 
 - name: fetch rados.py
   get_url: url={{ ceph.rados_url }}
-           dest="{{ lookup('items', 'openstack_package.virtualenv_base') }}/cinder/lib/python2.7/site-packages/rados.py"
+           dest="{{ openstack_package.virtualenv_base }}/cinder/lib/python2.7/site-packages/rados.py"
            owner=root
            group=root
            mode=0644
@@ -25,7 +25,7 @@
 
 - name: fetch rbd.py
   get_url: url={{ ceph.rbd_url }}
-           dest="{{ lookup('items', 'openstack_package.virtualenv_base') }}/cinder/lib/python2.7/site-packages/rbd.py"
+           dest="{{ openstack_package.virtualenv_base }}/cinder/lib/python2.7/site-packages/rbd.py"
            owner=root
            group=root
            mode=0644

--- a/roles/glance/tasks/ceph_integration.yml
+++ b/roles/glance/tasks/ceph_integration.yml
@@ -17,7 +17,7 @@
 
 - name: fetch rados.py
   get_url: url={{ ceph.rados_url }}
-           dest="{{ lookup('items', 'openstack_package.virtualenv_base') }}/glance/lib/python2.7/site-packages/rados.py"
+           dest="{{ openstack_package.virtualenv_base }}/glance/lib/python2.7/site-packages/rados.py"
            owner=root
            group=root
            mode=0644
@@ -25,7 +25,7 @@
 
 - name: fetch rbd.py
   get_url: url={{ ceph.rbd_url }}
-           dest="{{ lookup('items', 'openstack_package.virtualenv_base') }}/glance/lib/python2.7/site-packages/rbd.py"
+           dest="{{ openstack_package.virtualenv_base }}/glance/lib/python2.7/site-packages/rbd.py"
            owner=root
            group=root
            mode=0644

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -37,9 +37,9 @@
   
 - name: set uwsgi path (package install)
   set_fact:
-    uwsgi_path: "{{ lookup('items', 'openstack_package.virtualenv_base') }}/keystone/bin/uwsgi"
+    uwsgi_path: "{{ openstack_package.virtualenv_base }}/keystone/bin/uwsgi"
   when: openstack_install_method == 'package'
-  
+
 - name: install keystone uwsgi service
   template: src=etc/init/keystone.conf
             dest=/etc/init/keystone.conf mode=0644

--- a/roles/neutron-common/templates/etc/neutron/rootwrap-ursula.d/ursula.filters
+++ b/roles/neutron-common/templates/etc/neutron/rootwrap-ursula.d/ursula.filters
@@ -1,6 +1,6 @@
-{% set basepath = lookup('items', 'openstack_source.virtualenv_base') if
+{% set basepath = openstack_source.virtualenv_base if
 openstack_install_method == 'source' else
-lookup('items', 'openstack_package.virtualenv_base') %}
+openstack_package.virtualenv_base %}
 ## Filters we add to deal with Ursula install paths
 
 [Filters]


### PR DESCRIPTION
This double lookup doesn't seem to be a problem with Ansible 2.0, but
the use of the lookup function was breaking things, so take it out.