### PR TITLE
Use logstash_* Ansible vars

### DIFF
--- a/roles/common/templates/etc/hosts
+++ b/roles/common/templates/etc/hosts
@@ -18,6 +18,6 @@ ff02::2 ip6-allrouters
 {% endfor %}
 {% endif %}
 
-{% if ansible_env.LOGSTASH_HOST is defined and ansible_env.LOGSTASH_PRIVATE_IP is defined %}
-{{ ansible_env.LOGSTASH_HOST }} {{ ansible_env.LOGSTASH_PRIVATE_IP }}
+{% if logstash_host is defined and logstash_ip is defined %}
+{{ logstash_host }} {{ logstash_ip }}
 {% endif %}

--- a/test/setup
+++ b/test/setup
@@ -112,6 +112,3 @@ fi
 
 ring_bell
 echo "vms are up: ${VMS} !!"
-
-echo "LOGSTASH_HOST=${LOGSTASH_HOST}"
-echo "LOGSTASH_PRIVATE_IP=${LOGSTASH_PRIVATE_IP}"


### PR DESCRIPTION
Using logstash_* Ansible variables allows us to enable logstash
forwarding for Ursula tests by passing them as --extra-vars.