### PR TITLE
Copy the allinone example and adapt it for Ironic

### DIFF
--- a/envs/example/ironic/group_vars/all.yml
+++ b/envs/example/ironic/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-stack_env: example-ironic
+stack_env: example_allinone
 floating_ip: 172.16.0.100
 
 xtradb:
@@ -8,18 +8,73 @@ xtradb:
 percona:
   replication: False
 
-nova:
-  scheduler_default_filters: AvailabilityZoneFilter,ComputeFilter
+primary_interface: 'ansible_eth1'
+provider_interface: 'ansible_eth2'
+
 
 ironic:
   enabled: True
-  tftp_server: 172.16.255.100
-  dns_server: 172.16.255.100
-  api_url:
-    scheme: http
-    host: 172.16.255.100
-    port: 6385
+  logging:
+    debug: False
+
+cinder:
+  enabled: False
+
+heat:
+  enabled: False
+  logging:
+    debug: False
 
 neutron:
-  dhcp_dns_servers:
-    - 172.16.255.100
+  enable_external_interface: True
+  networks:
+    - name: provider
+      shared: true
+      router_external: true
+      provider_network_type: flat
+      provider_physical_network: provider
+      tenant_name: admin
+      external: true
+      segmentation_id: null
+    - name: private
+      tenant_name: demo
+
+nova:
+  compute_driver: ironic.IronicDriver
+  reserved_host_disk_mb: 0
+  controller_reserve_ram: 0
+  compute_reserve_ram: 0
+  enable_novnc: False
+  compute_ag: baremetal
+  zone: AZ1
+
+sensu_checks:
+    percona:
+      check_cluster_size:
+        sudo: true
+        handler: default
+        notification: "unexpected number of mysql processes"
+        interval: 120
+        standalone: true
+        command: "percona-cluster-size.rb -d /root/.my.cnf --expected 3 --criticality critical"
+        service_owner: openstack
+        dependencies: "{{ 'keepalive' | sensu_dependencies(hostvars, groups, 'db') }}"
+        # above is incredibly ugly, but works. Creates the list below.
+        #dependencies:
+        #  - "controller1.ursula-vagrant/keepalive"
+        #  - "controller2.ursula-vagrant/keepalive"
+        #  - "compute1.ursula-vagrant/keepalive"
+      check_mysql_process:
+        handler: default
+        notification: "unexpected number of mysql processes"
+        interval: 120
+        standalone: true
+        command: "check-procs.rb -p mysql -W 1 -C 1"
+        service_owner: openstack
+      check_garbd_process:
+        handler: default
+        notification: "unexpected number of garbd processes"
+        interval: 120
+        standalone: true
+        command: "check-procs.rb -p garbd -W 1 -C 1"
+        service_owner: openstack

--- a/envs/example/ironic/hosts
+++ b/envs/example/ironic/hosts
@@ -12,3 +12,9 @@ allinone
 
 [cinder_volume]
 allinone
+
+[ironic]
+allinone
+
+[compute_ironic]
+allinone

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ python-glanceclient
 python-cinderclient
 python-neutronclient
 python-keystoneclient
+python-ironicclient
 -e git://github.com/blueboxgroup/ursula-cli.git@master#egg=ursula-cli

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -40,6 +40,7 @@ nova:
   install_packages:
     - python-numpy
     - virt-top
+    - python-ironicclient
   driver:
     docker:
       rev: 'stable/mitaka'

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -79,7 +79,11 @@ reserved_host_memory_mb = {{ nova.compute_reserve_ram }}
 reserved_host_disk_mb = {{ nova.reserved_host_disk_mb }}
 
 # Misc #
+{% if ironic.enabled -%}
+compute_driver = ironic.IronicDriver
+{% else %}
 compute_driver = {{ nova.compute_driver }}
+{% endif %}
 resume_guests_state_on_host_boot = True
 
 disable_libvirt_livesnapshot = False


### PR DESCRIPTION
Replace the outdated "ironic" example with a fresh copy of the
"allinone" example, and begin updating it to properly deploy an allinone
host with Ironic.

Also adds an if-block to nova.conf, to adjust the virt driver if that
compute host should be using Ironic instead of libvirt.

Change-Id: I1ac20c10d64fe178220a88849d8f31b3b09e7aaa