### PR TITLE
Relocate keystone oslo_middleware config

### DIFF
--- a/roles/keystone/templates/etc/keystone/keystone.conf
+++ b/roles/keystone/templates/etc/keystone/keystone.conf
@@ -71,6 +71,9 @@ config_file = /etc/keystone/keystone-paste.ini
 [revoke]
 driver = keystone.contrib.revoke.backends.sql.Revoke
 
+[oslo_middleware]
+enable_proxy_headers_parsing = True
+
 {% if keystone.federation.enabled|bool -%}
 [auth]
 methods = external,password,token{{ ',oidc' if keystone.federation.sp.oidc.enabled|bool else '' }}{{ ',saml2' if keystone.federation.sp.k2k.enabled|bool else '' }}
@@ -103,6 +106,3 @@ idp_metadata_path=/etc/keystone/keystone_idp_metadata.xml
 {% endif -%}
 
 {% endif -%}
-
-[oslo_middleware]
-enable_proxy_headers_parsing = True


### PR DESCRIPTION
This was added inside the federation if block, so it was not getting
written out on non-federated installs.