### PR TITLE
Fix invalid configuration in /etc/pam.d/common-password

### DIFF
--- a/roles/common/tasks/password-policy.yml
+++ b/roles/common/tasks/password-policy.yml
@@ -1,8 +1,16 @@
 ---
+- name: remove invalid configuration for pam_unix
+  lineinfile: dest=/etc/pam.d/common-password regexp=(pam_unix.so) state=absent
+              line="password [success=7 default=ignore] pam_unix.so obscure sha512"
+
+- name: remove invalid configuration for pam_cracklib
+  lineinfile: dest=/etc/pam.d/common-password regexp=(pam_cracklib.so) state=absent
+              line="password requisite pam_cracklib.so ucredit=0 lcredit=-1 dcredit=-1 ocredit=0 minlen=8 retry=3"
+
 - name: implement password controls for pam.d login
   lineinfile:
     dest: "{{ item[0] }}"
-    state: present
+    state: absent
     line: "{{ item[1] }}"
   with_nested:
     - [ /etc/pam.d/login, /etc/pam.d/passwd, /etc/pam.d/sshd, /etc/pam.d/su ]
@@ -17,9 +25,12 @@
               line="PASS_MIN_DAYS   1" state=present
 
 - name: prevent resuse of passwords
-  lineinfile: dest=/etc/pam.d/common-password regexp=(success=1) state=present
-              line="password [success=7 default=ignore] pam_unix.so obscure sha512"
+  lineinfile: dest=/etc/pam.d/common-password regexp=(pam_unix.so) state=present
+              line="password [success=1 default=ignore] pam_unix.so obscure use_authtok sha512 remember=7 shadow"
+              insertafter='^# here are the per-package modules'
 
 - name: implement password complexity
-  lineinfile: dest=/etc/pam.d/common-password state=present
-              line="password requisite pam_cracklib.so ucredit=0 lcredit=-1 dcredit=-1 ocredit=0 minlen=8 retry=3"
+  lineinfile: dest=/etc/pam.d/common-password regexp=(pam_cracklib.so) state=present
+              line="password requisite pam_cracklib.so ucredit=0 lcredit=-1 dcredit=-1 ocredit=0 retry=3 minlen=8 difok=3 reject_username"
+              insertafter='^# here are the per-package modules'
+


### PR DESCRIPTION
Fix the invalid pam-config

Rebased PR #1903 

Please close #1903 when merged