### PR TITLE
Upgrade ansible version pinning to be explicit (3.0.x)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ tox
 pep8
 oslo.utils
 shade>=1.7.0
-ansible>=2.1.0.0,<3
+ansible==2.1.0.0
 python-novaclient
 python-glanceclient
 python-cinderclient


### PR DESCRIPTION
With the release of 2.1.1.0 some of our plays are now broken. We need to
explicitly pin to the older working release until we sort this out.

Change-Id: I8ec5c0de22bdb5ae7696ab263b1feaa3e5972290
(cherry picked from commit 13067e599db34cb305c4db7d6ed62727b751038a)