### PR TITLE
Use upstream ansible modules for keystone setup

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -131,7 +131,7 @@ apt_repos:
     key_url: https://apt-mirror.openstack.blueboxgrid.com/keys/percona.key
   rabbitmq:
     repo: https://apt-mirror.openstack.blueboxgrid.com/rabbitmq/debian
-    key_url: https://apt-mirror.openstack.blueboxgrid.com/keys/rabbitmq.key
+    key_url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
   cloud_archive:
     repo: https://apt-mirror.openstack.blueboxgrid.com/cloud_archive/ubuntu
   erlang:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ tox
 pep8
 oslo.utils
 shade>=1.7.0
-ansible>=2.0.2.0,<3
+ansible>=2.1.0.0,<3
 python-novaclient
 python-glanceclient
 python-cinderclient

--- a/roles/apt-repos/defaults/main.yml
+++ b/roles/apt-repos/defaults/main.yml
@@ -30,7 +30,7 @@ apt_repos:
     key_url: 'https://www.percona.com/redir/downloads/RPM-GPG-KEY-percona'
   rabbitmq:
     repo: 'http://www.rabbitmq.com/debian/'
-    key_url: 'https://www.rabbitmq.com/rabbitmq-signing-key-public.asc'
+    key_url: 'https://www.rabbitmq.com/rabbitmq-release-signing-key.asc'
   cloud_archive:
     repo: 'http://ubuntu-cloud.archive.canonical.com/ubuntu'
   erlang:

--- a/roles/ceilometer-common/defaults/main.yml
+++ b/roles/ceilometer-common/defaults/main.yml
@@ -5,6 +5,7 @@ ceilometer:
     rev: 'stable/mitaka'
     python_dependencies:
       - { name: pymongo, version: '3.0.3' }
+      - { name: amqp, version: '1.4.9' }
   alternatives:
     - ceilometer-api
     - ceilometer-collector

--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -29,6 +29,7 @@ cinder:
     rev: 'stable/mitaka'
     python_dependencies:
       - { name: PyMySQL }
+      - { name: amqp, version: '1.4.9' }
     system_dependencies: []
   logs:
   - paths:

--- a/roles/common/tasks/python.yml
+++ b/roles/common/tasks/python.yml
@@ -49,4 +49,4 @@
   with_items: "{{ common.python_extra_packages }}"
 
 - name: install shade for ansible modules
-  pip: name=shade state=latest
+  pip: name=shade>=1.9.0

--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -6,6 +6,7 @@ heat:
     rev: 'stable/mitaka'
     python_dependencies:
       - { name: PyMySQL }
+      - { name: amqp, version: '1.4.9' }
     system_dependencies: []
   alternatives:
     - heat-api

--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -51,25 +51,51 @@
     - heat_stack_user
   run_once: true
 
-## These heat openstack client calls can be replaced with ansible modules calls
-## when we upgrade to ansible 2.0
-
 - name: create heat domain
-  shell: . /root/stackrc; openstack --os-identity-api-version 3 --os-auth-url "{{ endpoints.keystone.url.admin }}/v3" domain create heat
+  environment:
+    OS_IDENTITY_API_VERSION: 3
+    OS_DOMAIN_ID: default
+  os_keystone_domain:
+    name: heat
+    auth:
+      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
   run_once: true
   register: heat_domain
-  failed_when: heat_domain|failed and "HTTP 409" not in heat_domain.stderr
 
 - name: create heat domain admin user
-  shell: . /root/stackrc; openstack --os-identity-api-version 3 --os-auth-url "{{ endpoints.keystone.url.admin }}/v3" user create --domain heat --password "{{ secrets.stack_domain_admin_password }}" heat_domain_admin
+  environment:
+    OS_IDENTITY_API_VERSION: 3
+    OS_DOMAIN_ID: default
+  os_user:
+    name: heat_domain_admin
+    password: "{{ secrets.stack_domain_admin_password }}"
+    default_project: admin
+    domain: "{{ heat_domain.domain.id }}"
+    auth:
+      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
   run_once: true
-  register: heat_user
-  failed_when: heat_user|failed and "HTTP 409" not in heat_user.stderr
 
 - name: add admin role to the heat domain admin user
-  shell: . /root/stackrc; openstack --os-identity-api-version 3 --os-auth-url "{{ endpoints.keystone.url.admin }}/v3" role add --domain heat --user "{{ heat_user.stdout_lines[5].split('|')[2].strip() }}" admin
+  environment:
+    OS_IDENTITY_API_VERSION: 3
+    OS_DOMAIN_ID: default
+  os_user_role:
+    role: admin
+    user: heat_domain_admin
+    domain: "{{ heat_domain.domain.id }}"
+    auth:
+      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
+  when: heat.enabled|bool
   run_once: true
-  when: heat_user.stderr == '' # otherwise result of user create not populated
 
 - name: stop heat services before db sync
   service: name={{ item }} state=stopped

--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -21,6 +21,9 @@ keystone:
   jellyroll: False # custom middleware for password compliance
   roles:
     - project_admin
+    - cloud_admin
+    - heat_stack_owner
+    - service
   logs:
     - paths:
       - /var/log/keystone/keystone-all.log

--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -8,6 +8,7 @@ keystone:
     python_dependencies:
       - { name: PyMySQL }
       - { name: uwsgi }
+      - { name: amqp, version: '1.4.9' }
     system_dependencies:
       - openssl
       - libldap2-dev

