### PR TITLE
Pin rspec version

### DIFF
--- a/roles/serverspec/defaults/main.yml
+++ b/roles/serverspec/defaults/main.yml
@@ -3,6 +3,8 @@ serverspec:
   enabled: true
   interval: 3600
   gems:
+    - name: rspec
+      version: 3.4.0
     - name: rspec-core
       version: 3.4.0
     - name: net-ssh


### PR DESCRIPTION
pin rspec gem to keep serverspec gem from installing a newer version of rspec-core.