### PR TITLE
Make swift great again

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -78,14 +78,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         c.vm.provider "libvirt" do |v|
           v.memory = vm['memory'] if vm.has_key?('memory')
           v.cpus = vm['cpus'] if vm.has_key?('cpus')
-          if vm.has_key?('custom')
-            if vm['custom'].kind_of?(Array)
-              vm['custom'].each do |custom|
-                v.customize eval(custom)
-              end
-            else
-              v.customize eval(vm['custom'])
-            end
+	  if vm.has_key?('libvirt')
+	    if vm['libvirt'].has_key?('storage')
+		v.storage :file, vm['libvirt']['storage']
+	    end
           end
           v.nested = true
         end

--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -1,5 +1,6 @@
 ---
 stack_env: example
+ursula_env_path: "{{ lookup('env','URSULA_ENV') }}"
 
 country_code: US
 

--- a/envs/example/swift/group_vars/all.yml
+++ b/envs/example/swift/group_vars/all.yml
@@ -1,5 +1,7 @@
 ---
 stack_env: example_swift
+
+swift_fqdn: swift-openstack.example.org
 swift_floating_ip: "{{ hostvars[groups['swiftnode'][0]][primary_interface]['ipv4']['address'] }}"
 
 undercloud_cidr: 
@@ -17,8 +19,10 @@ percona:
 swift:
   enabled: True
   disks:
-    - sdb
-  enabled: True
+    - disk: vda
+
+haproxy:
+  stats_group: haproxy
 
 openstack_setup:
   add_users: True

--- a/envs/example/swift/group_vars/all.yml
+++ b/envs/example/swift/group_vars/all.yml
@@ -20,6 +20,7 @@ swift:
   enabled: True
   disks:
     - disk: vda
+      make_label: True
 
 haproxy:
   stats_group: haproxy

--- a/envs/example/swift/ring_definition.yml
+++ b/envs/example/swift/ring_definition.yml
@@ -4,17 +4,17 @@ replicas: 3
 min_part_hours: 1
 zones:
   z1:
-    10.1.1.131:
+    172.16.0.111:
       disks:
         - blockdev: vda1
           weight: 1000
   z2:
-    10.1.1.132:
+    172.16.0.112:
       disks:
         - blockdev: vda1
           weight: 1000
   z3:
-    10.1.1.133:
+    172.16.0.113:
       disks:
         - blockdev: vda1
           weight: 1000

--- a/envs/example/swift/ring_definition.yml
+++ b/envs/example/swift/ring_definition.yml
@@ -6,12 +6,15 @@ zones:
   z1:
     10.1.1.131:
       disks:
-        - sdb1
+        - blockdev: vda1
+          weight: 1000
   z2:
     10.1.1.132:
       disks:
-        - sdb1
+        - blockdev: vda1
+          weight: 1000
   z3:
     10.1.1.133:
       disks:
-        - sdb1
+        - blockdev: vda1
+          weight: 1000

--- a/envs/example/swift/vagrant.yml
+++ b/envs/example/swift/vagrant.yml
@@ -10,20 +10,41 @@ vms:
     memory: 3072
     custom: '["modifyvm", :id, "--nicpromisc3", "allow-all"]'
   swiftnode1:
-    ip_address: 10.1.1.131
+    ip_address:
+       - 172.16.0.111
+       - 10.1.1.131
     memory: 768
     custom:
       - "['createhd', '--filename', 'proxy1.1.vdi', '--size', 1024]"
       - "['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium', 'proxy1.1.vdi']"
+    libvirt:
+      storage:
+        file:
+        size: 1G
+        type: qcow2
   swiftnode2:
-    ip_address: 10.1.1.132
+    ip_address: 
+      - 172.16.0.112
+      - 10.1.1.132
     memory: 768
     custom:
       - "['createhd', '--filename', 'proxy2.1.vdi', '--size', 1024]"
       - "['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium', 'proxy2.1.vdi']"
+    libvirt:
+      storage:
+        file:
+        size: 1G
+        type: qcow2
   swiftnode3:
