### PR TITLE
Use project_id in endpoints instead of tenant_id

### DIFF
--- a/roles/endpoints/defaults/main.yml
+++ b/roles/endpoints/defaults/main.yml
@@ -17,7 +17,7 @@ endpoints:
       admin: https://{{ fqdn }}:8774
       internal: https://{{ fqdn }}:8774
       public: https://{{ fqdn }}:8774
-      path: v2/%(tenant_id)s
+      path: v2/%(project_id)s
     port:
       backend_api: 9774
       haproxy_api: 8774
@@ -49,7 +49,7 @@ endpoints:
       admin: https://{{ fqdn }}:8776
       internal: https://{{ fqdn }}:8776
       public: https://{{ fqdn }}:8776
-      path: v1/%(tenant_id)s
+      path: v1/%(project_id)s
     port:
       backend_api: 8778
       haproxy_api: 8776
@@ -66,7 +66,7 @@ endpoints:
       admin: https://{{ fqdn }}:8776
       internal: https://{{ fqdn }}:8776
       public: https://{{ fqdn }}:8776
-      path: v2/%(tenant_id)s
+      path: v2/%(project_id)s
   keystone:
     name: keystone
     type: identity
@@ -152,7 +152,7 @@ endpoints:
       admin: https://{{ fqdn }}:8004
       internal: https://{{ fqdn }}:8004
       public: https://{{ fqdn }}:8004
-      path: v1/%(tenant_id)s
+      path: v1/%(project_id)s
     port:
       backend_api: 8005
       haproxy_api: 8004
@@ -216,7 +216,7 @@ endpoints:
       admin: https://{{ swift_fqdn }}:8090
       internal: https://{{ swift_fqdn }}:8090
       public: https://{{ swift_fqdn }}:8090
-      path: v1/%(tenant_id)s
+      path: v1/%(project_id)s
     port:
       haproxy_api: 8090
       cinder_backup: 8091


### PR DESCRIPTION
tenant_id is deprecated. This should only impact new installs, as there
is no API yet to modify existing endpoints.