### PR TITLE
Implement Ursula test for Swift

### DIFF
--- a/envs/example/ci-ceph_swift/group_vars/all.yml
+++ b/envs/example/ci-ceph_swift/group_vars/all.yml
@@ -3,6 +3,15 @@ stack_env: example_ci-ceph_swift
 
 state_path_base: /opt/stack/data
 
+swift_floating_ip: "{{ hostvars[groups['swiftnode'][0]][primary_interface]['ipv4']['address'] }}"
+swift_fqdn: "swift.{{ fqdn }}"
+
+etc_hosts:
+  - name: "{{ fqdn }}"
+    ip: "{{ undercloud_floating_ip }}"
+  - name: "{{ swift_fqdn }}"
+    ip: "{{ swift_floating_ip }}"
+
 neutron:
   enable_external_interface: True
 
@@ -20,3 +29,41 @@ cinder:
     # Ceph
     - name: rbd_volumes
       volume_driver: cinder.volume.drivers.rbd.RBDDriver
+
+swift:
+  enabled: True
+  allow_versions: True
+  disks:
+    - disk: vdb
+
+swift_common:
+  private_key: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEAtaUGSrXGeUudiTejoh19cSKNfVMtVw5WJgq4AfRt+iupwi7k
+    cwbUpjaCoQ06F5AnjbUlXN1dzppmnTlvLcRLQEsqGGkQ48t66nbJC0ERrvirS5Bx
+    XSKxrXGnaHtQqV7mJJEHAphDnD/jrmPhi/+HQBKo76Yw1XtJ0N4J/lk+G8a3TfAC
+    fzYfAzVwyOuTk1FnA+JzwtOIuBnkpGBb6gDr9NLsbawnrid312ZtekG7nr6tfOfB
+    h/PDx8/l1rIdQh3gIeGgq2l/HDxMmrSyZF9xdp3SjW4p52ucNd9kWaSBkMekd4oB
+    fNtLgFjNX99WREQR9aCsRSbmY2Xtg72UoKwydwIDAQABAoIBAARe8TTRBPKcQDEy
+    FozrGr6jLzZpzvh+TtJhhaX+ZLsVW+NhT3v5GRrayu/nKpOwk1MUnc6LQRucmYWF
+    AUjfpVPpuxyVQqPInK+RpirQKQXF1BFga2nrUM00o+uetAUvVGhi2QFV+qKC4w6q
+    Np4wyudey5PgsuIgMlmFTkZBjX4LkrI893ZbVPXqZ3cJIFXe3wUzi9dKeiJXDy1N
+    Nrk/1CkpI+wSduXMc23fG/yPdBv9xMDAv9pWSjNVb7tWRFQroQU+Z2BmV3izX+IT
+    LUnJAYikCcq1rKPvnmh4MvWM2Fx+OUlxAbKcUGoceGXOtMyNDZw+YymoHQxKb/1T
+    NrRK8wkCgYEA3E6ZwnRB1GjCsGoINuPb3XA6Rj1hyEOpIiUDhgRgNIOOVsBu1Cx2
+    LDiTTlBgQ7PbSwRDeHM0usnPsHWUoWutWxHk8m8dZ4shgzTjDabWJY0Mh2reVMeW
+    PnNQECySBeaKblNJ3fZ+A6dmUuS9pEjEOcok3xeJgdXhlFY93fCfEfsCgYEA0xLf
+    JV4aOdfASPvuVyqjAi3IJpE+ORkteECjck+0StfQVyTRDfwyo2P49+64ShE4AH/d
+    fam+yRgIehVOPPGOW7AkMHV8AFijNuZgmbU1pJqUodyuyAngWVzXLEhgQVUU039F
+    orG0nK3JADLgVrWOwL7iAXFDWHl4nWV4kPGwtLUCgYBJs84C3OvtCMMhS8fFvUMf
+    +Ny2BPECk4gw0Rs1qZ8Z0m07HpO1Tc6XCrJVP9SEsdYKabm8wSYB22QtD5kSy7gq
+    QHlMldnLeyNSBs5zEb6Qv3hSkXEiAceEywUc9BxB9xeWwyxyInWT+VvlHXtIS8PB
+    5ZuiOviYxBn8i0GVT1uYIwKBgEX/ji0wRfZEzKnnkqUpqKGCWUwhAsegx+mHVi0E
+    rb/cTmV3+jRvHMP+1YQzkL5Pc4kG3odcEb9Szwzdn/KqERHrGjVP4O2kd4wvXn3b
+    EI0kDoKXUwdX7yTzmxA+eF1yP9Pb81X/JOyI3Y3JUYiv8UWOiBj+XN0se4mHKzK2
+    VGm5AoGBALuemFgbQ/ikkOGlcm29VZj4oVNAGUePa0zeUPYmvdibBtcFWi2u95L1
+    H4XZ5PZElGqPP2JVKyp10tP2pu+5WX+/r4GV34ML4b24fgetRUC9J5HIff9exeI3
+    4j7WTz/A99zho9BVUSrVRJCO7CGDHGUbItkPlYe0Xj+OTa+ClhIa
+    -----END RSA PRIVATE KEY-----
+  public_key: |
+    ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC1pQZKtcZ5S52JN6OiHX1xIo19Uy1XDlYmCrgB9G36K6nCLuRzBtSmNoKhDToXkCeNtSVc3V3OmmadOW8txEtASyoYaRDjy3rqdskLQRGu+KtLkHFdIrGtcadoe1CpXuYkkQcCmEOcP+OuY+GL/4dAEqjvpjDVe0nQ3gn+WT4bxrdN8AJ/Nh8DNXDI65OTUWcD4nPC04i4GeSkYFvqAOv00uxtrCeuJ3fXZm16Qbuevq1858GH88PHz+XWsh1CHeAh4aCraX8cPEyatLJkX3F2ndKNbinna5w132RZpIGQx6R3igF820uAWM1f31ZERBH1oKxFJuZjZe2DvZSgrDJ3 swiftops@swiftnode

