### PR TITLE
Update haproxy config to support large clusters

### DIFF
--- a/roles/endpoints/defaults/main.yml
+++ b/roles/endpoints/defaults/main.yml
@@ -223,5 +223,6 @@ endpoints:
       proxy_api: 8080
     haproxy:
       health_check: 'httpchk HEAD /healthcheck HTTP/1.0'
-      balance: 'source'
+      balance: 'roundrobin'
       prefer_primary_backend: False
+      maxconn: 4096

--- a/roles/haproxy/templates/etc/haproxy/haproxy_swift.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_swift.cfg
@@ -1,6 +1,6 @@
 global
   log /dev/log local0
-  maxconn 256
+  maxconn {{ endpoints.swift.haproxy.maxconn }}
   user nobody
    group nogroup
   daemon


### PR DESCRIPTION
Increased number of maxconn parameter in haproxy since some of swift connections could persist longer.

Also, roundrobin would distribute requests evenly across all proxy nodes 