### PR TITLE
Purge outdated ceilometer alerts

### DIFF
--- a/roles/ceilometer-control/tasks/monitoring.yml
+++ b/roles/ceilometer-control/tasks/monitoring.yml
@@ -16,3 +16,13 @@
     - ceilometer-collector
     - ceilometer-agent-notification
   notify: restart sensu-client
+
+- name: remove old checks
+  sensu_process_check:
+    service: "{{ item }}"
+    state: absent
+  with_items:
+    - ceilometer-agent-central
+    - ceilometer-alarm-evaluator
+    - ceilometer-alarm-notifier
+  notify: restart sensu-client

--- a/roles/ceilometer-data/tasks/monitoring.yml
+++ b/roles/ceilometer-data/tasks/monitoring.yml
@@ -2,3 +2,9 @@
 - name: ceilometer-polling process check
   sensu_process_check: service=ceilometer-polling
   notify: restart sensu-client
+
+- name: remove retired process checks
+  sensu_process_check:
+    service: ceilometer-agent-compute
+    state: absent
+  notify: restart sensu-client


### PR DESCRIPTION
These services no longer exist, stop monitoring them.