### PR TITLE
Load correct federation mapping format

### DIFF
--- a/library/keystone_federation_mapping.py
+++ b/library/keystone_federation_mapping.py
@@ -77,7 +77,7 @@ def main():
                 params = {
                     'client': keystone,
                     'mapping_id': module.params['name'],
-                    'rules': module.params['rules']
+                    'rules': yaml.load(module.params['rules'])
                 }
                 _create_federation_mapping(**params)
                 changed = True


### PR DESCRIPTION
This fixes an error where the mapping creation request to keystone returns
a formatting error.