### PR TITLE
Fix swiftool file install method

### DIFF
--- a/roles/swift-common/tasks/main.yml
+++ b/roles/swift-common/tasks/main.yml
@@ -39,11 +39,11 @@
   when: swift.swifttool_method == 'git'
 
 - name: fetch swifttool tarball
-  get_url: url={{ swift.swifttool_url }} dest=/opt/stack/swifttool/swifttool-{{ swift.swifttool_version }}.tar.gz
+  get_url: url={{ swift.swifttool_url }} dest=/opt/stack/swifttool-{{ swift.swifttool_version }}.tar.gz
   when: swift.swifttool_method == 'file'
 
 - name: unzip swifttool tarball
-  unarchive: src=/opt/stack/swifttool/swifttool-{{ swift.swifttool_version }}.tar.gz dest=/opt/stack copy=no
+  unarchive: src=/opt/stack/swifttool-{{ swift.swifttool_version }}.tar.gz dest=/opt/stack copy=no
   notify:
     - pip install swifttool
   when: swift.swifttool_method == 'file'


### PR DESCRIPTION
We were trying to download swiftool file to a directory that didn't
exist, so just toss it in /opt/stack instead.

Change-Id: Ie96639e559b9c74dc70fc93b202e8c61c584e480