-    ip_address: 10.1.1.133
+    ip_address: 
+      - 172.16.0.113
+      - 10.1.1.133
     memory: 768
     custom:
       - "['createhd', '--filename', 'proxy3.1.vdi', '--size', 1024]"
       - "['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium', 'proxy3.1.vdi']"
+    libvirt:
+      storage:
+        file:
+        size: 1G
+        type: qcow2

--- a/library/swift_disk.py
+++ b/library/swift_disk.py
@@ -41,6 +41,7 @@ def main():
             dev  = dict(required=False, default=None),
             partition_path = dict(required=False, default=None),
             mount_point = dict(required=False, default=None),
+            make_label = dict(required=False, default=False),
         ),
         required_one_of = [['dev', 'partition_path']],
         mutually_exclusive = [['dev', 'partition_path']]
@@ -70,9 +71,9 @@ def main():
         module.exit_json(changed=False)
 
     if dev_path is not None:
-        # create label
-        cmd = ['parted', '--script', dev_path, 'mklabel', 'msdos']
-        rc, out, err = module.run_command(cmd, check_rc=True)    
+        if module.params.get('make_label'):
+            cmd = ['parted', '--script', dev_path, 'mklabel', 'gpt']
+            rc, out, err = module.run_command(cmd, check_rc=True)    
 
         # create partitions
         cmd = ['parted', '--script', dev_path, 'mkpart', 'primary', '1', '100%']

--- a/library/swift_disk.py
+++ b/library/swift_disk.py
@@ -69,8 +69,12 @@ def main():
     if os.path.exists(part_path) and os.path.ismount(mount_point):
         module.exit_json(changed=False)
 
-    # create partitions
     if dev_path is not None:
+        # create label
+        cmd = ['parted', '--script', dev_path, 'mklabel', 'msdos']
+        rc, out, err = module.run_command(cmd, check_rc=True)    
+
+        # create partitions
         cmd = ['parted', '--script', dev_path, 'mkpart', 'primary', '1', '100%']
         rc, out, err = module.run_command(cmd, check_rc=True)
 

--- a/plugins/filters/sensu_filters.py
+++ b/plugins/filters/sensu_filters.py
@@ -4,6 +4,8 @@ def sensu_dependencies(check_name, hostvars, host_groups, check_groups):
     deps = set()
     check_groups = check_groups.split(',')
     for group in check_groups:
+        if not group in host_groups:
+            continue
         for host in host_groups[group]:
             client_name = '{}.{}-{}'.format(host, hostvars[host]['ansible_domain'], hostvars[host]['stack_env'])
             if 'monitoring' in hostvars[host]:

--- a/roles/swift-account/tasks/main.yml
+++ b/roles/swift-account/tasks/main.yml
@@ -1,12 +1,14 @@
 ---
 - name: swift-account service scripts
-  template: src=roles/swift-common/templates/etc/init/swift-service.conf
-            dest=/etc/init/swift-{{ item.service_name }}.conf mode=0644
+  upstart_service: name=swift-{{ item.name }} 
+                   cmd=/usr/local/bin/swift-{{ item.cmd|default(item.name) }}
+                   args=/etc/swift/account-server.conf
+                   user=swift
   with_items:
-    - { service_name: account-auditor, conf: account-server }
-    - { service_name: account, conf: account-server }
-    - { service_name: account-reaper, conf: account-server }
-    - { service_name: account-replicator, conf: account-server }
+    - { name: account, cmd: account-server }
+    - { name: account-auditor }
+    - { name: account-reaper }
+    - { name: account-replicator }
 
 - stat: path=/etc/swift/account.ring.gz
   register: account_ring

--- a/roles/swift-container/tasks/main.yml
+++ b/roles/swift-container/tasks/main.yml
@@ -1,13 +1,15 @@
 ---
 - name: swift-container service scripts
