### PR TITLE
Revert to cli client from os_user due to os_user not respecting domain field

### DIFF
--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -61,22 +61,15 @@
   failed_when: heat_domain|failed and "HTTP 409" not in heat_domain.stderr
 
 - name: create heat domain admin user
-  os_user:
-    auth:
-      auth_url: "{{ endpoints.keystone.url.admin }}"
-      project_name: admin
-      username: admin
-      password: "{{ secrets.admin_password }}"
-    state: present
-    name: heat_domain_admin
-    password: "{{ secrets.stack_domain_admin_password }}"
-    domain: heat
+  shell: . /root/stackrc; openstack --os-identity-api-version 3 --os-auth-url "{{ endpoints.keystone.url.admin }}/v3" user create --domain heat --password "{{ secrets.stack_domain_admin_password }}" heat_domain_admin
   run_once: true
   register: heat_user
+  failed_when: heat_user|failed and "HTTP 409" not in heat_user.stderr
 
 - name: add admin role to the heat domain admin user
-  shell: . /root/stackrc; openstack --os-identity-api-version 3 --os-auth-url "{{ endpoints.keystone.url.admin }}/v3" role add --domain heat --user "{{ heat_user.user.id }}" admin
+  shell: . /root/stackrc; openstack --os-identity-api-version 3 --os-auth-url "{{ endpoints.keystone.url.admin }}/v3" role add --domain heat --user "{{ heat_user.stdout_lines[5].split('|')[2].strip() }}" admin
   run_once: true
+  when: heat_user.stderr == '' # otherwise result of user create not populated
 
 - name: stop heat services before db sync
   service: name={{ item }} state=stopped


### PR DESCRIPTION
feedback from tesla:


seems like heat_domain_admin user is not created under heat domain. Also, is missing the description (just a nit)..
clients) ➜  
tesla openstack --insecure domain list
+----------------------------------+---------+---------+--------------------+
| ID                               | Name    | Enabled | Description        |
+----------------------------------+---------+---------+--------------------+
| 9766008e644d481381188681e8c9bb2d | heat    | True    |                    |
| default                          | Default | True    | The default domain |
+----------------------------------+---------+---------+--------------------+
(clients) ➜  
tesla openstack --insecure user show heat_domain_admin
+-----------+----------------------------------+
| Field     | Value                            |
+-----------+----------------------------------+
| domain_id | default                          |
| email     | None                             |
| enabled   | True                             |
| id        | 32459b4fa9e34c34845f047f8ec60679 |
| name      | heat_domain_admin                |
+-----------+----------------------------------+

This is confirmed, appears that os_user does not respect identity_api_version and does not append domain to user create (code from prior commit creates heat_domain_admin in default domain)
