### PR TITLE
updated ceilometer policy with mitaka community rules

### DIFF
--- a/roles/ceilometer-common/templates/etc/ceilometer/policy.json
+++ b/roles/ceilometer-common/templates/etc/ceilometer/policy.json
@@ -1,7 +1,5 @@
 {
-    "context_is_admin": "role:admin or role:cloud_admin",
-    "context_is_project": "project_id:%(target.project_id)s",
-    "context_is_owner": "user_id:%(target.user_id)s",
+    "context_is_admin": "role:admin",
     "segregation": "rule:context_is_admin",
 
     "telemetry:get_samples": "",


### PR DESCRIPTION
Removed extra lines as per community's new Mitaka policy, and removed `cloud_admin` from `context_is_admin`. 