### PR TITLE
Adding allow_availability_zone_fallback option to cinder.conf

### DIFF
--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -13,6 +13,7 @@ cinder:
   volume_group: cinder-volumes
   create_vg: False
   common_volume_name: True
+  allow_availability_zone_fallback: True
   alternatives:
       - cinder-all
       - cinder-api

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -28,6 +28,10 @@ use_forwarded_for = true
 volume_name_template = volume-%s
 auth_strategy = keystone
 
+{% if cinder.allow_availability_zone_fallback is defined -%}
+allow_availability_zone_fallback = {{ cinder.allow_availability_zone_fallback }}
+{% endif -%}
+
 {% if cinder.volume_clear_size is defined -%}
 volume_clear_size = {{ cinder.volume_clear_size }}
 {% endif -%}


### PR DESCRIPTION
This config option allows cinder volumes to be created in default availability zone (nova) when cinder doesn't have an az equal to compute's az.  This config option is introduced in Liberty release.

upstream defect: https://review.openstack.org/#/c/217857/
