### PR TITLE
Fix a ceilometer service typo in a handler

### DIFF
--- a/roles/ceilometer-common/handlers/main.yml
+++ b/roles/ceilometer-common/handlers/main.yml
@@ -6,4 +6,4 @@
     - ceilometer-api
     - ceilometer-collector
     - ceilometer-agent-notification
-    - ceiloemter-polling
+    - ceilometer-polling


### PR DESCRIPTION
Change-Id: Ib23529165f5ad770a78388f6648f5251bfa791ad