### PR TITLE
Use specific mirror for swifttool install

### DIFF
--- a/roles/swift-common/defaults/main.yml
+++ b/roles/swift-common/defaults/main.yml
@@ -87,6 +87,7 @@ swift:
   swifttool_url: https://github.com/blueboxgroup/swifttool/archive/v0.0.1.tar.gz
   swifttool_version: 'v0.0.1'
   swifttool_method: 'git'
+  swifttool_pypi_mirror: https://pypi-mirror.openstack.blueboxgrid.com/bluebox/openstack
   monitoring:
     sensu_checks:
       check_ucarp_procs:

--- a/roles/swift-common/tasks/main.yml
+++ b/roles/swift-common/tasks/main.yml
@@ -42,7 +42,7 @@
   pip:
     name: swifttool
     version: "{{ swift.swifttool_version }}"
-    extra_args: "-i {{ openstack.pypi_mirror | default(omit) }}"
+    extra_args: "-i {{ swift.swifttool_pypi_mirror | default(omit) }}"
     virtualenv: "{{ swift.venv_dir }}"
   register: result
   until: result|success


### PR DESCRIPTION
We aren't putting swifttool into devpi root, so callout a specific
mirror url for it.

Change-Id: Ia3806815243c85454659cd4b986457d49c0aa672