### PR TITLE
Force install of older esl-erlang

### DIFF
--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -9,10 +9,21 @@
 # https://github.com/rabbitmq/rabbitmq-management/issues/244
 # lift when rabbitmq-server 3.6.4 is released
 - name: install erlang-solutions erlang
-  apt: pkg={{ item }}
+  apt:
+    pkg: "{{ item }}"
+    force: True
   with_items:
     - esl-erlang=1:18.3
+  register: result
+  until: result|succeeded
+  retries: 5
+
+- name: install rabbitmq-server
+  apt:
+    pkg: "{{ item }}"
+  with_items:
     - rabbitmq-server
+    #- esl-erlang
   register: result
   until: result|succeeded
   retries: 5


### PR DESCRIPTION
On systems where erlang is already too new, the apt module needs a force
to downgrade. Limit the force to just erlang as to minimize the scope of
things that could be forced in.

Change-Id: I562fc2c967f463988968a1bd804375744d89395c