### PR TITLE
Support Swift-only install

### DIFF
--- a/roles/common/templates/etc/hosts
+++ b/roles/common/templates/etc/hosts
@@ -12,6 +12,8 @@ ff02::2 ip6-allrouters
 {{ entry.ip }} {{ entry.name }}
 {% endfor %}
 
+{% if 'compute' in groups %}
 {% for host in groups['compute'] if inventory_hostname in groups['compute'] %}
 {{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].ansible_nodename }}
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
Right now the code assumes that there is a 'compute' group. This might
not actaully be the case.