### PR TITLE
Enable proxy header parsing in oslo_middleware.http_proxy_to_wsgi

### DIFF
--- a/roles/ceilometer-common/templates/etc/ceilometer/ceilometer.conf
+++ b/roles/ceilometer-common/templates/etc/ceilometer/ceilometer.conf
@@ -31,6 +31,9 @@ rabbit_port = 5672
 rabbit_userid = {{ rabbitmq.user }}
 rabbit_password = {{ secrets.rabbit_password }}
 
+[oslo_middleware]
+enable_proxy_headers_parsing = True
+
 [database]
 {% macro ceilometer_hosts() -%}
 {% for host in groups['controller'] -%}

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -111,6 +111,9 @@ rabbit_port = 5672
 rabbit_userid = {{ rabbitmq.user }}
 rabbit_password = {{ secrets.rabbit_password }}
 
+[oslo_middleware]
+enable_proxy_headers_parsing = True
+
 [database]
 connection=mysql+pymysql://cinder:{{ secrets.db_password }}@{{ endpoints.db }}/cinder?charset=utf8
 

--- a/roles/glance/templates/etc/glance/glance-api.conf
+++ b/roles/glance/templates/etc/glance/glance-api.conf
@@ -79,5 +79,8 @@ admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/glance/api
 cafile = {{ glance.cafile }}
 
+[oslo_middleware]
+enable_proxy_headers_parsing = True
+
 [paste_deploy]
 flavor = keystone

--- a/roles/glance/templates/etc/glance/glance-registry.conf
+++ b/roles/glance/templates/etc/glance/glance-registry.conf
@@ -56,6 +56,9 @@ admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/glance/registry
 cafile = {{ glance.cafile }}
 
+[oslo_middleware]
+enable_proxy_headers_parsing = True
+
 [paste_deploy]
 flavor = keystone
 # Name of the paste configuration file that defines the available pipelines

--- a/roles/heat/templates/etc/heat/heat.conf
+++ b/roles/heat/templates/etc/heat/heat.conf
@@ -88,3 +88,6 @@ rabbit_port = 5672
 {% endif -%}
 rabbit_userid = {{ rabbitmq.user }}
 rabbit_password = {{ secrets.rabbit_password }}
+
+[oslo_middleware]
+enable_proxy_headers_parsing = True

--- a/roles/keystone/templates/etc/keystone/keystone.conf
+++ b/roles/keystone/templates/etc/keystone/keystone.conf
@@ -85,3 +85,6 @@ trusted_dashboard = http://{{ fqdn }}/auth/websso/
 remote_id_attribute = HTTP_OIDC_CLAIM_ISS
 {% endif -%}
 {% endif -%}
+
+[oslo_middleware]
+enable_proxy_headers_parsing = True

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -109,3 +109,6 @@ rabbit_host = {{ endpoints.rabbit }}
 {% endif -%}
 rabbit_userid = {{ rabbitmq.user }}
 rabbit_password = {{ secrets.rabbit_password }}
+
+[oslo_middleware]
+enable_proxy_headers_parsing = True

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -195,6 +195,9 @@ rabbit_password = {{ secrets.rabbit_password }}
 driver = log
 {% endif %}
 
+[oslo_middleware]
+enable_proxy_headers_parsing = True
+
 [vnc]
 vncserver_proxyclient_address = {{ primary_ip }}
 vncserver_listen = {{ primary_ip }}


### PR DESCRIPTION
In master branch of oslo.middleware, by default proxy header parsing
is disabled. We need to enable is respective openstack api conf files.