--- a/envs/example/ci-ceph_swift/hosts
+++ b/envs/example/ci-ceph_swift/hosts
@@ -37,3 +37,11 @@ ceph-2
 ceph-0
 ceph-1
 ceph-2
+
+[swiftnode]
+swift-0
+swift-1
+swift-2
+
+[swiftnode_primary]
+swift-0

--- a/playbooks/ci-ceph_swift/tasks/pre-deploy.yml
+++ b/playbooks/ci-ceph_swift/tasks/pre-deploy.yml
@@ -35,6 +35,33 @@
     - name: umount ephemeral disk on ceph_osds
       shell: umount /dev/{{ item }}
       with_items: "{{ ceph.disks }}"
+      failed_when: False
+
+- name: umount ephemeral disk on swiftnode
+  hosts: swiftnode
+  tasks:
+    - name: umount ephemeral disk on swiftnode
+      shell: umount /dev/{{ item.disk }}
+      with_items: "{{ swift.disks }}"
+      failed_when: False
+
+- name: create new partition table for ephemeral disk on swiftnode
+  hosts: swiftnode
+  tasks:
+    - name: create new msdos partition table for ephemeral disk
+      shell: parted /dev/{{ item.disk }} --script mklabel msdos
+      with_items: "{{ swift.disks }}"
+
+- name: deploy fake lshw file on swiftnode to get disk info
+  hosts: swiftnode
+  tasks:
+    - name: rename the original /usr/bin/lshw
+      command: mv /usr/bin/lshw /usr/bin/lshw.original
+
+    - name: deploy fake lshw file /usr/bin/lshw
+      template: src=../templates/usr/bin/lshw
+                dest=/usr/bin/lshw
+                owner=root group=root mode=0755
 
 - name: tasks for all
   hosts: all

