### PR TITLE
Add a timeout to rdb/rados fetches

### DIFF
--- a/roles/cinder-common/tasks/ceph_integration.yml
+++ b/roles/cinder-common/tasks/ceph_integration.yml
@@ -1,35 +1,21 @@
 ---
 - name: fetch rados.py
-  get_url: url={{ ceph.rados_url }}
-           dest="{{ openstack_source.virtualenv_base }}/cinder/lib/python2.7/site-packages/rados.py"
-           owner=root
-           group=root
-           mode=0644
-  when: openstack_install_method == 'source'
+  get_url:
+    url: "{{ ceph.rados_url }}"
+    dest: /opt/openstack/current/cinder/lib/python2.7/site-packages/rados.py
+    owner: root
+    group: root
+    mode: 0644
+    timeout: 30
 
 - name: fetch rbd.py
-  get_url: url={{ ceph.rbd_url }}
-           dest="{{ openstack_source.virtualenv_base }}/cinder/lib/python2.7/site-packages/rbd.py"
-           owner=root
-           group=root
-           mode=0644
-  when: openstack_install_method == 'source'
-
-- name: fetch rados.py
-  get_url: url={{ ceph.rados_url }}
-           dest="{{ openstack_package.virtualenv_base }}/cinder/lib/python2.7/site-packages/rados.py"
-           owner=root
-           group=root
-           mode=0644
-  when: openstack_install_method == 'package'
-
-- name: fetch rbd.py
-  get_url: url={{ ceph.rbd_url }}
-           dest="{{ openstack_package.virtualenv_base }}/cinder/lib/python2.7/site-packages/rbd.py"
-           owner=root
-           group=root
-           mode=0644
-  when: openstack_install_method == 'package'
+  get_url:
+    url: "{{ ceph.rdb_url }}"
+    dest: /opt/openstack/current/cinder/lib/python2.7/site-packages/rdb.py
+    owner: root
+    group: root
+    mode: 0644
+    timeout: 30
 
 - name: fetch cinder keyring
   slurp: path=/etc/ceph/ceph.client.cinder.keyring

--- a/roles/glance/tasks/ceph_integration.yml
+++ b/roles/glance/tasks/ceph_integration.yml
@@ -1,35 +1,21 @@
 ---
 - name: fetch rados.py
-  get_url: url={{ ceph.rados_url }}
-           dest="{{ openstack_source.virtualenv_base }}/glance/lib/python2.7/site-packages/rados.py"
-           owner=root
-           group=root
-           mode=0644
-  when: openstack_install_method == 'source'
+  get_url:
+    url: "{{ ceph.rados_url }}"
+    dest: /opt/openstack/current/glance/lib/python2.7/site-packages/rados.py
+    owner: root
+    group: root
+    mode: 0644
+    timeout: 30
 
 - name: fetch rbd.py
-  get_url: url={{ ceph.rbd_url }}
-           dest="{{ openstack_source.virtualenv_base }}/glance/lib/python2.7/site-packages/rbd.py"
-           owner=root
-           group=root
-           mode=0644
-  when: openstack_install_method == 'source'
-
-- name: fetch rados.py
-  get_url: url={{ ceph.rados_url }}
-           dest="{{ openstack_package.virtualenv_base }}/glance/lib/python2.7/site-packages/rados.py"
-           owner=root
-           group=root
-           mode=0644
-  when: openstack_install_method == 'package'
-
-- name: fetch rbd.py
-  get_url: url={{ ceph.rbd_url }}
-           dest="{{ openstack_package.virtualenv_base }}/glance/lib/python2.7/site-packages/rbd.py"
-           owner=root
-           group=root
-           mode=0644
-  when: openstack_install_method == 'package'
+  get_url:
+    url: "{{ ceph.rdb_url }}"
+    dest: /opt/openstack/current/glance/lib/python2.7/site-packages/rdb.py
+    owner: root
+    group: root
+    mode: 0644
+    timeout: 30
 
 - name: fetch glance keyring
   slurp: path=/etc/ceph/ceph.client.glance.keyring


### PR DESCRIPTION
Also clean up the tasks so that we always use the same path to fetch the
file into, as that path is consistent across install methods.

Change-Id: I63008124ab2276e0b11555680fc5eea8e36a91fb