### PR TITLE
template root known hosts rather than symlink (2.1.x)

### DIFF
--- a/roles/nova-data/tasks/ssh.yml
+++ b/roles/nova-data/tasks/ssh.yml
@@ -27,11 +27,13 @@
     mode: 0700
     state: directory
 
-- name: nova known_hosts root symlink (for libvirt)
-  file:
-    src: "{{ nova.state_path }}/.ssh/known_hosts"
-    path: /root/.ssh/known_hosts
-    state: link
+- name: root known_hosts (for libvirt)
+  template:
+    src: var/lib/nova/ssh/known_hosts
+    dest: "/root/.ssh/known_hosts"
+    owner: root
+    group: root
+    mode: 0600
 
 - name: nova bin directory
   file:


### PR DESCRIPTION
(cherry picked from commit 4a6ef9fc1fcfc112ca0ea35c446bd173cd71284b)