### PR TITLE
Work around bugs in os_user_facts (3.0.x)

### DIFF
--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -27,17 +27,19 @@
       password: "{{ secrets.admin_password }}"
   with_items: "{{ keystone.tenants }}"
 
+# Putting user and project name in env works around a bug in openstack
+# modules, where the contents of the auth dict are considered no_log, so
+# users with "admin" somewhere in the name would be masked out of the facts.
 - name: get the current keystone users (requires Ansible >= 2.1)
   environment:
     OS_IDENTITY_API_VERSION: 3
     OS_DOMAIN_ID: default
+    OS_USERNAME: admin
+    OS_PROJECT_NAME: admin
   os_user_facts:
     auth:
       auth_url: "{{ endpoints.keystone.url.internal }}/v3"
-      project_name: admin
-      username: admin
       password: "{{ secrets.admin_password }}"
-  register: user_facts
 
 - name: keystone users
   environment:
@@ -57,7 +59,7 @@
   # If the username is not cloud_admin or monitor, create/update user.
   # If the name is cloud_admin or monitor, and the user does not exist, create user.
   when: "item.name not in ['cloud_admin', 'monitor'] or
-         (item.name in ['cloud_admin', 'monitor'] and item.name not in user_facts.ansible_facts.openstack_users|map(attribute='username')|list)"
+         (item.name in ['cloud_admin', 'monitor'] and item.name not in openstack_users|map(attribute='name')|list)"
 
 - name: keystone roles
   environment:


### PR DESCRIPTION
The contents of the auth dict get marked as no_log, which apparently
transforms the value of the data returned by os_user_facts. By moving
the 'admin' words out of the auth dict, the correct values come through.

In addition, the attribute where the name is found is "name" not
"username". Finally, it's a fact module so the facts are integrated
directly into the host facts, so we can access them without a register.

Change-Id: I9e28aa566c76372c31e16d4c0c138dc77fc2b146
(cherry picked from commit f49bf2f12ec1aaf3f9e82e065c2cf679bc065ada)