### PR TITLE
Don't pin OS_COMPUTE_API_VERSION for root client role

### DIFF
--- a/roles/client/templates/root/stackrc
+++ b/roles/client/templates/root/stackrc
@@ -12,3 +12,10 @@ export OS_CACERT=/opt/stack/ssl/openstack.crt
 export OS_CACERT=/etc/ssl/certs/ca-certificates.crt
 {% endif -%}
 export OS_NO_CACHE=True
+export OS_VOLUME_API_VERSION=2
+# NOTE(mriedem): OS_COMPUTE_API_VERSION is left unspecified. By default the
+# python-novaclient CLI does version negotation and requests the latest
+# microversion available from the server based on the latest version that the
+# installed client currently supports. For this reason, scripts should not be
+# written that rely on the nova CLI using this stackrc environment. This should
+# be purely for operator convenience/usage.

--- a/roles/common/templates/etc/sensu/stackrc
+++ b/roles/common/templates/etc/sensu/stackrc
@@ -8,4 +8,11 @@ export OS_CACERT=/opt/stack/ssl/openstack.crt
 export OS_NO_CACHE=True
 export NOVACLIENT_UUID_CACHE_DIR=/tmp/sensu
 export OS_VOLUME_API_VERSION=2
-export OS_COMPUTE_API_VERSION=2
+# NOTE(mriedem): Take care when changing OS_COMPUTE_API_VERSION as any sensu
+# plugin code that is using the Nova CLI could break since by default the CLI
+# does version negotation and requests the latest microversion available from
+# the server based on the latest version that the client currently supports,
+# which could change request/response semantics. This is why we pin to the 2.1
+# microversion which is backward compatible with the v2.0 API (which is
+# deprecated).
+export OS_COMPUTE_API_VERSION=2.1


### PR DESCRIPTION
The root user on our environments was having the nova CLI
version pinned to the v2.0 API which has been deprecated
since the Liberty release of OpenStack. It also meant that
we don't get the latest available microversion support from
our cloud and the installed version of python-novaclient by
default when using the nova CLI.

This removes the OS_COMPUTE_API_VERSION from the root client
role so by default the nova CLI negotiates the latest available
microversion. I've left a comment in the stackrc file for that
role to note that scripts shouldn't rely on that being set or
pinned to a specific version, it's purely for operator
convenience.

The sensu stackrc was also pinning the compute API version to
2 which is the deprecated v2.0 API, and with the latest code
upstream is actually gone. It's really talking to v2.1 which
is backward compatible with v2.0. So I've made this more
specific and pinned to 2.1. We don't want to default to 2.latest
for the CLI in the sensu stackrc because there are scripts
which rely on the nova CLI, e.g. check-nova-services.sh, which
could break in unexpected ways if we start requesting the
latest microversion.

Change-Id: I4219899c75ca583d9472b3225cefb50f3ec88835
(cherry picked from commit 2d4b92652e5740395454ab56876aae4e1936ae72)