### PR TITLE
fixed errors with cloud/admin access

### DIFF
--- a/roles/cinder-common/templates/etc/cinder/policy.json
+++ b/roles/cinder-common/templates/etc/cinder/policy.json
@@ -3,7 +3,7 @@
     "admin_or_owner":  "is_admin:True or project_id:%(project_id)s or role:cloud_admin",
     "default": "rule:admin_or_owner",
 
-    "admin_api": "role:admin",
+    "admin_api": "is_admin:True",
     "admin_or_cloudadmin": "role:admin or role:cloud_admin",
 
     "volume:create": "",

--- a/roles/nova-common/templates/etc/nova/policy.json
+++ b/roles/nova-common/templates/etc/nova/policy.json
@@ -1,6 +1,6 @@
 {
     "context_is_admin":  "role:admin or role:cloud_admin",
-    "admin_or_owner":  "is_admin:True or project_id:%(project_id)s",
+    "admin_or_owner":  "is_admin:True or project_id:%(project_id)s or role:cloud_admin",
     "default": "rule:admin_or_owner",
     "is_projAdmin": "role:project_admin and project_id:%(project_id)s",
     "is_cloudAdmin": "role:cloud_admin",


### PR DESCRIPTION
`cloud_admin` was unable to see certain buttons in Horizon despite being able to perform actions in the CLI, explicitly adding the role to `admin_or_owner` fixes this issue. 

Some APIs in Cinder require the `is_admin:True` boolean to be checked rather than `role:admin` in order to give proper access. This change effectively reverts the Cinder policy to the community Mitaka policy, with the addition of full admin rights to `cloud_admin`.