### PR TITLE
Reintroduce nova default floating pool

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -34,6 +34,7 @@ nova:
   block_device_allocate_retries: 200
   block_device_allocate_retries_interval: 3
   heartbeat_timeout_threshold: 30
+  floating_pool: external
   install_packages:
     - python-numpy
     - virt-top

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -59,6 +59,7 @@ my_ip = {{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}
 use_neutron = True
 security_group_api = neutron
 firewall_driver = nova.virt.firewall.NoopFirewallDriver
+default_floating_pool = {{ nova.floating_pool }}
 
 # Cinder #
 block_device_allocate_retries = {{ nova.block_device_allocate_retries }}


### PR DESCRIPTION
This is opinionated for the way we name things, but a site can change
'external' to 'nova' to reflect the upstream default value.