### PR TITLE
Ensure clients work after upgrade

### DIFF
--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -13,5 +13,6 @@ client:
     - python-ironicclient
     - python-swiftclient
     - python-magnumclient
+    - python-openstackclient
   apt_packages:
     - python-prettytable

--- a/upgrade.yml
+++ b/upgrade.yml
@@ -46,6 +46,25 @@
         state: restarted
   environment: "{{ env_vars|default({}) }}"
 
+- name: upgrade client bits
+  hosts: all:!vyatta-*
+  max_fail_percentage: 1
+  tags: client
+
+  pre_tasks:
+    - name: remove clients for re-install
+      pip:
+        name: "{{ item }}"
+        state: absent
+      with_items:
+        - python-openstackclient
+        - python-neutronclient
+        - python-heatclient
+
+  roles:
+    - role: client
+  environment: "{{ env_vars|default({}) }}"
+
 - name: stop the restarts
   hosts: all:!vyatta-*
   tags: always


### PR DESCRIPTION
Clients may be in an odd state, so reset some of them to make sure we
install good sets of them on upgrade.