### PR TITLE
Define project_name for keystone

### DIFF
--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+project_name: keystone
 keystone:
   token_expiration_in_seconds: 86400
   admin_workers: 5


### PR DESCRIPTION
This minimal change makes package based installs with Ansible 2.1 work
again. Probably should define this globally across the projects.