### PR TITLE
Pin erlang version (3.0.x)

### DIFF
--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -5,10 +5,13 @@
 - name: add rabbitmq config directory
   file: dest=/etc/rabbitmq state=directory owner=root mode=0755
 
+# pin version of esl-erlang for
+# https://github.com/rabbitmq/rabbitmq-management/issues/244
+# lift when rabbitmq-server 3.6.4 is released
 - name: install erlang-solutions erlang
   apt: pkg={{ item }}
   with_items:
-    - esl-erlang
+    - esl-erlang=1:18.3
     - rabbitmq-server
   register: result
   until: result|succeeded


### PR DESCRIPTION
Latest erlang breaks rabbitmq-server output,
https://github.com/rabbitmq/rabbitmq-management/issues/244

Change-Id: Iad80d55fc549a840e43d73057f3623ce0a8e4868
(cherry picked from commit 34d567cb8dfa2e8dc8d578fae8901d01349784fa)