### PR TITLE
Introduce oslo middleware for http proxy (nova)

### DIFF
--- a/roles/nova-common/templates/etc/nova/api-paste.ini
+++ b/roles/nova-common/templates/etc/nova/api-paste.ini
@@ -38,31 +38,31 @@ use = call:nova.api.openstack.urlmap:urlmap_factory
 # NOTE: this is deprecated in favor of openstack_compute_api_v21_legacy_v2_compatible
 [composite:openstack_compute_api_legacy_v2]
 use = call:nova.api.auth:pipeline_factory
-noauth = compute_req_id faultwrap sizelimit noauth ratelimit osapi_compute_app_v2
+noauth = compute_req_id faultwrap http_proxy_to_wsgi sizelimit noauth ratelimit osapi_compute_app_v2
 {% if nova.auditing.enabled|bool %}
-keystone = cors compute_req_id faultwrap sizelimit authtoken keystonecontext audit legacy_ratelimit osapi_compute_app_legacy_v2
-keystone_nolimit = cors compute_req_id faultwrap sizelimit authtoken keystonecontext audit osapi_compute_app_legacy_v2
+keystone = cors compute_req_id faultwrap http_proxy_to_wsgi sizelimit authtoken keystonecontext audit legacy_ratelimit osapi_compute_app_legacy_v2
+keystone_nolimit = cors compute_req_id faultwrap http_proxy_to_wsgi sizelimit authtoken keystonecontext audit osapi_compute_app_legacy_v2
 {% else %}
-keystone = cors compute_req_id faultwrap sizelimit authtoken keystonecontext legacy_ratelimit osapi_compute_app_legacy_v2
-keystone_nolimit = cors compute_req_id faultwrap sizelimit authtoken keystonecontext osapi_compute_app_legacy_v2
+keystone = cors compute_req_id faultwrap http_proxy_to_wsgi sizelimit authtoken keystonecontext legacy_ratelimit osapi_compute_app_legacy_v2
+keystone_nolimit = cors compute_req_id faultwrap http_proxy_to_wsgi sizelimit authtoken keystonecontext osapi_compute_app_legacy_v2
 {% endif %}
 
 [composite:openstack_compute_api_v21]
 use = call:nova.api.auth:pipeline_factory_v21
-noauth2 = cors compute_req_id faultwrap sizelimit noauth2 legacy_ratelimit osapi_compute_app_legacy_v2
+noauth2 = cors compute_req_id faultwrap http_proxy_to_wsgi sizelimit noauth2 legacy_ratelimit osapi_compute_app_legacy_v2
 {% if nova.auditing.enabled|bool %}
-keystone = cors compute_req_id faultwrap sizelimit authtoken keystonecontext audit legacy_ratelimit osapi_compute_app_legacy_v2
+keystone = cors compute_req_id faultwrap http_proxy_to_wsgi sizelimit authtoken keystonecontext audit legacy_ratelimit osapi_compute_app_legacy_v2
 {% else %}
-keystone = cors compute_req_id faultwrap sizelimit authtoken keystonecontext legacy_ratelimit osapi_compute_app_legacy_v2
+keystone = cors compute_req_id faultwrap http_proxy_to_wsgi sizelimit authtoken keystonecontext legacy_ratelimit osapi_compute_app_legacy_v2
 {% endif %}
 
 [composite:openstack_compute_api_v21_legacy_v2_compatible]
 use = call:nova.api.auth:pipeline_factory_v21
-noauth2 = cors compute_req_id faultwrap sizelimit noauth2 legacy_v2_compatible osapi_compute_app_v21
+noauth2 = cors compute_req_id faultwrap http_proxy_to_wsgi sizelimit noauth2 legacy_v2_compatible osapi_compute_app_v21
 {% if nova.auditing.enabled|bool %}
-keystone = cors compute_req_id faultwrap sizelimit authtoken keystonecontext audit legacy_v2_compatible osapi_compute_app_v21
+keystone = cors compute_req_id faultwrap http_proxy_to_wsgi sizelimit authtoken keystonecontext audit legacy_v2_compatible osapi_compute_app_v21
 {% else %}
-keystone = cors compute_req_id faultwrap sizelimit authtoken keystonecontext legacy_v2_compatible osapi_compute_app_v21
+keystone = cors compute_req_id faultwrap http_proxy_to_wsgi sizelimit authtoken keystonecontext legacy_v2_compatible osapi_compute_app_v21
 {% endif %}
 
 [filter:request_id]
@@ -86,6 +86,9 @@ paste.filter_factory = oslo_middleware:RequestBodySizeLimiter.factory
 [filter:legacy_v2_compatible]
 paste.filter_factory = nova.api.openstack:LegacyV2CompatibleWrapper.factory
 
+[filter:http_proxy_to_wsgi]
+paste.filter_factory = oslo_middleware:HTTPProxyToWSGI.factory
+
 [app:osapi_compute_app_legacy_v2]
 paste.app_factory = nova.api.openstack.compute:APIRouter.factory
 
@@ -93,7 +96,7 @@ paste.app_factory = nova.api.openstack.compute:APIRouter.factory
 paste.app_factory = nova.api.openstack.compute:APIRouterV21.factory
 
 [pipeline:oscomputeversions]
-pipeline = faultwrap oscomputeversionapp
+pipeline = faultwrap http_proxy_to_wsgi oscomputeversionapp
 
 [app:oscomputeversionapp]
 paste.app_factory = nova.api.openstack.compute.versions:Versions.factory


### PR DESCRIPTION
This is new oslo middleware to automatically translate from an http(s)
proxy to the wsgi application so that all the right references get sent
back. This replaces the one-off handling of the HTTPS proxy header.

This is just for nova to prove the model, before applying to all
services.

https://review.openstack.org/#/c/227868/4