--- a/playbooks/ci-ceph_swift/templates/heat_stack.yml
+++ b/playbooks/ci-ceph_swift/templates/heat_stack.yml
@@ -57,6 +57,18 @@ parameters:
     type: string
     description: Name of ceph-2 server
     default: {{ ansible_env.testenv_instance_prefix }}-ceph-2
+  swift-0_name:
+    type: string
+    description: Name of swift-0 server
+    default: {{ ansible_env.testenv_instance_prefix }}-swift-0
+  swift-1_name:
+    type: string
+    description: Name of swift-1 server
+    default: {{ ansible_env.testenv_instance_prefix }}-swift-1
+  swift-2_name:
+    type: string
+    description: Name of swift-2 server
+    default: {{ ansible_env.testenv_instance_prefix }}-swift-2
 
 resources:
 
@@ -114,6 +126,10 @@ resources:
           protocol: tcp
           port_range_min: 9696
           port_range_max: 9696
+        - remote_ip_prefix: 0.0.0.0/0
+          protocol: tcp
+          port_range_min: 8090
+          port_range_max: 8090
         - remote_ip_prefix: 0.0.0.0/0
           protocol: icmp
         - ethertype: 'IPv4'
@@ -190,7 +206,7 @@ resources:
       availability_zone: {{ ansible_env.AVAILABILITY_ZONE }}
       {% endif -%}
       # placeholder line
-      
+
   ceph-1:
     type: OS::Nova::Server
     properties:
@@ -206,11 +222,59 @@ resources:
       availability_zone: {{ ansible_env.AVAILABILITY_ZONE }}
       {% endif -%}
       # placeholder line
-      
+
   ceph-2:
     type: OS::Nova::Server
     properties:
       name: { get_param: ceph-2_name }
+      image: { get_param: image }
+      flavor: { get_param: flavor_ceph_swift }
+      key_name: { get_resource: ssh_keypair }
+      user_data_format: RAW
+      security_groups: [{ get_resource: server_security_group }]
+      networks:
+        - network: { get_param: network }
+      {% if ansible_env.AVAILABILITY_ZONE -%}
+      availability_zone: {{ ansible_env.AVAILABILITY_ZONE }}
+      {% endif -%}
+      # placeholder line
+
+  swift-0:
+    type: OS::Nova::Server
+    properties:
+      name: { get_param: swift-0_name }
+      image: { get_param: image }
+      flavor: { get_param: flavor_ceph_swift }
+      key_name: { get_resource: ssh_keypair }
+      user_data_format: RAW
+      security_groups: [{ get_resource: server_security_group }]
+      networks:
+        - network: { get_param: network }
+      {% if ansible_env.AVAILABILITY_ZONE -%}
+      availability_zone: {{ ansible_env.AVAILABILITY_ZONE }}
+      {% endif -%}
+      # placeholder line
+
+  swift-1:
+    type: OS::Nova::Server
+    properties:
+      name: { get_param: swift-1_name }
+      image: { get_param: image }
+      flavor: { get_param: flavor_ceph_swift }
+      key_name: { get_resource: ssh_keypair }
+      user_data_format: RAW
+      security_groups: [{ get_resource: server_security_group }]
+      networks:
+        - network: { get_param: network }
+      {% if ansible_env.AVAILABILITY_ZONE -%}
+      availability_zone: {{ ansible_env.AVAILABILITY_ZONE }}
+      {% endif -%}
+      # placeholder line
+
+  swift-2:
+    type: OS::Nova::Server
+    properties:
+      name: { get_param: swift-2_name }
       image: { get_param: image }
       flavor: { get_param: flavor_ceph_swift }
       key_name: { get_resource: ssh_keypair }
@@ -292,6 +356,39 @@ resources:
       floating_ip: { get_resource: ceph-2_floating_ip }
       server_id: { get_resource: ceph-2 }
 
