### PR TITLE
Use versionless URL for identity endpoint

### DIFF
--- a/library/keystone_service.py
+++ b/library/keystone_service.py
@@ -76,6 +76,8 @@ keystone_service: >
 '''
 
 try:
+    from keystoneauth1.identity import v2
+    from keystoneauth1 import session
     from keystoneclient.v2_0 import client
 except ImportError:
     keystoneclient_found = False
@@ -90,11 +92,18 @@ def authenticate(endpoint, token, login_user, login_password, tenant_name,
     """Return a keystone client object"""
 
     if token:
-        return client.Client(endpoint=endpoint, token=token, insecure=insecure)
+        auth = v2.Token(auth_url=endpoint, token=token)
     else:
-        return client.Client(auth_url=endpoint, username=login_user,
-                             password=login_password, tenant_name=tenant_name,
-                             insecure=insecure)
+        auth = v2.Password(auth_url=endpoint, username=login_user,
+                           password=login_password, tenant_name=tenant_name)
+
+    if insecure:
+        verify=False
+    else:
+        verify=True
+    sess = session.Session(auth=auth, verify=verify)
+
+    return client.Client(session=sess)
 
 def get_service(keystone, name):
     """ Retrieve a service by name """

--- a/library/neutron_network.py
+++ b/library/neutron_network.py
@@ -18,6 +18,8 @@
 
 try:
     from neutronclient.neutron import client
+    from keystoneauth1.identity import v2
+    from keystoneauth1 import session
     from keystoneclient.v2_0 import client as ksclient
 except ImportError:
     print("failed=True msg='neutronclient and keystone client are required'")
@@ -121,15 +123,19 @@ _os_tenant_id = None
 
 def _get_ksclient(module, kwargs):
     try:
-        kclient = ksclient.Client(username=kwargs.get('login_username'),
-                                 password=kwargs.get('login_password'),
-                                 tenant_name=kwargs.get('login_tenant_name'),
-                                 auth_url=kwargs.get('auth_url'))
+        auth = v2.Password(auth_url=kwargs.get('auth_url'),
+                           username=kwargs.get('login_username'),
+                           password=kwargs.get('login_password'),
+                           tenant_name=kwargs.get('login_tenant_name'))
+        sess = session.Session(auth=auth)
+
+        kclient = ksclient.Client(session=sess)
+        nclient = client.Client('2.0', session=sess)
     except Exception as e:
         module.fail_json(msg = "Error authenticating to the keystone: %s" %e.message)
     global _os_keystone
     _os_keystone = kclient
-    return kclient
+    return nclient
 
 
 def _get_endpoint(module, ksclient):
@@ -140,15 +146,8 @@ def _get_endpoint(module, ksclient):
     return endpoint
 
 def _get_neutron_client(module, kwargs):
-    _ksclient = _get_ksclient(module, kwargs)
-    token = _ksclient.auth_token
-    endpoint = _get_endpoint(module, _ksclient)
-    kwargs = {
-            'token': token,
-            'endpoint_url': endpoint
-    }
     try:
-        neutron = client.Client('2.0', **kwargs)
+        neutron = _get_ksclient(module, kwargs)
     except Exception as e:
         module.fail_json(msg = " Error in connecting to Neutron: %s " %e.message)
     return neutron

--- a/library/neutron_router.py
+++ b/library/neutron_router.py
@@ -18,6 +18,8 @@
 
 try:
     from neutronclient.neutron import client
+    from keystoneauth1.identity import v2
+    from keystoneauth1 import session
     from keystoneclient.v2_0 import client as ksclient
 except ImportError:
     print("failed=True msg='neutronclient and keystone client are required'")
@@ -87,16 +89,19 @@ _os_tenant_id = None
 
 def _get_ksclient(module, kwargs):
     try:
-        kclient = ksclient.Client(username=kwargs.get('login_username'),
-                                 password=kwargs.get('login_password'),
-                                 tenant_name=kwargs.get('login_tenant_name'),
-                                 auth_url=kwargs.get('auth_url'),
-                                 cacert=kwargs.get('cacert'))
+        auth = v2.Password(auth_url=kwargs.get('auth_url'),
+                           username=kwargs.get('login_username'),
+                           password=kwargs.get('login_password'),
+                           tenant_name=kwargs.get('login_tenant_name'))
+        sess = session.Session(auth=auth)
+
+        kclient = ksclient.Client(session=sess)
+        nclient = client.Client('2.0', session=sess)
     except Exception as e:
-        module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
+        module.fail_json(msg = "Error authenticating to the keystone: %s" %e.message)
     global _os_keystone
     _os_keystone = kclient
-    return kclient
+    return nclient
 
 
 def _get_endpoint(module, ksclient):
@@ -107,17 +112,10 @@ def _get_endpoint(module, ksclient):
     return endpoint
 
 def _get_neutron_client(module, kwargs):
-    _ksclient = _get_ksclient(module, kwargs)
-    token = _ksclient.auth_token
-    endpoint = _get_endpoint(module, _ksclient)
-    kwargs = {
-            'token': token,
-            'endpoint_url': endpoint
-    }
     try:
-        neutron = client.Client('2.0', **kwargs)
+        neutron = _get_ksclient(module, kwargs)
     except Exception as e:
-        module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
+        module.fail_json(msg = " Error in connecting to Neutron: %s " %e.message)
     return neutron
 
 def _set_tenant_id(module):

--- a/library/neutron_router_gateway.py
+++ b/library/neutron_router_gateway.py
@@ -18,6 +18,8 @@
 
 try:
     from neutronclient.neutron import client
+    from keystoneauth1.identity import v2
+    from keystoneauth1 import session
     from keystoneclient.v2_0 import client as ksclient
 except ImportError:
     print("failed=True msg='neutronclient and keystone client are required'")
@@ -87,17 +89,19 @@ EXAMPLES = '''
 _os_keystone = None
 def _get_ksclient(module, kwargs):
     try:
