### PR TITLE
Support for pip upper constraints

### DIFF
--- a/roles/aodh/defaults/main.yml
+++ b/roles/aodh/defaults/main.yml
@@ -4,6 +4,8 @@ aodh:
   debug: False
   source:
     rev: 'stable/mitaka'
+    constrain: True
+    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/mitaka/upper-constraints.txt'
     python_dependencies:
       - { name: PyMySQL }
       - { name: python-ceilometerclient }

--- a/roles/aodh/meta/main.yml
+++ b/roles/aodh/meta/main.yml
@@ -7,6 +7,8 @@ dependencies:
     alternatives: "{{ aodh.alternatives }}"
     system_dependencies: "{{ aodh.source.system_dependencies }}"
     python_dependencies: "{{ aodh.source.python_dependencies }}"
+    constrain: "{{ aodh.source.constrain }}"
+    upper_constraints: "{{ aodh.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package
     project_name: aodh

--- a/roles/ceilometer-common/defaults/main.yml
+++ b/roles/ceilometer-common/defaults/main.yml
@@ -4,6 +4,8 @@ ceilometer:
   enabled: False
   source:
     rev: 'stable/mitaka'
+    constrain: True
+    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/mitaka/upper-constraints.txt'
     python_dependencies:
       - { name: pymongo, version: '3.0.3' }
       - { name: amqp, version: '1.4.9' }

--- a/roles/ceilometer-common/meta/main.yml
+++ b/roles/ceilometer-common/meta/main.yml
@@ -12,6 +12,8 @@ dependencies:
     project_rev: "{{ ceilometer.source.rev }}"
     alternatives: "{{ ceilometer.alternatives }}"
     python_dependencies: "{{ ceilometer.source.python_dependencies }}"
+    constrain: "{{ ceilometer.source.constrain }}"
+    upper_constraints: "{{ ceilometer.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package
     project_name: ceilometer

--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -28,6 +28,8 @@ cinder:
   heartbeat_timeout_threshold: 30
   source:
     rev: 'stable/mitaka'
+    constrain: True
+    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/mitaka/upper-constraints.txt'
     python_dependencies:
       - { name: PyMySQL }
       - { name: amqp, version: '1.4.9' }

--- a/roles/cinder-common/meta/main.yml
+++ b/roles/cinder-common/meta/main.yml
@@ -14,6 +14,8 @@ dependencies:
     alternatives: "{{ cinder.alternatives }}"
     system_dependencies: "{{ cinder.source.system_dependencies }}"
     python_dependencies: "{{ cinder.source.python_dependencies }}"
+    constrain: "{{ cinder.source.constrain }}"
+    upper_constraints: "{{ cinder.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package
     project_name: cinder

--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -24,6 +24,8 @@ glance:
   show_multiple_locations: True
   source:
     rev: 'stable/mitaka'
+    constrain: True
+    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/mitaka/upper-constraints.txt'
     python_dependencies:
       - { name: PyMySQL }
       - { name: python-swiftclient }

--- a/roles/glance/meta/main.yml
+++ b/roles/glance/meta/main.yml
@@ -13,6 +13,8 @@ dependencies:
     alternatives: "{{ glance.alternatives }}"
     system_dependencies: "{{ glance.source.system_dependencies }}"
     python_dependencies: "{{ glance.source.python_dependencies }}"
+    constrain: "{{ glance.source.constrain }}"
+    upper_constraints: "{{ glance.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package
     project_name: glance

--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -5,6 +5,8 @@ heat:
   heartbeat_timeout_threshold: 30
   source:
     rev: 'stable/mitaka'
+    constrain: True
+    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/mitaka/upper-constraints.txt'
     python_dependencies:
       - { name: PyMySQL }
       - { name: amqp, version: '1.4.9' }

--- a/roles/heat/meta/main.yml
+++ b/roles/heat/meta/main.yml
@@ -13,6 +13,8 @@ dependencies:
     alternatives: "{{ heat.alternatives }}"
     system_dependencies: "{{ heat.source.system_dependencies }}"
     python_dependencies: "{{ heat.source.python_dependencies }}"
+    constrain: "{{ heat.source.constrain }}"
+    upper_constraints: "{{ heat.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package
     project_name: heat

--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -9,6 +9,8 @@ horizon:
   session_engine: django.contrib.sessions.backends.cache
   source:
     rev: 'stable/mitaka'
+    constrain: True
+    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/mitaka/upper-constraints.txt'
     python_dependencies:
       - { name: PyMySQL }
       - { name: python-memcached, version: '1.48' }

--- a/roles/horizon/meta/main.yml
+++ b/roles/horizon/meta/main.yml
@@ -12,6 +12,8 @@ dependencies:
     project_rev: "{{ horizon.source.rev }}"
     system_dependencies: "{{ horizon.source.system_dependencies }}"
     python_dependencies: "{{ horizon.source.python_dependencies }}"
