### PR TITLE
Set the enable type for the service provider module

### DIFF
--- a/library/keystone_service_provider.py
+++ b/library/keystone_service_provider.py
@@ -129,7 +129,7 @@ def main():
         service_provider_id=dict(required=True),
         service_provider_url=dict(required=True),
         service_provider_auth_url=dict(required=True),
-        enabled=dict(required=False, default=True),
+        enabled=dict(required=False, type='bool', default=True),
         description=dict(required=False, default=None),
         state=dict(default='present', choices=['absent', 'present']),
     )


### PR DESCRIPTION
This fixes a bug where the 'enabled' parameter gets set as type string
instead of type bool. Keystone throws an error saying that 'True' is
an invalid paramter for 'enabled' when creating the service provider.