### PR TITLE
Protect against undefined mongodb password

### DIFF
--- a/roles/ceilometer-common/defaults/main.yml
+++ b/roles/ceilometer-common/defaults/main.yml
@@ -15,7 +15,7 @@ ceilometer:
   purge_frequency: 86400
   mongodb_database: ceilometer
   mongodb_user: ceilometer
-  mongodb_password: "{{ secrets.mongodb_password }}"
+  mongodb_password: "{{ secrets.mongodb_password | default('BADPASS') }}"
   heartbeat_timeout_threshold: 30
   logs:
     - paths:


### PR DESCRIPTION
There may not be a secret defined for mongo, so let it default to
something silly rather than be undefined.