--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -13,60 +13,124 @@
     OS_BOOTSTRAP_REGION_ID: "RegionOne"
 
 - name: keystone tenants
-  keystone_user: tenant={{ item }}
-                 tenant_description="{{ item }} tenant"
-                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
-                 login_tenant_name={{ keystone.bootstrap.project }}
-                 login_user={{ keystone.bootstrap.user }}
-                 login_password={{ secrets.admin_password }}
+  environment:
+    OS_IDENTITY_API_VERSION: 3
+    OS_DOMAIN_ID: default
+  os_project:
+    name: "{{ item }}"
+    description: "{{ item }} tenant"
+    domain: default
+    auth:
+      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
   with_items: "{{ keystone.tenants }}"
 
 - name: keystone users
-  keystone_user: user={{ item.name }}
-                 password={{ item.password }}
-                 tenant={{ item.tenant }}
-                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
-                 login_tenant_name={{ keystone.bootstrap.project }}
-                 login_user={{ keystone.bootstrap.user }}
-                 login_password={{ secrets.admin_password }}
+  environment:
+    OS_IDENTITY_API_VERSION: 3
+    OS_DOMAIN_ID: default
+  os_user:
+    name: "{{ item.name }}"
+    password: "{{ item.password }}"
+    default_project: "{{ item.tenant }}"
+    domain: default
+    auth:
+      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
   with_items: "{{ keystone.users }}"
 
 - name: keystone roles
-  keystone_user: role={{ item }}
-                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
-                 login_tenant_name={{ keystone.bootstrap.project }}
-                 login_user={{ keystone.bootstrap.user }}
-                 login_password={{ secrets.admin_password }}
+  environment:
+    OS_IDENTITY_API_VERSION: 3
+    OS_DOMAIN_ID: default
+  os_keystone_role:
+    name: "{{ item }}"
+    auth:
+      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
   with_items: "{{ keystone.roles }}"
 
 - name: keystone user roles
-  keystone_user: role={{ item.role }}
-                 user={{ item.user }}
-                 tenant={{ item.tenant }}
-                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
-                 login_tenant_name={{ keystone.bootstrap.project }}
-                 login_user={{ keystone.bootstrap.user }}
-                 login_password={{ secrets.admin_password }}
+  environment:
+    OS_IDENTITY_API_VERSION: 3
+    OS_DOMAIN_ID: default
+  os_user_role:
+    role: "{{ item.role }}"
+    user: "{{ item.user }}"
+    project: "{{ item.tenant }}"
+    auth:
+      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
   with_items: "{{ keystone.user_roles }}"
 
+# This task is added separately as to not change the format in the
+# defaults-2.0.yml file, as that would be backwards incompatible.
+# The admin user needs admin role on the domain itself in keystonev3,
+# in particular to see the Domains tab in Horizon.
+- name: grant admin domain admin rights
+  environment:
+    OS_IDENTITY_API_VERSION: 3
+    OS_DOMAIN_ID: default
+  os_user_role:
+    role: admin
+    user: admin
+    domain: default
+    auth:
+      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
+
 - name: heat stack user
-  keystone_user: user=heat_stack_user
-                 password={{ secrets.service_password }}
-                 tenant=admin
-                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
-                 login_tenant_name={{ keystone.bootstrap.project }}
-                 login_user={{ keystone.bootstrap.user }}
-                 login_password={{ secrets.admin_password }}
+  environment:
+    OS_IDENTITY_API_VERSION: 3
+    OS_DOMAIN_ID: default
+  os_user:
+    name: heat_stack_user
+    password: "{{ secrets.service_password }}"
+    default_project: admin
+    domain: default
+    auth:
+      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
+  when: heat.enabled|bool
+
+- name: heat stack role
+  environment:
+    OS_IDENTITY_API_VERSION: 3
+    OS_DOMAIN_ID: default
+  os_keystone_role:
+    name: heat_stack_user
+    auth:
+      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
   when: heat.enabled|bool
 
 - name: heat stack user role
-  keystone_user: role=heat_stack_user
-                 user=heat_stack_user
-                 tenant=admin
-                 endpoint="http://127.0.0.1:{{ endpoints.keystone_admin.port.backend_api }}/{{ endpoints.keystone.version }}/"
-                 login_tenant_name={{ keystone.bootstrap.project }}
-                 login_user={{ keystone.bootstrap.user }}
-                 login_password={{ secrets.admin_password }}
+  environment:
+    OS_IDENTITY_API_VERSION: 3
+    OS_DOMAIN_ID: default
+  os_user_role:
+    role: heat_stack_user
+    user: heat_stack_user
+    project: admin
+    auth:
+      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
   when: heat.enabled|bool
 
 - include: federation.yml

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -58,6 +58,7 @@ neutron:
     python_dependencies:
       - { name: "git+git://github.com/openstack/neutron-lbaas.git@stable/mitaka#egg=neutron-lbaas" }
       - { name: PyMySQL }
+      - { name: amqp, version: '1.4.9' }
     system_dependencies: []
   alternatives:
     - neutron-db-manage

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -50,6 +50,7 @@ nova:
       - { name: PyMySQL }
       - { name: python-memcached }
       - { name: paramiko==1.16.0 }
+      - { name: amqp, version: '1.4.9' }
     system_dependencies:
       - libjs-jquery-tablesorter
       - python-libvirt


### PR DESCRIPTION
We get access to os_user, os_keystone_role, and os_user_role now so lets
use them. Also we need to set up the admin user to have admin role on
the default domain, which is a new keystonev3 thing.