### PR TITLE
Move the file permission update for mysql.err to later in the task

### DIFF
--- a/roles/percona-server/tasks/main.yml
+++ b/roles/percona-server/tasks/main.yml
@@ -8,14 +8,6 @@
 - name: create mysql config directory
   file: path=/etc/mysql/conf.d state=directory
 
-- name: check to see if /var/log/mysql/mysql.err exists
-  stat: path=/var/log/mysql/mysql.err
-  register: mysql_error_log
-
-- name: change /var/log/mysql/mysql.err to mode 644
-  file: dest=/var/log/mysql/mysql.err mode=0644
-  when: mysql_error_log.stat.exists|bool
-
 - name: configure the mysql defaults
   template: src=etc/default/mysql dest=/etc/default/mysql mode=644
   notify:
@@ -147,6 +139,14 @@
   with_items:
     - localhost
     - "{{ ansible_hostname }}"
+
+- name: check to see if /var/log/mysql/mysql.err exists
+  stat: path=/var/log/mysql/mysql.err
+  register: mysql_error_log
+
+- name: change /var/log/mysql/mysql.err to mode 644
+  file: dest=/var/log/mysql/mysql.err mode=0644
+  when: mysql_error_log.stat.exists|bool
 
 - include: monitoring.yml
   tags:


### PR DESCRIPTION
The mysql.err file is not getting created till later in the run. Thus the file permissions were not getting set correctly on a new deployment. Moved this to later in the run so that mysql.err file is created.