### PR TITLE
Fix allinone vagrant deploy

### DIFF
--- a/envs/example/allinone/group_vars/all.yml
+++ b/envs/example/allinone/group_vars/all.yml
@@ -10,3 +10,35 @@ percona:
 
 neutron:
   enable_external_interface: True
+
+
+sensu_checks:
+    percona:
+      check_cluster_size:
+        sudo: true
+        handler: default
+        notification: "unexpected number of mysql processes"
+        interval: 120
+        standalone: true
+        command: "percona-cluster-size.rb -d /root/.my.cnf --expected 3 --criticality critical"
+        service_owner: openstack
+        dependencies: "{{ 'keepalive' | sensu_dependencies(hostvars, groups, 'db') }}"
+        # above is incredibly ugly, but works. Creates the list below.
+        #dependencies:
+        #  - "controller1.ursula-vagrant/keepalive"
+        #  - "controller2.ursula-vagrant/keepalive"
+        #  - "compute1.ursula-vagrant/keepalive"
+      check_mysql_process:
+        handler: default
+        notification: "unexpected number of mysql processes"
+        interval: 120
+        standalone: true
+        command: "check-procs.rb -p mysql -W 1 -C 1"
+        service_owner: openstack
+      check_garbd_process:
+        handler: default
+        notification: "unexpected number of garbd processes"
+        interval: 120
+        standalone: true
+        command: "check-procs.rb -p garbd -W 1 -C 1"
+        service_owner: openstack


### PR DESCRIPTION
allinone does not have db_arbiter, causing sensu_dependencies to fail