-  template: src=roles/swift-common/templates/etc/init/swift-service.conf
-            dest=/etc/init/swift-{{ item.service_name }}.conf mode=0644
+  upstart_service: name=swift-{{ item.name }}
+                   cmd=/usr/local/bin/swift-{{ item.cmd|default(item.name) }}
+                   args=/etc/swift/container-server.conf
+                   user=swift
   with_items:
-    - { service_name: container-auditor, conf: container-server }
-    - { service_name: container, conf: container-server }
-    - { service_name: container-replicator, conf: container-server }
-    - { service_name: container-sync, conf: container-server }
-    - { service_name: container-updater, conf: container-server }
+    - { name: container, cmd: container-server }
+    - { name: container-auditor }
+    - { name: container-replicator }
+    - { name: container-sync }
+    - { name: container-updater }
 
 - stat: path=/etc/swift/container.ring.gz
   register: container_ring

--- a/roles/swift-object/tasks/main.yml
+++ b/roles/swift-object/tasks/main.yml
@@ -46,10 +46,12 @@
   swift_disk: dev={{ item.disk|default(omit) }}
               partition_path={{ item.partition_path|default(omit) }}
               mount_point={{ item.mount_point|default(omit) }}
+              make_label={{ item.make_label|default(False) }}
   with_items: "{{ swift.disks }}"
 
 - name: configure shared ssd partition if it exist
   swift_disk: partition_path={{ swift.os_shared_partition }}
+              make_label=False
   when: swift.os_shared_partition is defined
 
 - name: configure swift-drive-audit

--- a/roles/swift-object/tasks/main.yml
+++ b/roles/swift-object/tasks/main.yml
@@ -6,14 +6,16 @@
   retries: 5
 
 - name: swift-object service scripts
-  template: src=roles/swift-common/templates/etc/init/swift-service.conf
-            dest=/etc/init/swift-{{ item.service_name }}.conf mode=0644
+  upstart_service: name=swift-{{ item.name }}
+                   cmd=/usr/local/bin/swift-{{ item.cmd|default(item.name) }}
+                   args=/etc/swift/{{ item.conf|default('object-server.conf') }}
+                   user=swift
   with_items:
-    - { service_name: object-auditor, conf: object-server }
-    - { service_name: object, conf: object-server }
-    - { service_name: object-replicator, conf: object-server }
-    - { service_name: object-updater, conf: object-server }
-    - { service_name: object-expirer, conf: object-expirer }
+    - { name: object, cmd: object-server }
+    - { name: object-expirer, conf: object-expirer.conf }
+    - { name: object-auditor }
+    - { name: object-replicator }
+    - { name: object-updater }
 
 - stat: path=/etc/swift/object.ring.gz
   register: object_ring
@@ -65,4 +67,5 @@
     - swift-object
     - swift-object-expirer
     - swift-object-updater
+    - swift-object-auditor
   when: start_object|bool

--- a/roles/swift-proxy/tasks/main.yml
+++ b/roles/swift-proxy/tasks/main.yml
@@ -4,10 +4,10 @@
   tags: ufw
 
 - name: swift-proxy service script
-  template: src=roles/swift-common/templates/etc/init/swift-service.conf
-            dest=/etc/init/swift-{{ item.service_name }}.conf mode=0644
-  with_items:
-    - { service_name: proxy, conf: proxy-server }
+  upstart_service: name=swift-proxy
+                   cmd=/usr/local/bin/swift-proxy-server
+                   args=/etc/swift/proxy-server.conf
+                   user=swift
 
 - stat: path=/etc/swift/object.ring.gz
   register: object_ring

--- a/roles/swift-ring/handlers/main.yml
+++ b/roles/swift-ring/handlers/main.yml
@@ -4,22 +4,3 @@
            --config {{ swift_ring.outdir }}/ring_definition.yml --outdir {{ swift_ring.outdir }} bootstrap
   become: True
   become_user: swiftops
