### PR TITLE
Add option to verify k2k idp cert

### DIFF
--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -69,6 +69,7 @@ keystone:
         idp_metadata_min_refresh_delay: 600
         idp_metadata_max_refresh_delay: 3600
         idp_metadata_factor_refresh_delay: 0.75
+        verify_idp_cert: True
       oidc:
         enabled: False
         download:

--- a/roles/keystone/templates/etc/shibboleth/shibboleth2.xml
+++ b/roles/keystone/templates/etc/shibboleth/shibboleth2.xml
@@ -29,9 +29,11 @@
           minRefreshDelay="{{ keystone.federation.sp.k2k.idp_metadata_min_refresh_delay }}"
           maxRefreshDelay="{{ keystone.federation.sp.k2k.idp_metadata_max_refresh_delay }}"
           refreshDelayFactor="{{ keystone.federation.sp.k2k.idp_metadata_factor_refresh_delay }}">
+          {% if keystone.federation.sp.k2k.verify_idp_cert|bool -%}
           <TransportOption provider="CURL" option="64">1</TransportOption>
           <TransportOption provider="CURL" option="81">2</TransportOption>
           <TransportOption provider="CURL" option="10065">/etc/ssl/certs/ca-certificates.crt</TransportOption>
+          {% endif -%}
         </MetadataProvider>
         <AttributeExtractor type="XML" validate="true" reloadChanges="false" path="attribute-map.xml"/>
         <AttributeResolver type="Query" subjectMatch="true"/>


### PR DESCRIPTION
This adds the option for shibboleth to not verify the certificate
of the keystone idp. This is for testing purposes.