### PR TITLE
Fix handling of domain auth details for openstack clients and modules

### DIFF
--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -91,7 +91,6 @@
 - name: remove heat domain user from default domain
   environment:
     OS_IDENTITY_API_VERSION: 3
-    OS_DOMAIN_ID: default
   shell: . /root/stackrc; openstack --os-auth-url "{{ endpoints.keystone.url.internal }}/v3" user delete --domain default heat_domain_admin
   register: remove_heat_admin
   failed_when: remove_heat_admin|failed and
@@ -119,7 +118,6 @@
 - name: add admin role to the heat domain admin user
   environment:
     OS_IDENTITY_API_VERSION: 3
-    OS_DOMAIN_ID: default
   shell: . /root/stackrc; openstack --os-auth-url "{{ endpoints.keystone.url.internal }}/v3" role add --domain "{{ heat_domain.domain.id }}" --user "{{ heat_admin_user.user.id }}" admin
   when: heat.enabled|bool and heat_admin_user|changed
   run_once: true

--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -43,12 +43,13 @@
 - name: create heat trusts roles
   environment:
     OS_IDENTITY_API_VERSION: 3
-    OS_DOMAIN_ID: default
   os_keystone_role:
     name: "{{ item }}"
     auth:
       auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
+      project_domain_name: default
+      user_domain_name: default
       username: admin
       password: "{{ secrets.admin_password }}"
   with_items:
@@ -59,7 +60,6 @@
 - name: assign admin heat roles
   environment:
     OS_IDENTITY_API_VERSION: 3
-    OS_DOMAIN_ID: default
   os_user_role:
     role: "{{ item }}"
     user: admin
@@ -67,6 +67,8 @@
     auth:
       auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
+      project_domain_name: default
+      user_domain_name: default
       username: admin
       password: "{{ secrets.admin_password }}"
   with_items:
@@ -77,12 +79,13 @@
 - name: create heat domain
   environment:
     OS_IDENTITY_API_VERSION: 3
-    OS_DOMAIN_ID: default
   os_keystone_domain:
     name: heat
     auth:
       auth_url: "{{ endpoints.keystone.url.internal }}/v3"
       project_name: admin
+      project_domain_name: default
+      user_domain_name: default
       username: admin
       password: "{{ secrets.admin_password }}"
   run_once: true
@@ -100,7 +103,6 @@
 - name: create heat domain admin user
   environment:
     OS_IDENTITY_API_VERSION: 3
-    OS_DOMAIN_ID: default
   os_user:
     name: heat_domain_admin
     password: "{{ secrets.stack_domain_admin_password }}"
@@ -108,6 +110,8 @@
     auth:
       auth_url: "{{ endpoints.keystone.url.internal }}/v3"
       project_name: admin
+      project_domain_name: default
+      user_domain_name: default
       username: admin
       password: "{{ secrets.admin_password }}"
   register: heat_admin_user

--- a/roles/keystone-setup/tasks/ldap.yml
+++ b/roles/keystone-setup/tasks/ldap.yml
@@ -2,12 +2,13 @@
 - name: create ldap domain
   environment:
     OS_IDENTITY_API_VERSION: 3
-    OS_DOMAIN_ID: default
   os_keystone_domain:
     name: "{{ keystone.ldap_domain.domain }}"
     auth:
       auth_url: "{{ endpoints.keystone.url.internal }}/v3"
       project_name: admin
+      project_domain_name: default
+      user_domain_name: default
       username: admin
       password: "{{ secrets.admin_password }}"
   run_once: true
@@ -16,13 +17,14 @@
 - name: create ldap project
   environment:
     OS_IDENTITY_API_VERSION: 3
-    OS_DOMAIN_ID: default
   os_project:
     name: "{{ keystone.ldap_domain.project }}"
     domain_id: "{{ ldap_domain.domain.id }}"
     auth:
       auth_url: "{{ endpoints.keystone.url.internal }}/v3"
       project_name: admin
+      project_domain_name: default
+      user_domain_name: default
       username: admin
       password: "{{ secrets.admin_password }}"
   run_once: true

