### PR TITLE
Drop explicit Babel requirements

### DIFF
--- a/roles/magnum/defaults/main.yml
+++ b/roles/magnum/defaults/main.yml
@@ -8,7 +8,6 @@ magnum:
     virtualenv: "/opt/openstack/magnum"
     python_dependencies:
       - { name: PyMySQL }
-      - { name: Babel==2.2.0 }
     system_dependencies: []
   package: ~
   cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -47,7 +47,6 @@ nova:
   source:
     rev: 'stable/mitaka'
     python_dependencies:
-      - { name: Babel==2.2.0 }
       - { name: PyMySQL }
       - { name: python-memcached }
       - { name: paramiko==1.16.0 }


### PR DESCRIPTION
These do not appear to be necessary.