### PR TITLE
Do not add heat_stack_user role to admin

### DIFF
--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -61,7 +61,7 @@
   environment:
     OS_IDENTITY_API_VERSION: 3
   os_user_role:
-    role: "{{ item }}"
+    role: heat_stack_owner
     user: admin
     project: admin
     auth:
@@ -71,9 +71,6 @@
       user_domain_name: default
       username: admin
       password: "{{ secrets.admin_password }}"
-  with_items:
-    - heat_stack_owner
-    - heat_stack_user
   run_once: true
 
 - name: create heat domain


### PR DESCRIPTION
A user with heat_stack_user role will not be allowed to build heat
stacks. This role shouldn't be added to any real users, it just gets
added when heat adds users.

Change-Id: Icd37784d1bfe8a36a099df151292d95050ac4fc9