### PR TITLE
lbaas: increase haproxy global default connection limit

### DIFF
--- a/roles/neutron-data-network/files/etc/neutron/lbaas_templates/haproxy.loadbalancer.j2
+++ b/roles/neutron-data-network/files/etc/neutron/lbaas_templates/haproxy.loadbalancer.j2
@@ -1,0 +1,29 @@
+{# # Copyright 2014 OpenStack Foundation
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+#}
+{% extends 'haproxy_proxies.j2' %}
+{% set loadbalancer_name = loadbalancer.name %}
+{% set usergroup = user_group %}
+{% set sock_path = stats_sock %}
+
+{% block proxies %}
+{% from 'haproxy_proxies.j2' import frontend_macro as frontend_macro, backend_macro%}
+{% for listener in loadbalancer.listeners %}
+{{ frontend_macro(constants, listener, loadbalancer.vip_address) }}
+{% endfor %}
+{% for pool in loadbalancer.pools %}
+{{ backend_macro(constants, pool) }}
+{% endfor %}
+{% endblock proxies %}

--- a/roles/neutron-data-network/files/etc/neutron/lbaas_templates/haproxy_base.j2
+++ b/roles/neutron-data-network/files/etc/neutron/lbaas_templates/haproxy_base.j2
@@ -1,0 +1,34 @@
+{# # Copyright 2014 OpenStack Foundation
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+#}
+# Configuration for {{ loadbalancer_name }}
+global
+    daemon
+    user nobody
+    group {{ usergroup }}
+    log /dev/log local0
+    log /dev/log local1 notice
+    maxconn 200000
+    stats socket {{ sock_path }} mode 0666 level user
+
+defaults
+    log global
+    retries 3
+    option redispatch
+    timeout connect 5000
+    timeout client 50000
+    timeout server 50000
+
+{% block proxies %}{% endblock proxies %}

--- a/roles/neutron-data-network/files/etc/neutron/lbaas_templates/haproxy_proxies.j2
+++ b/roles/neutron-data-network/files/etc/neutron/lbaas_templates/haproxy_proxies.j2
@@ -1,0 +1,94 @@
+{# # Copyright 2014 OpenStack Foundation
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+#}
+{% extends 'haproxy_base.j2' %}
+
+{% macro bind_macro(constants, listener, lb_vip_address) %}
+{% if listener.default_tls_path %}
+{% set def_crt_opt = "ssl crt %s"|format(listener.default_tls_path)|trim() %}
+{% else %}
+{% set def_crt_opt = "" %}
+{% endif %}
+{% if listener.crt_dir %}
+{% set crt_dir_opt = "crt %s"|format(listener.crt_dir)|trim() %}
+{% else %}
+{% set crt_dir_opt = "" %}
+{% endif %}
+bind {{ lb_vip_address }}:{{ listener.protocol_port }} {{ "%s %s"|format(def_crt_opt, crt_dir_opt)|trim() }}
+{% endmacro %}
+
+{% macro use_backend_macro(listener) %}
+{% if listener.default_pool %}
+default_backend {{ listener.default_pool.id }}
+{% endif %}
+{% endmacro %}
+
+{% macro frontend_macro(constants, listener, lb_vip_address) %}
+frontend {{ listener.id }}
+    option tcplog
+{% if listener.protocol == constants.PROTOCOL_TERMINATED_HTTPS %}
+    redirect scheme https if !{ ssl_fc }
+{% endif %}
+{% if listener.connection_limit is defined %}
+    maxconn {{ listener.connection_limit }}
+{% endif %}
+{% if listener.protocol_mode == constants.PROTOCOL_HTTP.lower() %}
+    option forwardfor
+{% endif %}
+    {{ bind_macro(constants, listener, lb_vip_address)|trim() }}
+    mode {{ listener.protocol_mode }}
+{% if listener.default_pool %}
+    default_backend {{ listener.default_pool.id }}
+{% endif %}
+{% endmacro %}
+
+{% macro backend_macro(constants, pool) %}
+backend {{ pool.id }}
+    mode {{ pool.protocol }}
+    balance {{ pool.lb_algorithm }}
+{% if pool.session_persistence %}
+{% if pool.session_persistence.type == constants.SESSION_PERSISTENCE_SOURCE_IP %}
+    stick-table type ip size 10k
+    stick on src
+{% elif pool.session_persistence.type == constants.SESSION_PERSISTENCE_HTTP_COOKIE %}
+    cookie SRV insert indirect nocache
+{% elif pool.session_persistence.type == constants.SESSION_PERSISTENCE_APP_COOKIE and pool.session_persistence.cookie_name %}
+    appsession {{ pool.session_persistence.cookie_name }} len 56 timeout 3h
+{% endif %}
+{% endif %}
+{% if pool.health_monitor %}
+    timeout check {{ pool.health_monitor.timeout }}
+{% if pool.health_monitor.type == constants.HEALTH_MONITOR_HTTP or pool.health_monitor.type == constants.HEALTH_MONITOR_HTTPS %}
+    option httpchk {{ pool.health_monitor.http_method }} {{ pool.health_monitor.url_path }}
+    http-check expect rstatus {{ pool.health_monitor.expected_codes }}
+{% endif %}
+{% if pool.health_monitor.type == constants.HEALTH_MONITOR_HTTPS %}
+    option ssl-hello-chk
+{% endif %}
+{% endif %}
+{% for member in pool.members %}
+{% if pool.health_monitor %}
+{% set hm_opt = " check inter %ds fall %d"|format(pool.health_monitor.delay, pool.health_monitor.max_retries) %}
+{% else %}
+{% set hm_opt = "" %}
+{% endif %}
+{%if pool.session_persistence.type == constants.SESSION_PERSISTENCE_HTTP_COOKIE %}
+{% set persistence_opt = " cookie %s"|format(member.id) %}
+{% else %}
+{% set persistence_opt = "" %}
+{% endif %}
+    {{ "server %s %s:%d weight %s%s%s"|e|format(member.id, member.address, member.protocol_port, member.weight, hm_opt, persistence_opt)|trim() }}
+{% endfor %}
+{% endmacro %}

--- a/roles/neutron-data-network/tasks/main.yml
+++ b/roles/neutron-data-network/tasks/main.yml
@@ -62,6 +62,19 @@
     neutron-metadata-agent:
       config_files: /etc/neutron/metadata_agent.ini
 
+- name: modified neutron lbaas templates to workaround 2000 connection limit
+  file:
+    src: etc/neutron/lbaas_templates/{{ item }}
+    dest: /etc/neutron/lbaas_templates/{{ item }}
+    mode: 0644
+  with_items:
+    - haproxy.loadbalancer.j2
+    - haproxy_base.j2
+    - haproxy_proxies.j2
+  when: (neutron.lbaas.enabled == "smart" and
+         groups['controller'][0] not in groups['compute']) or
+         neutron.lbaas.enabled|bool
+
 - name: neutron lbaas config
   template:
     src: etc/neutron/neutron_lbaas.conf

--- a/roles/neutron-data-network/templates/etc/neutron/neutron_lbaas.conf
+++ b/roles/neutron-data-network/templates/etc/neutron/neutron_lbaas.conf
@@ -5,4 +5,7 @@
 [service_providers]
 service_provider = {{ neutron.lbaas.service_provider }}
 
+[haproxy]
+jinja_config_template = /etc/neutron/lbaas_templates/haproxy.loadbalancer.j2
+
 [certificates]


### PR DESCRIPTION
HAProxy defaults to 2000 connections as a global limit. Increase this by
using our own modified configuration templates.

This is a temporary workaround until a more complete solution can be introduced upstream: https://review.openstack.org/#/c/341806/

Ideally we could use the intree haproxy templates, but until this connection limit is address in tree we can specify the configuration option to use our own modified templates.