### PR TITLE
Avoid sudo in commands

### DIFF
--- a/roles/horizon/handlers/main.yml
+++ b/roles/horizon/handlers/main.yml
@@ -7,5 +7,8 @@
   service: name=apache2 state=restarted must_exist=false
 
 - name: compress horizon assets
-  command: sudo -u www-data tools/with_venv.sh ./manage.py compress
-           chdir=/opt/stack/horizon/
+  command: tools/with_venv.sh ./manage.py compress
+  args:
+    chdir: /opt/stack/horizon/
+  become: true
+  become_user: www-data


### PR DESCRIPTION
Use become and become_user instead.

There is still a sudo call in swift roles, but that should be addressed in PR #1931 .