+  swift-0_floating_ip:
+    type: OS::Nova::FloatingIP
+    properties:
+      pool: { get_param: floating_ip_pool }
+
+  swift-0_fip_association:
+    type: OS::Nova::FloatingIPAssociation
+    properties:
+      floating_ip: { get_resource: swift-0_floating_ip }
+      server_id: { get_resource: swift-0 }
+
+  swift-1_floating_ip:
+    type: OS::Nova::FloatingIP
+    properties:
+      pool: { get_param: floating_ip_pool }
+
+  swift-1_fip_association:
+    type: OS::Nova::FloatingIPAssociation
+    properties:
+      floating_ip: { get_resource: swift-1_floating_ip }
+      server_id: { get_resource: swift-1 }
+
+  swift-2_floating_ip:
+    type: OS::Nova::FloatingIP
+    properties:
+      pool: { get_param: floating_ip_pool }
+
+  swift-2_fip_association:
+    type: OS::Nova::FloatingIPAssociation
+    properties:
+      floating_ip: { get_resource: swift-2_floating_ip }
+      server_id: { get_resource: swift-2 }
+
   {% endif -%}
   # placeholder line
 
@@ -320,6 +417,15 @@ outputs:
   ceph-2:
     description: IP address of ceph-2 in provider network
     value: { get_attr: [ ceph-2, first_address ] }
+  swift-0:
+    description: IP address of swift-0 in provider network
+    value: { get_attr: [ swift-0, first_address ] }
+  swift-1:
+    description: IP address of swift-1 in provider network
+    value: { get_attr: [ swift-1, first_address ] }
+  swift-2:
+    description: IP address of swift-2 in provider network
+    value: { get_attr: [ swift-2, first_address ] }
   {% else -%}
   controller-0:
     description: Floating IP address of controller-0
@@ -342,5 +448,14 @@ outputs:
   ceph-2_floating_ip:
     description: Floating IP address of ceph-2
     value: { get_attr: [ ceph-2_floating_ip, ip ] }
+  swift-0:
+    description: Floating IP address of swift-0
+    value: { get_attr: [ swift-0_floating_ip, ip ] }
+  swift-1:
+    description: Floating IP address of swift-1
+    value: { get_attr: [ swift-1_floating_ip, ip ] }
+  swift-2:
+    description: Floating IP address of swift-2
+    value: { get_attr: [ swift-2_floating_ip, ip ] }
   {% endif -%}
   # placeholder line

