### PR TITLE
Unipin (most) clients

### DIFF
--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -5,12 +5,12 @@ client:
   names:
     - python-keystoneclient<3.0.0
     - python-glanceclient>=1.1.0
-    - python-novaclient<2.27.0
-    - python-neutronclient<4.0.0
+    - python-novaclient
+    - python-neutronclient
     - python-cinderclient
-    - python-heatclient<0.9.0
+    - python-heatclient
     - python-ceilometerclient
-    - python-ironicclient<0.9.0
+    - python-ironicclient
     - python-swiftclient
     - python-magnumclient
   apt_packages:


### PR DESCRIPTION
We no longer rely on the command line in our automation, and we don't
rely on the libraries as much any more given use of shade. Unpinning
these seems to make the clients work again, including openstackclient,
which wasn't previously working.

Keystone client is pinned under 3.0.0 as the newer one does break a few
things.