### PR TITLE
Add the ability to specify availability zone

### DIFF
--- a/playbooks/ci-full/tasks/create.yml
+++ b/playbooks/ci-full/tasks/create.yml
@@ -38,6 +38,7 @@
         nics:
           - net-name: internal
         auto_floating_ip: false
+        availability_zone: "{{ ansible_env.AVAILABILITY_ZONE | default(omit) }}"
       with_items: "{{ testenv_instance_names }}"
       register: instances
 

--- a/test/common
+++ b/test/common
@@ -16,6 +16,7 @@ SSH_ARGS=\
 export ANSIBLE_SSH_ARGS="${SSH_ARGS}"
 export ANSIBLE_VAR_DEFAULTS_FILE="${ROOT}/envs/test/defaults-2.0.yml"
 export IMAGE_ID=${IMAGE_ID:=ubuntu-14.04}
+export AVAILABILITY_ZONE=${OS_AVAILABILITY_ZONE:=nova}
 
 if [[ -n ${BUILD_TAG} ]]; then
   export testenv_instance_prefix=${BUILD_TAG}


### PR DESCRIPTION
Test VMs running into the new CI cloud will need to boot in a specific
availability zone.