### PR TITLE
Don't use dnsmasq for local dns

### DIFF
--- a/roles/ipv6ra/tasks/main.yml
+++ b/roles/ipv6ra/tasks/main.yml
@@ -11,5 +11,10 @@
             mode=0644
   notify: restart-dnsmasq
 
+- name: prevent dnsmasq from add itself to /etc/resolv.conf via resolvconf
+  lineinfile: dest=/etc/default/dnsmasq regexp="^DNSMASQ_EXCEPT="
+              line="DNSMASQ_EXCEPT=lo"
+  notify: restart-dnsmasq
+
 - name: Enable/start dnsmasq
   service: name=dnsmasq state=started enabled=yes


### PR DESCRIPTION
When using ipv6ra we don't actually want to use dnsmasq for our local
dns server so make sure it doesn't affect resolvconf if that is
installed.

Without this as soon as dnsmasq is installed everything stops getting
resolved.

Change-Id: I5d3ff13e9b1cbc58fd97caf6f6bbf6fbfa74f545