### PR TITLE
RELEASE-3.0.X Fix so that openidc does not run when only federation is enabled

### DIFF
--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -60,8 +60,14 @@
             dest=/etc/keystone/uwsgi/keystone-main.ini mode=0775
             owner=keystone group=keystone
 
-- include: federation.yml
+- name: setup keystone sso template
+  template: src=etc/keystone/sso_callback_template.html
+            dest=/etc/keystone/sso_callback_template.html
   when: keystone.federation.enabled|bool
+  notify: restart keystone services
+
+- include: openidc.yml
+  when: keystone.federation.enabled|bool and keystone.federation.sp.oidc.enabled|bool
 
 - name: keystone apache vhost
   template: src=etc/apache2/sites-available/keystone.conf

--- a/roles/keystone/tasks/openidc.yml
+++ b/roles/keystone/tasks/openidc.yml
@@ -24,7 +24,3 @@
 - name: enable apache mod auth_openidc
   apache2_module: name=auth_openidc
   notify: reload apache
-
-- name: setup keystone sso template
-  template: src=etc/keystone/sso_callback_template.html
-            dest=/etc/keystone/sso_callback_template.html


### PR DESCRIPTION
The openidc tasks were ran anyways if any type of federation was enabled.
This fixes that problem by requiring openidc to be enabled.