### PR TITLE
Pin keystone client below 3.0.0

### DIFF
--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -3,7 +3,7 @@ client:
   write_stackrc: True
   self_signed_cert: false
   names:
-    - python-keystoneclient
+    - python-keystoneclient<3.0.0
     - python-glanceclient>=1.1.0
     - python-novaclient<2.27.0
     - python-neutronclient<4.0.0


### PR DESCRIPTION
This will break things for us if it goes above 3.0.0, such as our old
clients and modules.