### PR TITLE
Add task to install ironic flavors from group_vars

### DIFF
--- a/envs/example/ironic/group_vars/all.yml
+++ b/envs/example/ironic/group_vars/all.yml
@@ -16,6 +16,11 @@ ironic:
   enabled: True
   logging:
     debug: False
+  flavors:
+    - name: 'baremetal'
+      ram: 512
+      disk: 19
+      vcpus: 1
 
 cinder:
   enabled: False

--- a/roles/openstack-setup/tasks/flavors.yml
+++ b/roles/openstack-setup/tasks/flavors.yml
@@ -10,3 +10,23 @@
   shell: mysql -e "update nova.instance_types set root_gb=10 where name='m1.tiny';"
   when: resize_tiny_flavor|failed
   run_once: true
+
+- name: Add ironic flavors
+  os_nova_flavor:
+    name: '{{ item.name }}'
+    ram: '{{ item.ram | int }}'
+    disk: '{{ item.disk | int }}'
+    vcpus: '{{ item.vcpus | int }}'
+    flavorid: '{{ item.flavorid | default(omit) }}'
+    rxtx_factor: '{{ item.rxtx_factor | default(omit) }}'
+    ephemeral: '{{ item.ephemeral | default(omit) }}'
+    is_public: '{{ item.is_public | default(omit) }}'
+    swap: '{{ item.swap | default(omit) }}'
+    state: present
+    auth:
+      auth_url: "{{ endpoints.auth_uri  }}"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password  }}"
+  with_items: '{{ ironic.flavors | default([]) }}'
+  when: ironic.enabled | default(False) | bool


### PR DESCRIPTION
On setup, the ability to add baremetal flavors to nova is needed.

This commit adds the usage of the ironic.flavors to iterate over and
install required baremetal flavors when ironic.enabled is True.

Signed-off-by: Philip Marc Schwartz <philip@progmad.com>