### PR TITLE
Add ability to tune scheduler subset size

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -22,6 +22,7 @@ nova:
   novnc_url: https://github.com/kanaka/noVNC/archive/v0.5.1.tar.gz
   vnc_keymap: en-us
   scheduler_default_filters: RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,CoreFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,AggregateInstanceExtraSpecsFilter
+  scheduler_host_subset_size: 1
   libvirt_bin_version: 1.2.2-0ubuntu13.1.9~cloud0
   python_libvirt_version: 1.2.2-0ubuntu2~cloud0
   qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.16~cloud0

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -26,6 +26,7 @@ debug = {{ nova.logging.debug }}
 
 # Scheduler #
 scheduler_default_filters = {{ nova.scheduler_default_filters }}
+scheduler_host_subset_size = {{ nova.scheduler_host_subset_size }}
 
 {% if nova.default_availability_zone is defined -%}
 default_schedule_zone = {{ nova.default_availability_zone }}


### PR DESCRIPTION
This setting will have the scheduler pic randomly from up to N computes
that pass through the filters. On a busy system or with multiple
schedulers at play this can more evenly distribute the load of instances
across systems.

Leave the setting at 1, the default, which should have no impact. This
will allow us to tune clusters based on needs.

Change-Id: I97fb3eea1b11755c3fbade7910650c7218c482e3