### PR TITLE
Add log forwarding host info to test envs

### DIFF
--- a/roles/common/templates/etc/hosts
+++ b/roles/common/templates/etc/hosts
@@ -17,3 +17,7 @@ ff02::2 ip6-allrouters
 {{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].ansible_nodename }}
 {% endfor %}
 {% endif %}
+
+{% if ansible_env.LOGSTASH_HOST is defined and ansible_env.LOGSTASH_PRIVATE_IP is defined %}
+{{ ansible_env.LOGSTASH_HOST }} {{ ansible_env.LOGSTASH_PRIVATE_IP }}
+{% endif %}

--- a/test/setup
+++ b/test/setup
@@ -112,3 +112,6 @@ fi
 
 ring_bell
 echo "vms are up: ${VMS} !!"
+
+echo "LOGSTASH_HOST=${LOGSTASH_HOST}"
+echo "LOGSTASH_PRIVATE_IP=${LOGSTASH_PRIVATE_IP}"


### PR DESCRIPTION
Allow a test to optionally add log forwarding location info to
/etc/hosts.