-        kclient = ksclient.Client(
-            username=module.params.get('login_username'),
-            password=module.params.get('login_password'),
-            tenant_name=module.params.get('login_tenant_name'),
-            auth_url=module.params.get('auth_url'),
-            region_name=module.params.get('region_name'))
+        auth = v2.Password(auth_url=kwargs.get('auth_url'),
+                           username=kwargs.get('login_username'),
+                           password=kwargs.get('login_password'),
+                           tenant_name=kwargs.get('login_tenant_name'))
+        sess = session.Session(auth=auth)
+
+        kclient = ksclient.Client(session=sess)
+        nclient = client.Client('2.0', session=sess)
     except Exception as e:
-        module.fail_json(msg = "Error authenticating to the keystone: %s " % e.message)
+        module.fail_json(msg = "Error authenticating to the keystone: %s" %e.message)
     global _os_keystone
     _os_keystone = kclient
-    return kclient
+    return nclient
 
 
 def _get_endpoint(module, ksclient):
@@ -108,17 +112,10 @@ def _get_endpoint(module, ksclient):
     return endpoint
 
 def _get_neutron_client(module, kwargs):
-    _ksclient = _get_ksclient(module, kwargs)
-    token = _ksclient.auth_token
-    endpoint = _get_endpoint(module, _ksclient)
-    kwargs = {
-            'token': token,
-            'endpoint_url': endpoint
-    }
     try:
-        neutron = client.Client('2.0', **kwargs)
+        neutron = _get_ksclient(module, kwargs)
     except Exception as e:
-        module.fail_json(msg = "Error in connecting to neutron: %s " % e.message)
+        module.fail_json(msg = " Error in connecting to Neutron: %s " %e.message)
     return neutron
 
 def _get_router(module, neutron):

--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -41,11 +41,34 @@
     - restart heat services
 
 - name: create heat trusts roles
