### PR TITLE
fix ntp configuration

### DIFF
--- a/roles/common/tasks/ntp.yml
+++ b/roles/common/tasks/ntp.yml
@@ -1,24 +1,15 @@
 ---
-- name: ntp.conf include directive
-  lineinfile: dest=/etc/ntp.conf
-              line="includefile /etc/ntp/cluster.conf" state=present
-
-- name: ntp servers
-  lineinfile: dest=/etc/ntp.conf
-              line="server {{ item }} iburst" state=present
-  with_items: "{{ common.ntpd.servers }}"
-  notify:
-    - restart-ntp
-
-- name: /etc/ntp directory
-  file: dest=/etc/ntp state=directory mode=755 owner=root
-
-- name: ntp/cluster.conf
-  template: dest=/etc/ntp/cluster.conf
-            src=etc/ntp/cluster.conf
-            mode=644 owner=root
+- name: install ntp.conf
+  template:
+    dest: /etc/ntp.conf
+    src: etc/ntp.conf
+    mode: 0644
+    owner: root
   notify:
     - restart-ntp
 
 - name: ntp service enabled
-  service: name=ntp state=started enabled=true
+  service:
+    name: ntp
+    state: started
+    enabled: true

--- a/roles/common/templates/etc/ntp.conf
+++ b/roles/common/templates/etc/ntp.conf
@@ -1,0 +1,66 @@
+# {{ ansible_managed }}
+# /etc/ntp.conf, configuration for ntpd; see ntp.conf(5) for help
+
+driftfile /var/lib/ntp/ntp.drift
+
+# Enable this if you want statistics to be logged.
+#statsdir /var/log/ntpstats/
+
+statistics loopstats peerstats clockstats
+filegen loopstats file loopstats type day enable
+filegen peerstats file peerstats type day enable
+filegen clockstats file clockstats type day enable
+
+# Specify one or more NTP servers.
+
+{% if common.ntpd.servers %}
+# Blue Box designated ntpd servers
+{% for server in common.ntpd.servers %}
+server {{ server }} iburst
+{% endfor %}
+{% else %}
+# Use servers from the NTP Pool Project. Approved by Ubuntu Technical Board
+# on 2011-02-08 (LP: #104525). See http://www.pool.ntp.org/join.html for
+# more information.
+server 0.ubuntu.pool.ntp.org
+server 1.ubuntu.pool.ntp.org
+server 2.ubuntu.pool.ntp.org
+server 3.ubuntu.pool.ntp.org
+
+# Use Ubuntu's ntp server as a fallback.
+server ntp.ubuntu.com
+{% endif %}
+
+# Access control configuration; see /usr/share/doc/ntp-doc/html/accopt.html for
+# details.  The web page <http://support.ntp.org/bin/view/Support/AccessRestrictions>
+# might also be helpful.
+#
+# Note that "restrict" applies to both servers and clients, so a configuration
+# that might be intended to block requests from certain clients could also end
+# up blocking replies from your own upstream servers.
+
+# By default, exchange time with everybody, but don't allow configuration.
+restrict -4 default kod notrap nomodify nopeer noquery
+restrict -6 default kod notrap nomodify nopeer noquery
+
+# Local users may interrogate the ntp server more closely.
+restrict 127.0.0.1
+restrict ::1
+
+# Clients from this (example!) subnet have unlimited access, but only if
+# cryptographically authenticated.
+#restrict 192.168.123.0 mask 255.255.255.0 notrust
+
+# If you want to provide time to your local subnet, change the next line.
+# (Again, the address is an example only.)
+#broadcast 192.168.123.255
+
+# If you want to listen to time broadcasts on your local subnet, de-comment the
+# next lines.  Please do this only if you trust everybody on the network!
+#disable auth
+#broadcastclient
+
+# Maintain NTP peering with all other cluster nodes
+{% for controller_ip in hostvars|ursula_controller_ips(groups) %}
+peer {{ controller_ip }}
+{% endfor %}

--- a/roles/common/templates/etc/ntp/cluster.conf
+++ b/roles/common/templates/etc/ntp/cluster.conf
@@ -1,4 +1,0 @@
-# Maintain NTP peering with all other cluster nodes
-{% for controller_ip in hostvars|ursula_controller_ips(groups) %}
-peer {{ controller_ip }}
-{% endfor %}


### PR DESCRIPTION
vendor ntp configuration into /etc/ntp.conf;
use ntp servers as configured in vars @ common.ntpd.servers, or use defaults from ubuntu;
integrates ntp peering into single file (removes /etc/ntp/cluster.conf).