+    constrain: "{{ horizon.source.constrain }}"
+    upper_constraints: "{{ horizon.source.upper_constraints }}"
     additional_handlers: [ "compress horizon assets" ]
     when: openstack_install_method == 'source'
   - role: openstack-package

--- a/roles/ironic-common/defaults/main.yml
+++ b/roles/ironic-common/defaults/main.yml
@@ -19,6 +19,8 @@ ironic:
   heartbeat_timeout_threshold: 30
   source:
     rev: 'stable/mitaka'
+    constrain: True
+    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/mitaka/upper-constraints.txt'
     python_dependencies:
       - { name: PyMySQL }
     system_dependencies: []

--- a/roles/ironic-common/meta/main.yml
+++ b/roles/ironic-common/meta/main.yml
@@ -12,6 +12,8 @@ dependencies:
     alternatives: "{{ ironic.alternatives }}"
     system_dependencies: "{{ ironic.source.system_dependencies }}"
     python_dependencies: "{{ ironic.source.python_dependencies }}"
+    constrain: "{{ ironic.source.constrain }}"
+    upper_constraints: "{{ ironic.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package
     project_name: ironic

--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -6,6 +6,8 @@ keystone:
   public_workers: 5
   source:
     rev: 'stable/mitaka'
+    constrain: True
+    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/mitaka/upper-constraints.txt'
     python_dependencies:
       - { name: PyMySQL }
       - { name: uwsgi }

--- a/roles/keystone/meta/main.yml
+++ b/roles/keystone/meta/main.yml
@@ -14,6 +14,8 @@ dependencies:
     alternatives: "{{ keystone.alternatives }}"
     system_dependencies: "{{ keystone.source.system_dependencies }}"
     python_dependencies: "{{ keystone.source.python_dependencies }}"
+    constrain: "{{ keystone.source.constrain }}"
+    upper_constraints: "{{ keystone.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package
     project_name: keystone

--- a/roles/magnum/defaults/main.yml
+++ b/roles/magnum/defaults/main.yml
@@ -5,6 +5,8 @@ magnum:
   heartbeat_timeout_threshold: 30
   source:
     rev: 'stable/mitaka'
+    constrain: True
+    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/mitaka/upper-constraints.txt'
     virtualenv: "/opt/openstack/magnum"
     python_dependencies:
       - { name: PyMySQL }

--- a/roles/magnum/meta/main.yml
+++ b/roles/magnum/meta/main.yml
@@ -13,6 +13,8 @@ dependencies:
     virtualenv: "{{ magnum.source.virtualenv }}"
     system_dependencies: "{{ magnum.source.system_dependencies }}"
     python_dependencies: "{{ magnum.source.python_dependencies }}"
+    constrain: "{{ magnum.source.constrain }}"
+    upper_constraints: "{{ magnum.source.upper_constraints }}"
     alternatives: "{{ magnum.alternatives }}"
     when: openstack_install_method == 'source'
   - role: openstack-package

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -59,6 +59,8 @@ neutron:
     envs: []
   source:
     rev: 'stable/mitaka'
+    constrain: True
+    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/mitaka/upper-constraints.txt'
     python_dependencies:
       - { name: "git+git://github.com/openstack/neutron-lbaas.git@stable/mitaka#egg=neutron-lbaas" }
       - { name: PyMySQL }

--- a/roles/neutron-common/meta/main.yml
+++ b/roles/neutron-common/meta/main.yml
@@ -15,6 +15,8 @@ dependencies:
     alternatives: "{{ neutron.alternatives }}"
     system_dependencies: "{{ neutron.source.system_dependencies }}"
     python_dependencies: "{{ neutron.source.python_dependencies }}"
+    constrain: "{{ neutron.source.constrain }}"
+    upper_constraints: "{{ neutron.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package
     project_name: neutron

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -46,6 +46,8 @@ nova:
       dest: /opt/stack/novadocker
   source:
     rev: 'stable/mitaka'
+    constrain: True
+    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/mitaka/upper-constraints.txt'
     python_dependencies:
       - { name: Babel==2.2.0 }
       - { name: PyMySQL }

--- a/roles/nova-common/meta/main.yml
+++ b/roles/nova-common/meta/main.yml
@@ -20,6 +20,8 @@ dependencies:
     alternatives: "{{ nova.alternatives }}"
     system_dependencies: "{{ nova.source.system_dependencies }}"
     python_dependencies: "{{ nova.source.python_dependencies }}"
+    constrain: "{{ nova.source.constrain }}"
+    upper_constraints: "{{ nova.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package
     project_name: nova

