### PR TITLE
Drop the & from swift init scripts

### DIFF
--- a/roles/swift-common/templates/etc/init/swift-service.conf
+++ b/roles/swift-common/templates/etc/init/swift-service.conf
@@ -3,7 +3,7 @@ stop on runlevel [016]
 
 pre-start script
   if [ -f "/etc/swift/{{ item.conf }}.conf" ]; then
-    exec /usr/local/bin/swift-init {{ item.service_name }} start &
+    exec /usr/local/bin/swift-init {{ item.service_name }} start
   else
     exit 1
   fi


### PR DESCRIPTION
This is causing a very weird traceback on mitaka, and it's not
necessary. swift-init does the right thing anyway.