### PR TITLE
Enable memcached for Shibboleth sp

### DIFF
--- a/roles/keystone/templates/etc/shibboleth/shibboleth2.xml
+++ b/roles/keystone/templates/etc/shibboleth/shibboleth2.xml
@@ -1,9 +1,32 @@
+{% macro memcached_hosts() -%}
+{% for host in groups['controller'] -%}
+   {%- if loop.last -%}
+{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ memcached.port }}
+   {%- else -%}
+{{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ memcached.port }}, {% endif -%}
+{% endfor -%}
+{% endmacro -%}
 <SPConfig xmlns="urn:mace:shibboleth:2.0:native:sp:config"
     xmlns:conf="urn:mace:shibboleth:2.0:native:sp:config"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
     xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
     clockSkew="180">
+
+    <OutOfProcess logger="shibd.logger">
+        <Extensions>
+            <Library path="memcache-store.so" fatal="true"/>
+        </Extensions>
+    </OutOfProcess>
+    <StorageService type="MEMCACHE" id="mc" prefix="SHIBD_SERVICE" buildMap="1">
+       <Hosts>
+           {{ memcached_hosts() }}
+       </Hosts>
+    </StorageService>
+    <SessionCache type="StorageService" StorageService="mc" cacheAssertions="false"
+                  cacheTimeout="3600" inprocTimeout="900" cleanupInterval="900"/>
+    <ReplayCache StorageService="mc"/>
+    <ArtifactMap StorageService="mc" artifactTTL="180"/>
 
     <ApplicationDefaults entityID="{{ keystone.federation.sp.k2k.sp_id }}">
         <Sessions lifetime="28800" timeout="3600" relayState="ss:mem"


### PR DESCRIPTION
Shibboleth establishes sessions when authenticating the user during
the SAML flow. Memcached will be used to store the sessions
and enable Shibboleth to share sessions on multiple nodes.

This is to fix the bug where a federated user logs in using the Keystone to Keystone SAML ECP flow - the first request goes to controller 1 and then the 2nd request goes to controller 2. Since the sessions are not shared shibboleth does not know what to do with the 2nd request. The k2k auth plugin does not appear to use cookies, so using session stickiness with HAProxy doesn't seem like an option.

**Shibboleth2.xml documentation:** 
https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPShibbolethXML
**Storage backend documentation:**
https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPStorageService
**Configuring Shibboleth on a load balancing cluster:**
https://wiki.library.ucsf.edu/display/IAM/Configure+Shib+SP+on+a+Load+Balancing+Cluster

