### PR TITLE
Remove keystone-all from alternatives

### DIFF
--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -20,7 +20,6 @@ keystone:
       - libkrb5-dev
   alternatives:
     - keystone-manage
-    - keystone-all
     - keystone-wsgi-admin
     - keystone-wsgi-public
   jellyroll: False # custom middleware for password compliance


### PR DESCRIPTION
The keystone-all binary doesn't exist in the latest version of keystone
so linking the alternative fails. The implementation has moved on to
support uwsgi deployment instead so there's no reason to keep it around.