### PR TITLE
Make ceilometer work again

### DIFF
--- a/roles/ceilometer-common/defaults/main.yml
+++ b/roles/ceilometer-common/defaults/main.yml
@@ -9,10 +9,7 @@ ceilometer:
     - ceilometer-api
     - ceilometer-collector
     - ceilometer-agent-notification
-    - ceilometer-agent-central
-    - ceilometer-alarm-evaluator
-    - ceilometer-alarm-notifier
-    - ceilometer-agent-compute
+    - ceilometer-polling
   purge_frequency: 86400
   mongodb_database: ceilometer
   mongodb_user: ceilometer
@@ -30,30 +27,15 @@ ceilometer:
         type: openstack
         tags: ceilometer,ceilometer-agent-notification
     - paths:
-        - /var/log/ceilometer/alarm-evaluator.log
-      fields:
-        type: openstack
-        tags: ceilometer,ceilometer-alarm-evaluator
-    - paths:
-        - /var/log/ceilometer/alarm-notifier.log
-      fields:
-        type: openstack
-        tags: ceilometer,ceilometer-alarm-notifier
-    - paths:
-        - /var/log/ceilometer/central.log
-      fields:
-        type: openstack
-        tags: ceilometer,ceilometer-agent-central
-    - paths:
         - /var/log/ceilometer/collector.log
       fields:
         type: openstack
         tags: ceilometer,ceilometer-collector
     - paths:
-        - /var/log/ceilometer/compute.log
+        - /var/log/ceilometer/polling.log
       fields:
         type: openstack
-        tags: ceilometer,ceilometer-agent-compute
+        tags: ceilometer,ceilometer-polling
   logging:
     debug: False
     verbose: True

--- a/roles/ceilometer-common/handlers/main.yml
+++ b/roles/ceilometer-common/handlers/main.yml
@@ -6,7 +6,4 @@
     - ceilometer-api
     - ceilometer-collector
     - ceilometer-agent-notification
-    - ceilometer-agent-central
-    - ceilometer-alarm-evaluator
-    - ceilometer-alarm-notifier
-    - ceiloemter-agent-compute
+    - ceiloemter-polling

--- a/roles/ceilometer-common/templates/etc/ceilometer/ceilometer.conf
+++ b/roles/ceilometer-common/templates/etc/ceilometer/ceilometer.conf
@@ -8,7 +8,7 @@ notification_driver = log
 
 log_dir = /var/log/ceilometer
 policy_file = /etc/ceilometer/policy.json
-rpc_backend = ceilometer.openstack.common.rpc.impl_kombu
+rpc_backend = rabbit
 
 [oslo_messaging_rabbit]
 {% macro rabbitmq_hosts() -%}
@@ -53,13 +53,15 @@ host = 0.0.0.0
 port = {{ endpoints.ceilometer.port.backend_api }}
 
 [keystone_authtoken]
-identity_uri = {{ endpoints.identity_uri }}
-auth_uri = {{ endpoints.auth_uri }}
-admin_tenant_name = service
-admin_user = ceilometer
-admin_password = {{ secrets.service_password }}
+auth_url = {{ endpoints.keystone.url.admin }}
+auth_uri = {{ endpoints.keystone.url.internal }}
 cafile = {{ ceilometer.cafile }}
 signing_dir = /var/cache/ceilometer/api
+auth_type = password
+project_domain_name = Default
+project_name = service
+username = ceilometer
+password = {{ secrets.service_password }}
 
 [clients]
 ca_file = {{ ceilometer.cafile }}
@@ -69,13 +71,11 @@ ca_file = {{ ceilometer.cafile }}
 telemetry_secret = {{ secrets.telemetry_secret }}
 
 [service_credentials]
-os_auth_url = {{ endpoints.auth_uri }}
-os_username = ceilometer
-os_tenant_name = service
-os_password = {{ secrets.service_password }}
-os_endpoint_type = internalURL
-os_region_name = RegionOne
-os_cacert = {{ ceilometer.cafile }}
-
-[alarm]
-rest_notifier_ssl_verify = false
+auth_type = password
+auth_url = {{ endpoints.keystone.url.admin }}
+username = ceilometer
+project_name = service
+password = {{ secrets.service_password }}
+project_domain_name = Default
+user_domain_name = Default
+cafile = {{ ceilometer.cafile }}

