### PR TITLE
Disable logging to logstash by default

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -599,12 +599,7 @@ haproxy:
   enabled: True
 
 logging:
-  enabled: True
-  follow:
-    global_fields:
-      cluster_name: "example-dev"
-  download:
-    url: https://file-mirror.openstack.blueboxgrid.com/logstash/logstash-forwarder_0.3.1_amd64.deb
+  enabled: False
 
 keystonev3:
   enabled: True

--- a/roles/apache/meta/main.yml
+++ b/roles/apache/meta/main.yml
@@ -3,3 +3,4 @@ dependencies:
   - role: logging-config
     service: apache
     logdata: "{{ apache.logs }}"
+    when: logging.enabled|default('True')|bool

--- a/test/setup
+++ b/test/setup
@@ -67,14 +67,7 @@ neutron:
 eof
 UNDERCLOUD_CIDR="$(python -c 'import shade; cloud = shade.openstack_cloud(); print cloud.search_subnets("internal")[0]["cidr"]')"
 cat >> ${ROOT}/envs/test/defaults-2.0.yml <<eof
-logging:
-  follow:
-    global_fields:
-      cluster_name: "ci-test"
-  forward:
-    host: kibana.sea03.blueboxgrid.com
-    port: 4560
-undercloud_cidr: 
+undercloud_cidr:
   - cidr: ${UNDERCLOUD_CIDR}
 eof
 popd


### PR DESCRIPTION
Let the CI enable logging to logstash since it knows where logs should
be forwarded to and how it should be configured.