### PR TITLE
Remove conntrackd

### DIFF
--- a/roles/neutron-data-network/tasks/main.yml
+++ b/roles/neutron-data-network/tasks/main.yml
@@ -10,11 +10,11 @@
     - resolvconf
 
 - name: install packages for l3ha
-  apt: pkg={{ item }}
-  with_items:
-    - keepalived
-    - conntrackd
+  apt: pkg=keepalived
   when: neutron.l3ha.enabled|bool
+
+- name: remove conntrackd
+  apt: name=conntrackd purge=yes state=absent
 
 - include: dnsmasq.yml
 


### PR DESCRIPTION
1. If l3ha is enabled, install only keepalived since conntrackd is not required.  
2. For upgrade path, if conntrackd is already installed, remove it.