-
-- name: setup swift rings - scaleup
-  command: setsid /usr/local/bin/swifttool -u swiftops -i /home/swiftops/.ssh/id_rsa
-           --config {{ swift_ring.outdir }}/ring_definition.yml --outdir {{ swift_ring.outdir }} scaleup
-           --iterations {{ swift_ring.iterations }} 
-  async: "{{ (swift_ring.iterations + 1) * 60 * 60|int }}"
-  become: True
-  become_user: swiftops
-  poll: 0
-
-- name: setup swift rings - scaledown
-  command:  setsid /usr/local/bin/swifttool -u swiftops -i /home/swiftops/.ssh/id_rsa
-           --config {{ swift_ring.outdir }}/ring_definition.yml --outdir {{ swift_ring.outdir }} scaledown
-           --iterations {{ swift_ring.iterations }}
-  async: "{{ (swift_ring.iterations + 1) * 60 * 60|int }}"
-  become: True
-  become_user: swiftops
-  poll: 0
-

--- a/roles/swift-ring/tasks/main.yml
+++ b/roles/swift-ring/tasks/main.yml
@@ -2,4 +2,12 @@
 - name: drop our ring configuration
   copy: src={{ swift_ring.ring_definition_file }} owner=swiftops group=swiftops
         dest={{ swift_ring.outdir }}/ring_definition.yml mode=644 backup=yes
-  notify: setup swift rings - {{ swift_ring.mode }}
+  notify: 
+    - setup swift rings - bootstrap
+
+- name: flush handlers
+  meta: flush_handlers
+
+- name: swift-init stop all
+  command: swift-init stop all
+  ignore_errors: true

--- a/site.yml
+++ b/site.yml
@@ -292,6 +292,22 @@
       tags: ['openstack', 'horizon', 'control']
   environment: "{{ env_vars|default({}) }}"
 
+- name: install swift-common
+  hosts: swiftnode
+  any_errors_fatal: true
+  roles:
+    - role: swift-common
+      tags: ['openstack', 'swift', 'swift-common', 'data']
+  environment: "{{ env_vars|default({}) }}"
+
+- name: swift bootstrap rings
+  hosts: swiftnode_primary
+  any_errors_fatal: true
+  roles:
+    - role: swift-ring
+      tags: ['openstack', 'swift', 'swift-ring', 'data']
+  environment: "{{ env_vars|default({}) }}"
+
 - name: swift code and config
   hosts: swiftnode
   any_errors_fatal: true
@@ -307,14 +323,6 @@
       tags: ['openstack', 'swift', 'swift-container', 'data']
     - role: swift-proxy
       tags: ['openstack', 'swift', 'swift-proxy', 'control']
-  environment: "{{ env_vars|default({}) }}"
-
-- name: swift bootstrap rings
-  hosts: swiftnode_primary
-  any_errors_fatal: true
-  roles:
-    - role: swift-ring
-      tags: ['openstack', 'swift', 'swift-ring', 'data']
   environment: "{{ env_vars|default({}) }}"
 
 - name: heat code and config

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -31,21 +31,3 @@ vms:
       - 192.168.255.111
     memory: 1536
     custom: '["modifyvm", :id, "--nicpromisc3", "allow-all"]'
-  swiftnode1:
-    ip_address: 10.1.1.131
-    memory: 768
-    custom:
-      - "['createhd', '--filename', 'proxy1.1.vdi', '--size', 1024]"
-      - "['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium', 'proxy1.1.vdi']"
-  swiftnode2:
-    ip_address: 10.1.1.132
-    memory: 768
-    custom:
-      - "['createhd', '--filename', 'proxy2.1.vdi', '--size', 1024]"
-      - "['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium', 'proxy2.1.vdi']"
-  swiftnode3:
-    ip_address: 10.1.1.133
-    memory: 768
-    custom:
-      - "['createhd', '--filename', 'proxy3.1.vdi', '--size', 1024]"
-      - "['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium', 'proxy3.1.vdi']"


### PR DESCRIPTION
Swift was previously using swift-init to manage all of the swift
services. Well it turns out that this leads to some confusion when using
upstart.

To address this, call all of the native binaries in the upstart_services
and reorder when we build the rings. This moves the start/restart
control back into Ansible's hands for now.

Some other small swift updates to make Vagrant great again.