### PR TITLE
create, update and delete role should have only role:admin in policy …

### DIFF
--- a/roles/keystone/templates/etc/keystone/policy.json
+++ b/roles/keystone/templates/etc/keystone/policy.json
@@ -84,9 +84,9 @@
 
     "identity:get_role": "rule:admin_or_cloudadmin or role:project_admin",
     "identity:list_roles": "rule:admin_or_cloudadmin or role:project_admin",
-    "identity:create_role": "rule:admin_required",
-    "identity:update_role": "rule:admin_required",
-    "identity:delete_role": "rule:admin_required",
+    "identity:create_role": "role:admin or is_admin:1",
+    "identity:update_role": "role:admin or is_admin:1",
+    "identity:delete_role": "role:admin or is_admin:1",
     "identity:get_domain_role": "rule:admin_required",
     "identity:list_domain_roles": "rule:admin_required",
     "identity:create_domain_role": "rule:admin_required",


### PR DESCRIPTION
With the previous policy file cloud admin could see the create role button. But when he tried to create a role it gave an error. This patch allows only admin to see the button to create role