### PR TITLE
Generate our own host uuid for libvirt

### DIFF
--- a/roles/nova-data/tasks/libvirt.yml
+++ b/roles/nova-data/tasks/libvirt.yml
@@ -102,6 +102,33 @@
   when: "'{{ nova.libvirt_type }}' == 'kvm'"
   changed_when: False
 
+- name: generate really unique uuid
+  command: uuidgen -t
+  args:
+    creates: /etc/machine-id
+  register: machine_id
+
+- name: write machine-id for really uniqe uuid
+  copy:
+    dest: /etc/machine-id
+    content: "{{ machine_id.stdout + '\n'}}"
+    force: no
+  when: machine_id | changed
+  notify: restart nova compute
+
+- name: read machine-id to populate libvirt host_uuid
+  slurp:
+    src: /etc/machine-id
+  register: slurp_id
+
+- name: write machine-id to libvirtd.conf
+  lineinfile:
+    dest: /etc/libvirt/libvirtd.conf
+    regexp: '^host_uuid\s*='
+    line: host_uuid = "{{ slurp_id.content | b64decode | trim }}"
+    insertafter: '^#host_uuid\s*='
+  notify: restart libvirt-bin
+
 - name: shutdown default libvirt network if started
   shell: ip addr show virbr0 && virsh net-destroy default
   failed_when: False

--- a/roles/nova-data/templates/etc/machine-id
+++ b/roles/nova-data/templates/etc/machine-id
@@ -1,0 +1,1 @@
+{{ machine_id.stdout }}


### PR DESCRIPTION
This does two things:
1) Ensure a uuid exists in /etc/machine-id
2) Write value from machine-id into libvirt config as host_uuid

host_uuid should always be unique, as it's used to validate a live
migration target.

Nova exposes to the guest some information about the host, including the
uuid. The nova default is to read /etc/machine-id and fallback to what
libvirt shows. Since we need to store a generated uuid somewhere, we're
picking /etc/machine-id for this storage.