### PR TITLE
Pin keystoneclient below 3.0.0

### DIFF
--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -3,15 +3,15 @@ client:
   write_stackrc: True
   self_signed_cert: false
   names:
-    - python-keystoneclient<3.0.0
-    - python-glanceclient>=1.1.0
-    - python-novaclient<2.27.0
-    - python-neutronclient<4.0.0
-    - python-cinderclient
-    - python-heatclient<0.9.0
-    - python-ceilometerclient
-    - python-ironicclient<0.9.0
-    - python-swiftclient
-    - python-magnumclient
+    - python-glanceclient==2.0.0
+    - python-novaclient==2.26.0
+    - python-neutronclient==3.1.1
+    - python-cinderclient==1.1.3
+    - python-heatclient==0.8.1
+    - python-ceilometerclient==2.4.0
+    - python-ironicclient==0.8.1
+    - python-swiftclient==3.0.0
+    - python-magnumclient==2.0.0
+    - python-keystoneclient==2.3.1
   apt_packages:
     - python-prettytable

--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -3,7 +3,7 @@ client:
   write_stackrc: True
   self_signed_cert: false
   names:
-    - python-keystoneclient
+    - python-keystoneclient<3.0.0
     - python-glanceclient>=1.1.0
     - python-novaclient<2.27.0
     - python-neutronclient<4.0.0

--- a/test/common
+++ b/test/common
@@ -15,7 +15,7 @@ SSH_ARGS=\
 " -i ${KEY_PATH}"
 export ANSIBLE_SSH_ARGS="${SSH_ARGS}"
 export ANSIBLE_VAR_DEFAULTS_FILE="${ROOT}/envs/test/defaults-2.0.yml"
-export IMAGE_ID=${IMAGE_ID:=1525c3f3-1224-4958-bd07-da9feaedf18b}
+export IMAGE_ID=${IMAGE_ID:=ubuntu-14.04}
 
 if [[ -n ${BUILD_TAG} ]]; then
   export testenv_instance_prefix=${BUILD_TAG}


### PR DESCRIPTION
3.0.0 drops the keystone executable and changes some of the python API
in a way that we aren't ready for in the 2.1.x release tree.