### PR TITLE
Disable horizon next gen panel

### DIFF
--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -4,6 +4,8 @@ horizon:
   session_timeout: 5400
   customize: false
   horizon_lib_dir: "/opt/openstack/current/horizon"
+  nextgen_instance_panel: false
+  legacy_instance_panel: true
   source:
     rev: 'stable/mitaka'
     python_dependencies:

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -54,6 +54,7 @@
     mode: 0640
     owner: "www-data"
     group: "www-data"
+  when: horizon.customize|default('False')|bool
   notify:
     - reload apache
 

--- a/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
+++ b/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
@@ -221,8 +221,17 @@ OPENSTACK_KEYSTONE_BACKEND = {
 # Toggle LAUNCH_INSTANCE_LEGACY_ENABLED and LAUNCH_INSTANCE_NG_ENABLED to
 # determine the experience to enable.  Set them both to true to enable
 # both.
-#LAUNCH_INSTANCE_LEGACY_ENABLED = True
-#LAUNCH_INSTANCE_NG_ENABLED = False
+{% if horizon.legacy_instance_panel|default('True')|bool %}
+LAUNCH_INSTANCE_LEGACY_ENABLED = True
+{% else %}
+LAUNCH_INSTANCE_LEGACY_ENABLED = False
+{% endif %}
+
+{% if horizon.nextgen_instance_panel|default('False')|bool %}
+LAUNCH_INSTANCE_NG_ENABLED = True
+{% else %}
+LAUNCH_INSTANCE_NG_ENABLED = False
+{% endif %}
 
 # A dictionary of settings which can be used to provide the default values for
 # properties found in the Launch Instance modal.


### PR DESCRIPTION
Having CSRF issues with horizons nextgen panel, enabling legacy panel by default until that is resolved. 