### PR TITLE
template root known hosts rather than symlink

### DIFF
--- a/roles/nova-data/tasks/ssh.yml
+++ b/roles/nova-data/tasks/ssh.yml
@@ -27,11 +27,13 @@
     mode: 0700
     state: directory
 
-- name: nova known_hosts root symlink (for libvirt)
-  file:
-    src: "{{ nova.state_path }}/.ssh/known_hosts"
-    path: /root/.ssh/known_hosts
-    state: link
+- name: root known_hosts (for libvirt)
+  template:
+    src: var/lib/nova/ssh/known_hosts
+    dest: "/root/.ssh/known_hosts"
+    owner: root
+    group: root
+    mode: 0600
 
 - name: nova bin directory
   file:


### PR DESCRIPTION
The symlink task currently fails when the file exists and it is not already a symlink due to missing the force option.

Opting to template twice rather than the force the link so that root's known_hosts aren't forever determined by the nova user.