### PR TITLE
Remove apache cookie manipulation for horizon

### DIFF
--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -4,8 +4,8 @@ horizon:
   session_timeout: 5400
   customize: false
   horizon_lib_dir: "/opt/openstack/current/horizon"
-  nextgen_instance_panel: false
-  legacy_instance_panel: true
+  nextgen_instance_panel: true
+  legacy_instance_panel: false
   session_engine: django.contrib.sessions.backends.cache
   source:
     rev: 'stable/mitaka'

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -10,12 +10,6 @@
   notify:
     - reload apache
 
-- name: disable apache status
-  template: src=etc/apache2/mods-enabled/headers.conf
-            dest=/etc/apache2/mods-enabled/headers.conf
-  notify:
-    - reload apache
-
 - name: create horizon config directory
   file: dest=/etc/openstack-dashboard state=directory
 

--- a/roles/horizon/templates/etc/apache2/mods-enabled/headers.conf
+++ b/roles/horizon/templates/etc/apache2/mods-enabled/headers.conf
@@ -1,4 +1,0 @@
-<IfModule mod_headers.c>
- Header edit Set-Cookie ^(.*)$ $1;HttpOnly;Secure
-</IfModule>
-# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
Adding the secure and httponly attributes to horizon cookies was causing CSRF validation failures when using ajax panels. These attributes can be set using django settings. With this fix, I've enabled the next gen instance panel and made the legacy panel disabled by default. 