### PR TITLE
Enforce novnc off on dedicated controllers

### DIFF
--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -203,4 +203,6 @@ vncserver_listen = {{ primary_ip }}
 enabled = {{ nova.enable_novnc }}
 novncproxy_base_url= {{ endpoints.novnc.url.internal }}/vnc_auto.html
 novncproxy_port = {{ endpoints.novnc.port.backend_api }}
+{% else %}
+enabled = False
 {% endif %}


### PR DESCRIPTION
novnc should only be turned on (if configured to be on) on compute nodes
only. The upstream default value has changed to default to enabled, so
we have to explictly turn it off.