### PR TITLE
removed filters from nova serverspec

### DIFF
--- a/roles/nova-common/templates/etc/serverspec/nova_spec.rb
+++ b/roles/nova-common/templates/etc/serverspec/nova_spec.rb
@@ -10,7 +10,7 @@ files.each do |file, mode|
   end
 end
 
-files = ['api-metadata.filters' , 'baremetal-compute-ipmi.filters' , 'baremetal-deploy-helper.filters' , 'compute.filters', 'network.filters']
+files = ['api-metadata.filters' , 'compute.filters', 'network.filters']
 files.each do |file|
   describe file("/etc/nova/rootwrap.d/#{file}") do
     it { should be_owned_by 'root' }


### PR DESCRIPTION
The filters baremetal-compute-ipmi.filters and baremetal-deploy-helper.filters have been removed from /etc/nova/rootwrap.d folder. So the check in serverspec has been removed.