### PR TITLE
Make VNC great again

### DIFF
--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -207,4 +207,4 @@ vncserver_listen = {{ primary_ip }}
 enabled = {{ nova.enable_novnc }}
 novncproxy_base_url= {{ endpoints.novnc.url.internal }}/vnc_auto.html
 novncproxy_port = {{ endpoints.novnc.port.backend_api }}
-vnc_keymap={{ nova.vnc_keymap }}
+keymap={{ nova.vnc_keymap }}

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -200,6 +200,11 @@ driver = log
 [oslo_middleware]
 enable_proxy_headers_parsing = True
 
+[cache]
+backend = oslo_cache.memcache_pool
+enabled = True
+memcache_servers = {{ hostvars|ursula_memcache_hosts(groups, memcached.port) }}
+
 [vnc]
 vncserver_proxyclient_address = {{ primary_ip }}
 vncserver_listen = {{ primary_ip }}


### PR DESCRIPTION
VNC consoles were intermittently failing, because we were running multiple nova-consoleauth, and only one would get a token while the other would not. This would lead to token rejections. Using memcache allows these to be kept in sync so either will work.