--- a/roles/keystone-setup/tasks/main.yml
+++ b/roles/keystone-setup/tasks/main.yml
@@ -15,7 +15,6 @@
 - name: keystone tenants
   environment:
     OS_IDENTITY_API_VERSION: 3
-    OS_DOMAIN_ID: default
   os_project:
     name: "{{ item }}"
     description: "{{ item }} tenant"
@@ -23,6 +22,8 @@
     auth:
       auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
+      project_domain_name: default
+      user_domain_name: default
       username: admin
       password: "{{ secrets.admin_password }}"
   with_items: "{{ keystone.tenants }}"
@@ -33,18 +34,18 @@
 - name: get the current keystone users (requires Ansible >= 2.1)
   environment:
     OS_IDENTITY_API_VERSION: 3
-    OS_DOMAIN_ID: default
     OS_USERNAME: admin
     OS_PROJECT_NAME: admin
   os_user_facts:
     auth:
       auth_url: "{{ endpoints.keystone.url.internal }}/"
       password: "{{ secrets.admin_password }}"
+      project_domain_name: default
+      user_domain_name: default
 
 - name: keystone users
   environment:
     OS_IDENTITY_API_VERSION: 3
-    OS_DOMAIN_ID: default
   os_user:
     name: "{{ item.name }}"
     password: "{{ item.password }}"
@@ -53,6 +54,8 @@
     auth:
       auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
+      project_domain_name: default
+      user_domain_name: default
       username: admin
       password: "{{ secrets.admin_password }}"
   with_items: "{{ keystone.users }}"
@@ -64,12 +67,13 @@
 - name: keystone roles
   environment:
     OS_IDENTITY_API_VERSION: 3
-    OS_DOMAIN_ID: default
   os_keystone_role:
     name: "{{ item }}"
     auth:
       auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
+      project_domain_name: default
+      user_domain_name: default
       username: admin
       password: "{{ secrets.admin_password }}"
   with_items: "{{ keystone.roles }}"
@@ -77,7 +81,6 @@
 - name: keystone user roles
   environment:
     OS_IDENTITY_API_VERSION: 3
-    OS_DOMAIN_ID: default
   os_user_role:
     role: "{{ item.role }}"
     user: "{{ item.user }}"
@@ -85,6 +88,8 @@
     auth:
       auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
+      project_domain_name: default
+      user_domain_name: default
       username: admin
       password: "{{ secrets.admin_password }}"
   with_items: "{{ keystone.user_roles }}"
@@ -96,7 +101,6 @@
 - name: grant admin domain admin rights
   environment:
     OS_IDENTITY_API_VERSION: 3
-    OS_DOMAIN_ID: default
   os_user_role:
     role: admin
     user: admin
@@ -104,13 +108,14 @@
     auth:
       auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
+      project_domain_name: default
+      user_domain_name: default
       username: admin
       password: "{{ secrets.admin_password }}"
 
 - name: heat stack user
   environment:
     OS_IDENTITY_API_VERSION: 3
-    OS_DOMAIN_ID: default
   os_user:
     name: heat_stack_user
     password: "{{ secrets.service_password }}"
@@ -126,12 +131,13 @@
 - name: heat stack role
   environment:
     OS_IDENTITY_API_VERSION: 3
-    OS_DOMAIN_ID: default
   os_keystone_role:
     name: heat_stack_user
     auth:
       auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
+      project_domain_name: default
+      user_domain_name: default
       username: admin
       password: "{{ secrets.admin_password }}"
   when: heat.enabled|bool
@@ -139,7 +145,6 @@
 - name: heat stack user role
   environment:
     OS_IDENTITY_API_VERSION: 3
-    OS_DOMAIN_ID: default
   os_user_role:
     role: heat_stack_user
     user: heat_stack_user
@@ -147,6 +152,8 @@
     auth:
       auth_url: "{{ endpoints.keystone.url.internal }}/"
       project_name: admin
+      project_domain_name: default
+      user_domain_name: default
       username: admin
       password: "{{ secrets.admin_password }}"
   when: heat.enabled|bool


### PR DESCRIPTION
We're masking these problems currently by pinning openstack-client-config, but when we unpin or move to a higher version, we'll want all of these things set correctly to avoid any future attempt at interpreting meaning from an incorrect variable.