### PR TITLE
Add log forwarding host to /etc/hosts

### DIFF
--- a/playbooks/tests/tasks/pre-test.yml
+++ b/playbooks/tests/tasks/pre-test.yml
@@ -1,0 +1,9 @@
+
+- name: Pre-test setup
+  hosts: all
+  tasks:
+    - name: add log forwarding node to /etc/hosts
+      lineinfile: dest=/etc/hosts regexp={{ ansible_env.LOGSTASH_HOST }}
+                  insertafter=EOF
+                  line="{{ ansible_env.LOGSTASH_PRIVATE_IP }} {{ ansible_env.LOGSTASH_HOST }}"
+      when: ansible_env.LOGSTASH_HOST  != "" and ansible_env.LOGSTASH_PRIVATE_IP != ""

--- a/test/run
+++ b/test/run
@@ -24,6 +24,7 @@ if [ "${ACTION}" == "all" -o "${ACTION}" == "deploy" ]; then
 fi
 
 if [ "${ACTION}" == "all" -o "${ACTION}" == "test" ]; then
+  time ursula ${extra_args} "envs/test" ${ROOT}/playbooks/tests/tasks/pre-test.yml -u ${LOGIN_USER} $@
   time ursula ${extra_args} "envs/test" ${ROOT}/playbooks/tests/tasks/main.yml -u ${LOGIN_USER} $@
   ring_bell
 fi


### PR DESCRIPTION
If the job running the tests has defined a logstash forwarding host with
a private IP address, we should add it to /etc/hosts, so the node can
properly forward its logs.