### PR TITLE
Make default horizon session engine to use cache backend

### DIFF
--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -6,6 +6,7 @@ horizon:
   horizon_lib_dir: "/opt/openstack/current/horizon"
   nextgen_instance_panel: false
   legacy_instance_panel: true
+  session_engine: django.contrib.sessions.backends.cache
   source:
     rev: 'stable/mitaka'
     python_dependencies:

--- a/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
+++ b/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
@@ -37,6 +37,7 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTOCOL', 'https')
 # settings to better secure the cookies from security exploits
 CSRF_COOKIE_SECURE = True
 SESSION_COOKIE_SECURE = True
+SESSION_ENGINE = "{{ horizon.session_engine }}"
 
 # The absolute path to the directory where message files are collected.
 # The message file must have a .json file extension. When the user logins to


### PR DESCRIPTION
By default the session engine used is signed cookies.
This changes the default to use the cache session engine and
makes the option configurable.

This patch relates to the security note:
https://wiki.openstack.org/wiki/OSSN/OSSN-0017

The security note refers to a vulnerability back in icehouse. When a user logged out, horizon invalidated the session but did not send a request to keystone to invalidate the token (which was stored inside the cookie). This has been fixed here: https://github.com/openstack/django_openstack_auth/commit/cad8def073222618857bebf9a18bb4d8dd098bfc

Although the bug has been fixed, the token is still available to anyone who has access to the local token (cookie in the browser) or who have stolen it in transit (Non TLS). Using the cache session engine prevents the token from being sent to the browser.

more about django sessions here:
https://docs.djangoproject.com/en/1.9/topics/http/sessions/