### PR TITLE
Restore required neutron alternatives

### DIFF
--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -64,6 +64,7 @@ neutron:
     - neutron-db-manage
     - neutron-debug
     - neutron-dhcp-agent
+    - neutron-keepalived-state-change
     - neutron-l3-agent
     - neutron-lbaasv2-agent
     - neutron-linuxbridge-agent
@@ -74,6 +75,7 @@ neutron:
     - neutron-openvswitch-agent
     - neutron-ovs-cleanup
     - neutron-rootwrap
+    - neutron-rootwrap-daemon
     - neutron-rootwrap-xen-dom0
     - neutron-sanity-check
     - neutron-server


### PR DESCRIPTION
Following commit removed neutron-keepalived-state-change and neutron-rootwrap-daemon from neutron alternatives list in error.
1ef4659

They are present in the commit from which this was cherry-picked from (8cf09fc) and are required for neutron.
