### PR TITLE
Restore arp_responder to true for migration to Mitaka

### DIFF
--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -28,6 +28,7 @@ neutron:
   metadata_workers: 3
   agent_down_time: 20
   report_interval: 4
+  arp_responder: True
   state_path: "/var/lib/neutron"
   dhcp_dns_servers:
     - 8.8.8.8

--- a/roles/neutron-common/templates/etc/neutron/plugins/ml2/ml2_plugin.ini
+++ b/roles/neutron-common/templates/etc/neutron/plugins/ml2/ml2_plugin.ini
@@ -45,6 +45,7 @@ vxlan_group = {{ neutron.vxlan.group_prefix }}
 [vxlan]
 enable_vxlan = {{ "vxlan" in neutron.tunnel_types }}
 l2_population = {{ neutron.l2_population }}
+arp_responder = {{ neutron.arp_responder }}
 
 [database]
 sql_connection = mysql+pymysql://neutron:{{ secrets.db_password }}@{{ endpoints.db }}/neutron?charset=utf8


### PR DESCRIPTION
arp_responder default value has changed to false in Mitaka. Restoring arp_responder to true to prevent existing clouds from networking issues when migrating to Mitaka.