--- a/roles/openstack-source/defaults/main.yml
+++ b/roles/openstack-source/defaults/main.yml
@@ -8,4 +8,4 @@ openstack_source:
   rootwrap: "{{ rootwrap|default(False)|bool }}"
   system_dependencies: "{{ system_dependencies|default([]) }}"
   python_dependencies: "{{ python_dependencies|default([]) }}"
-
+  pip_extra_args: ""

--- a/roles/openstack-source/tasks/main.yml
+++ b/roles/openstack-source/tasks/main.yml
@@ -12,50 +12,57 @@
   until: git_result|success
   retries: 3
 
+- name: set pip args fact
+  set_fact:
+    pip_extra_args: "{{ openstack_source.pip_extra_args|default('') }}"
+  when: openstack.pypi_mirror is defined
+
+- name: set pip proxy args
+  set_fact:
+    pip_extra_args: "{{ pip_extra_args }} -i {{ openstack.pypi_mirror }}"
+  when: openstack.pypi_mirror is defined
+
+- name: update pip in virtualenv
+  pip:
+    name: pip
+    state: latest
+    virtualenv: "{{ openstack_source.virtualenv_base }}/{{ project_name }}"
+    extra_args: "{{ pip_extra_args }}"
+
+- name: get constraints file
+  get_url:
+    url: "{{ upper_constraints }}"
+    dest: /opt/stack/constraints.txt
+    force: true
+  when: constrain | bool
+
+- name: set pip constraints args
+  set_fact:
+    pip_extra_args: "{{ pip_extra_args }} -c /opt/stack/constraints.txt"
+  when: constrain | bool
+
 - name: set code has changed fact
   set_fact:
     code_has_changed: True
   when: git_result | changed
-
-- name: python requirements for project from alternative proxy
-  pip:
-    name: "{{ item.name }}"
-    version: "{{ item.version|default(omit) }}"
-    virtualenv: "{{ openstack_source.virtualenv_base }}/{{ project_name }}"
-    extra_args: "-i {{ openstack_source.pypi_mirror }}"
-  with_items: "{{ openstack_source.python_dependencies }}"
-  when: openstack_source.pypi_mirror
-
-- name: pip install project from alternative proxy
-  pip:
-    name: "/opt/stack/{{ project_name }}"
-    extra_args: "-i {{ openstack_source.pypi_mirror }}"
-    virtualenv: "{{ openstack_source.virtualenv_base }}/{{ project_name }}"
-  register: pip_result
-  until: pip_result|success
-  retries: 3
-  delay: 10
-  when: openstack_source.pypi_mirror
-  notify:
-    - update ca-certs
 
 - name: python requirements for project
   pip:
     name: "{{ item.name }}"
     version: "{{ item.version|default(omit) }}"
     virtualenv: "{{ openstack_source.virtualenv_base }}/{{ project_name }}"
+    extra_args: "{{ pip_extra_args }}"
   with_items: "{{ openstack_source.python_dependencies }}"
-  when: not openstack_source.pypi_mirror
 
-- name: pip install project_name
+- name: pip install project
   pip:
     name: "/opt/stack/{{ project_name }}"
+    extra_args: "{{ pip_extra_args }}"
     virtualenv: "{{ openstack_source.virtualenv_base }}/{{ project_name }}"
   register: pip_result
   until: pip_result|success
   retries: 3
   delay: 10
-  when: not openstack_source.pypi_mirror
   notify:
     - update ca-certs
 

--- a/roles/swift-common/defaults/main.yml
+++ b/roles/swift-common/defaults/main.yml
@@ -9,6 +9,8 @@ swift:
   allow_versions: True
   source:
     rev: 'stable/mitaka'
+    constrain: True
+    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/mitaka/upper-constraints.txt'
     python_dependencies:
       - { name: keystonemiddleware }
       - { name: python-swiftclient }

--- a/roles/swift-common/meta/main.yml
+++ b/roles/swift-common/meta/main.yml
@@ -11,6 +11,8 @@ dependencies:
     project_name: swift
     python_dependencies: "{{ swift.source.python_dependencies }}"
     system_dependencies: "{{ swift.source.system_dependencies }}"
+    constrain: "{{ swift.source.constrain }}"
+    upper_constraints: "{{ swift.source.upper_constraints }}"
     project_rev: "{{ swift.source.rev }}"
     alternatives: "{{ swift.alternatives }}"
     when: openstack_install_method == 'source'


### PR DESCRIPTION
Each project can specify an upper constraints file to fetch and use to
constrain the deps and project itself.

A project can still opt out of being constrained.

This also has the byproduct of fixing source installs with a pypi mirror
(which was broken), and updating pip inside the virtualenv (which was
really really old).

Change-Id: Idb02f7bb3071f3cab336bf473d1c70ca1a7ede46