### PR TITLE
Fix sudo needing sensu checks

### DIFF
--- a/roles/common/templates/monitoring/sensu-sudoers
+++ b/roles/common/templates/monitoring/sensu-sudoers
@@ -1,4 +1,5 @@
 Defaults:sensu env_keep += "OS_AUTH_URL OS_USERNAME OS_PASSWORD OS_TENANT_NAME OS_NO_CACHE OS_CACERT"
+Defaults:sensu secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/etc/sensu/plugins"
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check-log.rb
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check-os-api.rb
 sensu ALL= NOPASSWD: /etc/sensu/plugins/percona-cluster-size.rb

--- a/roles/sensu-check/defaults/main.yml
+++ b/roles/sensu-check/defaults/main.yml
@@ -83,11 +83,10 @@ sensu_checks:
 
   nova:
     check_nova_services:
-      sudo: true
       handler: default
       interval: 120
       standalone: true
-      command: check-nova-services.sh -z critical
+      command: sudo check-nova-services.sh -z critical
       service_owner: openstack
       dependencies: "{{ 'keepalive' | sensu_dependencies(hostvars, groups, 'controller') }}"
       # above is incredibly ugly, but works. Creates the list below.
@@ -97,12 +96,11 @@ sensu_checks:
 
   percona:
     check_cluster_size:
-      sudo: true
       handler: default
       notification: "unexpected number of mysql processes"
       interval: 120
       standalone: true
-      command: "percona-cluster-size.rb -d /root/.my.cnf --expected 3 --criticality critical"
+      command: "sudo percona-cluster-size.rb -d /root/.my.cnf --expected 3 --criticality critical"
       service_owner: openstack
       dependencies: "{{ 'keepalive' | sensu_dependencies(hostvars, groups, 'db,db_arbiter') }}"
       # above is incredibly ugly, but works. Creates the list below.


### PR DESCRIPTION
A sudo key isn't being read by the ansible module or by sensu itself,
the sudo action needs to go on the command itself.

Also, given that some commands are now done without paths, we need to
define the secure path for sensu user for sudo.

Change-Id: I0942b7e44898cff7f1fc575f5bd0f73f9d712ba5