### PR TITLE
Pin os-client-config

### DIFF
--- a/roles/common/tasks/python.yml
+++ b/roles/common/tasks/python.yml
@@ -69,8 +69,12 @@
   command: python setup.py install chdir=/opt/stack/{{ item.name }}
   with_items: "{{ common.python_extra_packages }}"
 
-- name: install shade for ansible modules
-  pip: name=shade>=1.9.0
+- name: install shade bits for ansible modules
+  pip:
+    name: "{{ item }}"
+  with_items:
+    - os-client-config==1.18.0
+    - shade>=1.9.0
   register: result
   until: result|succeeded
   retries: 5


### PR DESCRIPTION
Related to https://review.openstack.org/#/c/351394/

The change this reverts broke how ansible modules work, as all arguments
to ansible modules are being passed into os-client-config, and things
are stomping on each other.

Change-Id: I0b2889c0ff982eb65ac56ec540c8ec7b07e1596b