--- a/playbooks/ci-ceph_swift/templates/usr/bin/lshw
+++ b/playbooks/ci-ceph_swift/templates/usr/bin/lshw
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+hostname="{{ inventory_hostname }}"
+
+{% raw -%}
+# Note: If there is a need to run the original lshw command,
+# please uncomment the following code,
+# and add an entry for "/usr/bin/lshw.original" in "/etc/sudoers.d/swiftops"
+#if [ "$1" != "-C" -o "$2" != "disk" ]; then
+#  if [ -f /usr/bin/lshw.original ]; then
+#    /usr/bin/lshw.original $@
+#    exit 0
+#  fi
+#fi
+
+# Output additional content for disks
+arr_label=(`lsblk -db |awk 'NR>1{print $1}'`)
+GB=1073741824
+arr_size=(`lsblk -db |awk -v gb=$GB 'NR>1{print $4/gb}'`)
+for((i=0;i<${#arr_label[@]};i++));
+do
+  cat << EOF
+  *-disk:$i
+       logical name: /dev/${arr_label[$i]}
+       serial: ${hostname}-${arr_label[$i]}
+       size: ${arr_size[$i]}GiB
+EOF
+done
+{% endraw %}

--- a/playbooks/tests/tasks/main.yml
+++ b/playbooks/tests/tasks/main.yml
@@ -4,4 +4,6 @@
 - include: network.yml
 - include: ceph.yml
   when: ceph.enabled|default('False')|bool
+- include: swift.yml
+  when: swift.enabled|default('False')|bool
 - include: integration.yml

--- a/playbooks/tests/tasks/swift.yml
+++ b/playbooks/tests/tasks/swift.yml
@@ -1,0 +1,12 @@
+---
+- name: tests on a single controller for swift
+  hosts: controller[0]
+  tasks:
+  - name: Openstack service list should include swift
+    shell: . /root/stackrc; openstack service list | grep swift
+
+  - name: Openstack endpoint list should include swift
+    shell: . /root/stackrc; openstack endpoint list | grep swift
+
+  - name: swift has a working api
+    shell: . /root/stackrc; openstack object store account show | grep Containers

--- a/test/common
+++ b/test/common
@@ -31,7 +31,10 @@ elif [[ $TEST_ENV == "ci-ceph_swift" ]]; then
   ${testenv_instance_prefix}-compute-0\
   ${testenv_instance_prefix}-ceph-0\
   ${testenv_instance_prefix}-ceph-1\
-  ${testenv_instance_prefix}-ceph-2"
+  ${testenv_instance_prefix}-ceph-2\
+  ${testenv_instance_prefix}-swift-0\
+  ${testenv_instance_prefix}-swift-1\
+  ${testenv_instance_prefix}-swift-2"
 
   export testenv_flavor_ceph_swift=${testenv_flavor_ceph_swift:=ci_ceph_swift}
 else

--- a/test/gen-cert
+++ b/test/gen-cert
@@ -63,7 +63,11 @@ cat >> req.conf <<eof
 [ v3_req ]
 basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment, keyCertSign
-subjectAltName = DNS.1:${DOMAIN}
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = ${DOMAIN}
+DNS.2 = swift.${DOMAIN}
 eof
 
 # Generate the cert (good for 10 years)

--- a/test/setup
+++ b/test/setup
@@ -79,7 +79,36 @@ else
   CONTROLLER_IP=$(private_ip ${testenv_instance_prefix}-controller-0)
 fi
 
-echo "controller_primary: ${CONTROLLER_IP}" >> ${ROOT}/envs/test/group_vars/all.yml
+cat >> ${ROOT}/envs/test/group_vars/all.yml <<eof
+controller_primary: ${CONTROLLER_IP}
+ursula_env_path: ${ROOT}/envs/test
+eof
+
+if [[ ${TEST_ENV} == "ci-ceph_swift" ]]; then
+  echo "generating ring_definition.yml file for swift ..."
+  swift_0_ip="$(private_ip ${testenv_instance_prefix}-swift-0)"
+  swift_1_ip="$(private_ip ${testenv_instance_prefix}-swift-1)"
+  swift_2_ip="$(private_ip ${testenv_instance_prefix}-swift-2)"
+  cat > ${ROOT}/envs/test/ring_definition.yml <<eof
+---
+part_power: 13
+replicas: 3
+min_part_hours: 1
+zones:
+  z1:
+    ${swift_0_ip}:
+      disks:
+        - vdb1
+  z2:
+    ${swift_1_ip}:
+      disks:
+        - vdb1
+  z3:
+    ${swift_2_ip}:
+      disks:
+        - vdb1
+eof
+fi
 
 ring_bell
 echo "vms are up: ${VMS} !!"


### PR DESCRIPTION
Implement Ursula test with Swift enabled (based on current heat provisioner approach for ursula PR tests and ceph tests). Once the swift deployment and tests are enabled, it can be included in the current nightly ursula test jenkins job which already has ceph enabled since they are sharing the same set of ursula env "envs/example/ci-ceph_swift".

The test cases for swift in this PR are only very basic ones to make sure swift is deployed properly and working well. After the Openstack is deployed with swift, glance will be configured with swift as backend store by default, so that the swift component can also be verified by the general image creation and query actions during the existing ursula tests.