### PR TITLE
Clean apt repos on upgrades

### DIFF
--- a/upgrade.yml
+++ b/upgrade.yml
@@ -18,6 +18,24 @@
         openstack_source:
           git_update: yes
 
+- name: cleanups
+  hosts: all:!vyatta-*
+  gather_facts: no
+  tags: always
+  tasks:
+    - name: clean out existing apt repos
+      file:
+        path: /etc/apt/sources.list.d/
+        state: absent
+
+    - name: recreate apt sources directory
+      file:
+        path: /etc/apt/sources.list.d
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+
 - name: upgrade common bits first
   hosts: all:!vyatta-*
   max_fail_percentage: 1


### PR DESCRIPTION
Some left over repos may break our ability to run apt, which can stall
an upgrade. Just blow away what's there and let Ansible put the repos
back as it needs them.

Change-Id: Id6c145c986ff35eda0cfb1bad9929c8674351073