### PR TITLE
Use "enabled" instead of "enable" for lbaas

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -197,7 +197,7 @@ neutron:
   tunnel_types:
     - vxlan
   lbaas:
-    enable: False
+    enabled: False
   logging:
     debug: True
     verbose: True

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -97,7 +97,7 @@
   file:
     src: "{{ horizon.horizon_lib_dir }}/lib/python2.7/site-packages/neutron_lbaas_dashboard/enabled/_1481_project_ng_loadbalancersv2_panel.py"
     path: "{{ horizon.horizon_lib_dir }}/lib/python2.7/site-packages/openstack_dashboard/local/enabled/_1481_project_ng_loadbalancersv2_panel.py"
-    state: "{{ (neutron.lbaas.enable | bool) | ternary('link', 'absent') }}"
+    state: "{{ (neutron.lbaas.enabled | bool) | ternary('link', 'absent') }}"
   notify: reload apache
 
 - name: gather static assets from openstack install

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -46,7 +46,7 @@ neutron:
   lbaas:
     # enabled can be "smart" or true / false. Smart will turn on lbaas if
     # controllers are dedicated.
-    enable: smart
+    enabled: smart
     interface_driver: neutron.agent.linux.interface.BridgeInterfaceDriver
     service_plugin:
       - neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPluginv2

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -25,9 +25,9 @@ control_exchange = neutron
 {% if neutron.plugin == 'ml2' %}
 core_plugin = neutron.plugins.ml2.plugin.Ml2Plugin
 {% endif %}
-{% if (neutron.lbaas.enable == 'smart' and
+{% if (neutron.lbaas.enabled == 'smart' and
   groups['controller'][0] not in groups['compute']) or
-  neutron.lbaas.enable|bool %}
+  neutron.lbaas.enabled|bool %}
 service_plugins = {{ neutron.service_plugins|union(neutron.lbaas.service_plugin)|join(',') }}
 {% elif neutron.service_plugins|length %}
 service_plugins = {{ neutron.service_plugins|join(',') }}

--- a/roles/neutron-control/tasks/main.yml
+++ b/roles/neutron-control/tasks/main.yml
@@ -30,9 +30,9 @@
   command: neutron-db-manage --service lbaas --config-file /etc/neutron/neutron.conf \
            --config-file /etc/neutron/plugins/ml2/ml2_plugin.ini upgrade head
   when: (database_create.changed or force_sync|default('false')|bool) and
-        ((neutron.lbaas.enable == "smart" and
+        ((neutron.lbaas.enabled == "smart" and
          groups['controller'][0] not in groups['compute']) or
-         neutron.lbaas.enable|bool)
+         neutron.lbaas.enabled|bool)
   run_once: true
   changed_when: true
   notify: restart neutron services

--- a/roles/neutron-control/tasks/monitoring.yml
+++ b/roles/neutron-control/tasks/monitoring.yml
@@ -25,7 +25,7 @@
 - name: lbaas sla metrics
   sensu_metrics_check: name=lbaas-sla-metrics plugin=metrics-os-api.py
                        args='-S lbaas --scheme {{ monitoring.graphite.host_prefix }}'
-  when: (neutron.lbaas.enable == "smart" and
+  when: (neutron.lbaas.enabled == "smart" and
         groups['controller'][0] not in groups['compute']) or
-        neutron.lbaas.enable|bool
+        neutron.lbaas.enabled|bool
   notify: restart sensu-client

--- a/roles/neutron-data-network/handlers/main.yml
+++ b/roles/neutron-data-network/handlers/main.yml
@@ -5,9 +5,9 @@
 
 - name: restart neutron lbaas agent
   service: name=neutron-lbaasv2-agent state=restarted_if_running
-  when: restart|default('True') and ((neutron.lbaas.enable == "smart" and
+  when: restart|default('True') and ((neutron.lbaas.enabled == "smart" and
                      groups['controller'][0] not in groups['compute']) or
-                     neutron.lbaas.enable|bool)
+                     neutron.lbaas.enabled|bool)
 
 - name: restart xorp
   service: name=xorp state=restarted sleep=10

--- a/roles/neutron-data-network/tasks/main.yml
+++ b/roles/neutron-data-network/tasks/main.yml
@@ -58,9 +58,9 @@
     src: etc/neutron/neutron_lbaas.conf
     dest: /etc/neutron/neutron_lbaas.conf
     mode: 0644
-  when: (neutron.lbaas.enable == "smart" and
+  when: (neutron.lbaas.enabled == "smart" and
          groups['controller'][0] not in groups['compute']) or
-         neutron.lbaas.enable|bool
+         neutron.lbaas.enabled|bool
   notify:
     - restart neutron lbaas agent
 
@@ -69,9 +69,9 @@
     src: etc/neutron/services/loadbalancer/haproxy/lbaas_agent.ini
     dest: /etc/neutron/services/loadbalancer/haproxy
     mode: 0644
-  when: (neutron.lbaas.enable == "smart" and
+  when: (neutron.lbaas.enabled == "smart" and
          groups['controller'][0] not in groups['compute']) or
-         neutron.lbaas.enable|bool
+         neutron.lbaas.enabled|bool
   notify:
     - restart neutron lbaas agent
 
@@ -86,9 +86,9 @@
     config_dirs: /etc/neutron
     config_files: "{{ item.value.config_files|join(',') }}"
     envs: "{{ neutron.service.envs }}"
-  when: (neutron.lbaas.enable == "smart" and
+  when: (neutron.lbaas.enabled == "smart" and
          groups['controller'][0] not in groups['compute']) or
-         neutron.lbaas.enable|bool
+         neutron.lbaas.enabled|bool
   with_dict:
     neutron-lbaasv2-agent:
       config_files:
@@ -124,9 +124,9 @@
 
 - name: start neutron lbaas agent
   service: name=neutron-lbaasv2-agent state=started
-  when: (neutron.lbaas.enable == "smart" and
+  when: (neutron.lbaas.enabled == "smart" and
          groups['controller'][0] not in groups['compute']) or
-         neutron.lbaas.enable|bool
+         neutron.lbaas.enabled|bool
 
 - include: ipchanged.yml
 

--- a/roles/neutron-data-network/tasks/monitoring.yml
+++ b/roles/neutron-data-network/tasks/monitoring.yml
@@ -10,9 +10,9 @@
 - name: neutron lbaas process check
   sensu_process_check: service=neutron-lbaasv2-agent
   notify: restart sensu-client
-  when: (neutron.lbaas.enable == "smart" and
+  when: (neutron.lbaas.enabled == "smart" and
          groups['controller'][0] not in groups['compute']) or
-         neutron.lbaas.enable|bool
+         neutron.lbaas.enabled|bool
 
 - name: ipchanged process check
   sensu_process_check: service=/usr/local/sbin/ipchanged


### PR DESCRIPTION
Our internal envs had it listed wrong, so 'smart' was used all the time.
Rename it here so that everything matches up and fits convention.