### PR TITLE
added _member_ to list of roles created by default

### DIFF
--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -26,6 +26,7 @@ keystone:
     - cloud_admin
     - heat_stack_owner
     - service
+    - _member_
   logs:
     - paths:
       - /var/log/keystone/keystone-all.log


### PR DESCRIPTION
`_member_` role was not being automatically created by Ansible