### PR TITLE
Pin os-brick version for nova

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -52,6 +52,7 @@ nova:
       - { name: python-memcached }
       - { name: paramiko==1.16.0 }
       - { name: amqp, version: '1.4.9' }
+      - { name: os-brick, version: '1.3.0' }
     system_dependencies:
       - libjs-jquery-tablesorter
       - python-libvirt


### PR DESCRIPTION
New version breaks some cases of volume attach.

This can be removed when we switch over to upper constraints.

Change-Id: I179cf0b25a3f2ba8194a376748af15848224572c