### PR TITLE
Clean up federation defaults and move sp variables

### DIFF
--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -54,12 +54,12 @@ keystone:
       # for keystone to keystone federation
       k2k:
         enabled: False
-        sp_id: "default-service-provider-id"
+        sp_id: None
         shibboleth_crt: None
         shibboleth_key: None
         support_contact: ""
-        idp_id: "default-identity-provider-id"
-        idp_metadata_url: "default-keystone-idp-url"
+        idp_id: None
+        idp_metadata_url: None
         idp_metadata_min_refresh_delay: 600
         idp_metadata_max_refresh_delay: 3600
         idp_metadata_factor_refresh_delay: 0.75
@@ -69,36 +69,22 @@ keystone:
           url: https://github.com/pingidentity/mod_auth_openidc/releases/download/v1.8.3/libapache2-mod-auth-openidc_1.8.3-1_amd64.deb
         module_name: libapache2-mod-auth-openidc_1.8.3-1_amd64.deb
         scope: 'openid'
-        issuer: 'issuer'
-        remote_user_claim: 'Email'
-        user_info_endpoint: 'https://op.example.org/oauth/userinfo'
-        authorization_endpoint: 'https://op.example.org/oauth/authorize'
-        token_endpoint: 'https://op.example.org/oauth/token'
-        introspection_endpoint: 'https://op.example.org/oauth/introspection'
-        client_id: 'clientid'
-        client_secret: 'client_secret'
-        crypto_passphrase: 'openstack'
-        redirect_uri: 'https://openstack.example.org:5000/v3/auth/OS-FEDERATION/websso/oidc/redirect'
+        issuer: None
+        remote_user_claim: None
+        user_info_endpoint: None
+        authorization_endpoint: None
+        token_endpoint: None
+        introspection_endpoint: None
+        client_id: None
+        client_secret: None
+        crypto_passphrase: None
+        redirect_uri: None
         ssl_validate_server: True
-    identity_providers:
-      - { name: someprovider, remote_ids: oidc }
-    groups:
-      - { name: someprovider-admins }
-    role:
-      - { group: someprovider-admins, role: some-role, project: some-project }
-    mappings:
-      - name: someprovider-admins
-        rules:
-          - local:
-            - group:
-                name: someprovider-admins
-                domain:
-                  name: Default
-            remote:
-            - type: HTTP_OIDC_CLAIM_USERNAME
-              any_one_of: ['user@someprovider.com']
-    protocols:
-      - { name: oidc, mapping: someprovider-admins, identity_provider: someprovider }
+      identity_providers: []
+      groups: []
+      role: []
+      mappings: []
+      protocols: []
 
   bootstrap:
     user: admin

--- a/roles/keystone-setup/tasks/federation.yml
+++ b/roles/keystone-setup/tasks/federation.yml
@@ -31,7 +31,7 @@
                               description="{{ item.description|default(omit) }}"
                               remote_ids="{{ item.remote_ids|default(omit) }}"
                               enabled="{{ item.enabled|default(omit) }}"
-  with_items: "{{ keystone.federation.identity_providers }}"
+  with_items: "{{ keystone.federation.sp.identity_providers }}"
 
 - name: create keystone groups
   keystone_group: auth_url="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v3"
@@ -42,7 +42,7 @@
                   project_name_to_auth="admin"
                   domain_name_to_auth="Default"
                   domain="{{ item.domain|default(omit) }}"
-  with_items: "{{ keystone.federation.groups }}"
+  with_items: "{{ keystone.federation.sp.groups }}"
 
 - name: add role to keystone group
   keystone_role: auth_url="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v3"
@@ -54,7 +54,7 @@
                   domain="{{ item.domain|default(omit) }}"
                   role="{{ item.role }}"
                   project="{{ item.project }}"
-  with_items: "{{ keystone.federation.role }}"
+  with_items: "{{ keystone.federation.sp.role }}"
 
 - name: create keystone federation mappings
   keystone_federation_mapping: auth_url="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v3"
@@ -64,7 +64,7 @@
                                project_name_to_auth="admin"
                                domain_name_to_auth="Default"
                                rules="{{ item.rules }}"
-  with_items: "{{ keystone.federation.mappings }}"
+  with_items: "{{ keystone.federation.sp.mappings }}"
 
 - name: create keystone protocols
   keystone_federation_protocol: auth_url="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/v3"
@@ -75,4 +75,4 @@
                                 domain_name_to_auth="Default"
                                 identity_provider="{{ item.identity_provider }}"
                                 mapping="{{ item.mapping }}"
-  with_items: "{{ keystone.federation.protocols }}"
+  with_items: "{{ keystone.federation.sp.protocols }}"


### PR DESCRIPTION
The variables for federation should not have example strings and
should have useful default values.

The group, role, mapping, and protocol, federation variables will be moved
into the sp section since they are considered to be variables intended for
service providers.