### PR TITLE
use ansible_processor fact in place of ansible_processor_vcpus

### DIFF
--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -42,8 +42,8 @@ ram_allocation_ratio = {{ nova.ram_allocation_ratio }}
 
 #Reserve CPUs for host OS on converged controllers and compute hosts
 {% set reserved_cores = 4 if inventory_hostname in groups['controller'] else 1 %}
-{% set cpulimit = cpulimit | default(ansible_processor_vcpus) %}
-{% set cpu_core_count = cpulimit if cpulimit < ansible_processor_vcpus else ansible_processor_vcpus %}
+{% set cpulimit = cpulimit | default((ansible_processor | count / 2) | int) %}
+{% set cpu_core_count = cpulimit if cpulimit < (ansible_processor | count / 2) | int else (ansible_processor | count / 2) | int %}
 {% if cpu_core_count > reserved_cores %}
 vcpu_pin_set = "{{ reserved_cores }}-{{ cpu_core_count - 1 }}"
 {% endif -%}


### PR DESCRIPTION
The ansible_processor_vcpus fact has been found to detect the incorrect number of available cpus.  Moving to ansible_processor instead.