### PR TITLE
Changes to oidc keystone federation setup fo mitaka

### DIFF
--- a/roles/keystone-setup/handlers/main.yml
+++ b/roles/keystone-setup/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: restart keystone services
+  service: name=keystone state=restarted must_exist=false
+  when: restart|default('True')

--- a/roles/keystone-setup/tasks/federation.yml
+++ b/roles/keystone-setup/tasks/federation.yml
@@ -1,4 +1,12 @@
 ---
+- name: set federated domain name
+  ini_file: dest=/etc/keystone/keystone.conf
+            section=federation
+            option=federated_domain_name
+            value=Default
+  when: keystone.federation.sp.oidc.enabled|bool
+  notify: restart keystone services
+
 - name: create keystone identity providers
   keystone_identity_provider: auth_url="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v3"
                               username="admin"


### PR DESCRIPTION
This is to get around the keystone bootstrap failure when the "federated_domain_name = Default" is set in the keystone config file. This is needed so that horizon is scoped to the default domain after the oidc authentication with the BoxPanel auth