-  keystone_user: role={{ item }}
-                 login_user=admin
-                 endpoint="{{ endpoints.keystone.url.admin }}/{{ endpoints.keystone.version }}/"
-                 login_password="{{ secrets.admin_password }}"
-                 login_tenant_name=admin
+  environment:
+    OS_IDENTITY_API_VERSION: 3
+    OS_DOMAIN_ID: default
+  os_keystone_role:
+    name: "{{ item }}"
+    auth:
+      auth_url: "{{ endpoints.keystone.url.internal }}/"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
+  with_items:
+    - heat_stack_owner
+    - heat_stack_user
+  run_once: true
+
+- name: assign admin heat roles
+  environment:
+    OS_IDENTITY_API_VERSION: 3
+    OS_DOMAIN_ID: default
+  os_user_role:
+    role: "{{ item }}"
+    user: admin
+    project: admin
+    auth:
+      auth_url: "{{ endpoints.keystone.url.internal }}/"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
   with_items:
     - heat_stack_owner
     - heat_stack_user

--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -6,9 +6,9 @@
     OS_BOOTSTRAP_PASSWORD: "{{ keystone.bootstrap.password }}"
     OS_BOOTSTRAP_PROJECT_NAME: "{{ keystone.bootstrap.project }}"
     OS_BOOTSTRAP_ROLE_NAME: "{{ keystone.bootstrap.role }}"
-    OS_BOOTSTRAP_ADMIN_URL: "{{ endpoints.keystone.url.admin }}/{{ endpoints.keystone.version }}"
-    OS_BOOTSTRAP_INTERNAL_URL: "{{ endpoints.keystone.url.internal }}/{{ endpoints.keystone.version }}"
-    OS_BOOTSTRAP_PUBLIC_URL: "{{ endpoints.keystone.url.public }}/{{ endpoints.keystone.version }}"
+    OS_BOOTSTRAP_ADMIN_URL: "{{ endpoints.keystone.url.admin }}/"
+    OS_BOOTSTRAP_INTERNAL_URL: "{{ endpoints.keystone.url.internal }}/"
+    OS_BOOTSTRAP_PUBLIC_URL: "{{ endpoints.keystone.url.public }}/"
     OS_BOOTSTRAP_SERVICE_NAME: "{{ 'keystone' }}"  # otherwise it uses the keystone variable
     OS_BOOTSTRAP_REGION_ID: "RegionOne"
 
@@ -21,7 +21,7 @@
     description: "{{ item }} tenant"
     domain: default
     auth:
-      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
       username: admin
       password: "{{ secrets.admin_password }}"
@@ -33,7 +33,7 @@
     OS_DOMAIN_ID: default
   os_user_facts:
     auth:
-      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
       username: admin
       password: "{{ secrets.admin_password }}"
@@ -49,7 +49,7 @@
     default_project: "{{ item.tenant }}"
     domain: default
     auth:
-      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
       username: admin
       password: "{{ secrets.admin_password }}"
@@ -66,7 +66,7 @@
   os_keystone_role:
     name: "{{ item }}"
     auth:
-      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
       username: admin
       password: "{{ secrets.admin_password }}"
@@ -81,7 +81,7 @@
     user: "{{ item.user }}"
     project: "{{ item.tenant }}"
     auth:
-      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
       username: admin
       password: "{{ secrets.admin_password }}"
@@ -100,7 +100,7 @@
     user: admin
     domain: default
     auth:
-      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
       username: admin
       password: "{{ secrets.admin_password }}"
@@ -115,7 +115,7 @@
     default_project: admin
     domain: default
     auth:
-      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
       username: admin
       password: "{{ secrets.admin_password }}"
@@ -128,7 +128,7 @@
   os_keystone_role:
     name: heat_stack_user
     auth:
-      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
       username: admin
       password: "{{ secrets.admin_password }}"
@@ -143,7 +143,7 @@
     user: heat_stack_user
     project: admin
     auth:
-      auth_url: "{{ endpoints.keystone.url.internal }}/v3"
+      auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
       username: admin
       password: "{{ secrets.admin_password }}"


### PR DESCRIPTION
There is no need to put a version in there, modern clients figure it
out. Of course, I had to update a bunch of our modules because they
aren't modern.