### PR TITLE
Remove default availability zone settings

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -34,7 +34,6 @@ nova:
   block_device_allocate_retries: 200
   block_device_allocate_retries_interval: 3
   heartbeat_timeout_threshold: 30
-  default_availability_zone: nova
   install_packages:
     - python-numpy
     - virt-top

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -27,8 +27,9 @@ debug = {{ nova.logging.debug }}
 # Scheduler #
 scheduler_default_filters = {{ nova.scheduler_default_filters }}
 
-default_availability_zone = {{ nova.default_availability_zone }}
+{% if nova.default_availability_zone is defined -%}
 default_schedule_zone = {{ nova.default_availability_zone }}
+{% endif -%}
 
 {% if ironic.enabled -%}
 scheduler_host_manager = nova.scheduler.ironic_host_manager.IronicHostManager

--- a/test/setup
+++ b/test/setup
@@ -65,10 +65,6 @@ cat >> ${ROOT}/envs/test/group_vars/all.yml <<eof
 neutron:
    enable_external_interface: True
 eof
-cat >> ${ROOT}/envs/test/group_vars/all.yml <<eof
-nova:
-   default_availability_zone: ci
-eof
 UNDERCLOUD_CIDR="$(python -c 'import shade; cloud = shade.openstack_cloud(); print cloud.search_subnets("internal")[0]["cidr"]')"
 cat >> ${ROOT}/envs/test/defaults-2.0.yml <<eof
 logging:


### PR DESCRIPTION
Turns out that if nothing is specified, the scheduler will just toss it
at any available compute and not try to filter by AZ. This is most
likely what we want for our stacks.

However we do want to retain the ability for for a site to override the
default, which can be done in site config.