### PR TITLE
library: sensu_*_check modules support tags/deps

### DIFF
--- a/library/sensu_check.py
+++ b/library/sensu_check.py
@@ -39,6 +39,8 @@ def main():
             env_vars=dict(required=False,default=''),
             command=dict(required=False,default=''),
             handler=dict(required=False,default='default'),
+            tags=dict(required=False, type='list'),
+            dependencies=dict(required=False, type='list'),
             plugin_dir=dict(default='/etc/sensu/plugins', required=False),
             check_dir=dict(default='/etc/sensu/conf.d/checks', required=False),
             state=dict(default='present', required=False, choices=['present','absent'])
@@ -69,7 +71,9 @@ def main():
                         'interval': int(module.params['interval']),
                         'occurrences': int(module.params['occurrences']),
                         'auto_resolve': module.params['auto_resolve'],
-                        'handle': module.params['handle']
+                        'handle': module.params['handle'],
+                        'tags': module.params['tags'],
+                        'dependencies': module.params['dependencies']
                     }
                 }
             })

--- a/library/sensu_metrics_check.py
+++ b/library/sensu_metrics_check.py
@@ -31,6 +31,7 @@ def main():
             use_sudo=dict(required=False, type='bool', default=False),
             plugin=dict(default=None, required=True),
             args=dict(default='', required=False),
+            tags=dict(required=False, type='list'),
             plugin_dir=dict(default='/etc/sensu/plugins', required=False),
             check_dir=dict(default='/etc/sensu/conf.d/checks', required=False),
             prefix=dict(default='', required=False),
@@ -56,7 +57,8 @@ def main():
                         'command': command,
                         'standalone': True,
                         'interval': int(module.params['interval']),
-                        'handlers': [ 'metrics' ]
+                        'handlers': [ 'metrics' ],
+                        'tags': module.params['tags'],
                     }
                 }
             })

--- a/library/sensu_process_check.py
+++ b/library/sensu_process_check.py
@@ -30,6 +30,8 @@ def main():
             crit_over=dict(default=30, required=False),
             interval=dict(default=30, required=False),
             occurrences=dict(default=2, required=False),
+            tags=dict(required=False, type='list'),
+            dependencies=dict(required=False, type='list'),
             plugin_dir=dict(default='/etc/sensu/plugins', required=False),
             check_dir=dict(default='/etc/sensu/conf.d/checks', required=False),
             state=dict(default='present', required=False, choices=['present','absent'])
@@ -52,7 +54,9 @@ def main():
                         'handlers': [ 'default' ],
                         'interval': int(module.params['interval']),
                         'notification': notification,
-                        'occurrences':  int(module.params['occurrences'])
+                        'occurrences':  int(module.params['occurrences']),
+                        'tags': module.params['tags'],
+                        'dependencies': module.params['dependencies']
                     }
                 }
             })


### PR DESCRIPTION
Due to more complicated alert routing required, the checks and alerts
generated need to have tags sent with them (to direct to the correct
    recipient).
Dependencies are also useful for silencing an alert based upon the state
of some other specified checkt.