### PR TITLE
Stop setting public/admin_workers in keystone.conf

### DIFF
--- a/roles/keystone/templates/etc/keystone/keystone.conf
+++ b/roles/keystone/templates/etc/keystone/keystone.conf
@@ -12,9 +12,6 @@ admin_port = {{ endpoints.keystone_admin.port.backend_api }}
 log_dir = /var/log/keystone
 default_log_levels=keystonemiddleware=INFO
 
-admin_workers = {{ keystone.admin_workers }}
-public_workers = {{ keystone.public_workers }}
-
 notification_format = cadf
 notification_driver = log
 


### PR DESCRIPTION
Keystone is running under uwsgi, so setting public_workers or
admin_workers in keystone.conf has no effect and is confusing
since someone might think that changing this value will have
some effect.