### PR TITLE
Remove duplicate Ansible keys

### DIFF
--- a/roles/openstack-source/tasks/main.yml
+++ b/roles/openstack-source/tasks/main.yml
@@ -77,9 +77,6 @@
   delay: 10
   notify:
     - update ca-certs
-  register: result
-  until: result|succeeded
-  retries: 5
 
 - name: setup openstack current base path
   file:

--- a/roles/swift-common/handlers/main.yml
+++ b/roles/swift-common/handlers/main.yml
@@ -11,9 +11,6 @@
     - update ca-certs
     - pip clean swifttool outside venv
     - setup swifttool alternatives
-  register: result
-  until: result|succeeded
-  retries: 5
 
 - name: pip clean swifttool outside venv
   pip: name=swifttool state=absent


### PR DESCRIPTION
It looks like there was some duplication applied from this
commit: ed41072a212615019d04734e8508423f6715044c Removing
duplication since it is overriding some functionality and
you can’t duplicate ‘register’, ‘until’ and ‘retries’ keys
in the same task.