### PR TITLE
Don't add +simple to pypi_mirror

### DIFF
--- a/roles/common/tasks/python.yml
+++ b/roles/common/tasks/python.yml
@@ -1,7 +1,7 @@
 ---
 - name: update pip
   pip: name=pip version={{ common.pip_version }}
-       extra_args='-i {{ openstack.pypi_mirror }}/+simple'
+       extra_args='-i {{ openstack.pypi_mirror }}'
   when: ansible_distribution_version == "12.04" and openstack.pypi_mirror is defined
   register: result
   until: result|succeeded
@@ -9,7 +9,7 @@
 
 - name: update pip
   pip: name=pip version={{ common.pip_version }}
-       extra_args='-i {{ openstack.pypi_mirror }}/+simple'
+       extra_args='-i {{ openstack.pypi_mirror }}'
   when: ansible_distribution_version != "12.04"
   register: result
   until: result|succeeded
@@ -28,7 +28,7 @@
 
 - name: update pip
   pip: name=pip version={{ common.pip_version }}
-       extra_args='-i {{ openstack.pypi_mirror }}/+simple'
+       extra_args='-i {{ openstack.pypi_mirror }}'
   when: ansible_distribution_version == "12.04" and openstack.pypi_mirror is not defined
   register: result
   until: result|succeeded


### PR DESCRIPTION
The +simple extension is something typically added by devpi, though it
exists on pypi.python.org. For some envrionments like the upstream
openstack pypi mirror and the portbleu mirror we don't have the +simple
path. The +simple path isn't required, if ommited it will correctly
lookup the path and enable the non +simple use case.