--- a/roles/ceilometer-common/templates/etc/serverspec/ceilometer_spec.rb
+++ b/roles/ceilometer-common/templates/etc/serverspec/ceilometer_spec.rb
@@ -23,10 +23,8 @@ end
 {% if inventory_hostname in groups['controller'] %}
 processes = ['ceilometer-api',
   'ceilometer-collector',
+  'ceilometer-polling',
   'ceilometer-agent-notification',
-  'ceilometer-agent-central',
-  'ceilometer-alarm-evaluator',
-  'ceilometer-alarm-notifier']
 processes.each do |process|
   describe process(process) do
     its(:user) { should eq 'ceilometer' }

--- a/roles/ceilometer-control/tasks/main.yml
+++ b/roles/ceilometer-control/tasks/main.yml
@@ -10,10 +10,8 @@
   with_items:
     - ceilometer-api
     - ceilometer-collector
+    - ceilometer-polling
     - ceilometer-agent-notification
-    - ceilometer-agent-central
-    - ceilometer-alarm-evaluator
-    - ceilometer-alarm-notifier
   notify: restart ceilometer services
 
 - name: trigger restart on upgrades
@@ -25,7 +23,14 @@
         upgrade | default('False') | bool
 
 - name: create ceilometer user in mongodb
-  mongodb_user: database={{ ceilometer.mongodb_database }} name={{ ceilometer.mongodb_user }} password={{ ceilometer.mongodb_password }} roles='readWrite,dbAdmin' state=present
+  mongodb_user:
+    database: "{{ ceilometer.mongodb_database }}"
+    name: "{{ ceilometer.mongodb_user }}"
+    password: "{{ ceilometer.mongodb_password }}"
+    roles: 'readWrite,dbAdmin'
+    state: present
+    login_password: "{{ secrets.mongodb_password }}"
+    login_user: admin
   when: inventory_hostname in groups['controller'][0]
 
 - meta: flush_handlers
@@ -35,10 +40,8 @@
   with_items:
     - ceilometer-api
     - ceilometer-collector
+    - ceilometer-polling
     - ceilometer-agent-notification
-    - ceilometer-agent-central
-    - ceilometer-alarm-evaluator
-    - ceilometer-alarm-notifier
 
 - include: monitoring.yml
   tags:

--- a/roles/ceilometer-control/tasks/monitoring.yml
+++ b/roles/ceilometer-control/tasks/monitoring.yml
@@ -15,7 +15,4 @@
     - ceilometer-api
     - ceilometer-collector
     - ceilometer-agent-notification
-    - ceilometer-agent-central
-    - ceilometer-alarm-evaluator
-    - ceilometer-alarm-notifier
   notify: restart sensu-client

--- a/roles/ceilometer-data/tasks/main.yml
+++ b/roles/ceilometer-data/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- name: install ceilometer compute service
-  upstart_service: name=ceilometer-agent-compute
+- name: install ceilometer polling agent
+  upstart_service: name=ceilometer-polling
                    user=ceilometer
-                   cmd=/usr/local/bin/ceilometer-agent-compute
+                   cmd=/usr/local/bin/ceilometer-polling
   notify: restart ceilometer services
 
 - name: install libvirt-python in package venv
@@ -25,8 +25,10 @@
 
 - meta: flush_handlers
 
-- name: start ceilometer-compute service
-  service: name=ceilometer-agent-compute state=started
+- name: start ceilometer-polling service
+  service:
+    name: ceilometer-polling
+    state: started
 
 - include: monitoring.yml
   tags:

--- a/roles/ceilometer-data/tasks/monitoring.yml
+++ b/roles/ceilometer-data/tasks/monitoring.yml
@@ -1,4 +1,4 @@
 ---
-- name: ceilometer-agent-compute process check
-  sensu_process_check: service=ceilometer-agent-compute
+- name: ceilometer-polling process check
+  sensu_process_check: service=ceilometer-polling
   notify: restart sensu-client


### PR DESCRIPTION
Lots of change from Kilo -> Mitaka

Alarms were split off to aodh
Auth stuff changed syntax
Mongo module needs auth creds to add non-admin user
New polling service replaces some agents services

With all these changes, the services appear to run, but doing anything
useful with them may require more changes.