### PR TITLE
Provide a list of flavors to create

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -149,6 +149,19 @@ nova:
     verbose: True
   novnc_method: file
   novnc_url: https://file-mirror.openstack.blueboxgrid.com/novnc/novnc-0.5.1.tar.gz
+  flavors:
+    - flavor_id: 1
+      name: m1.tiny
+      ram: 512
+      disk: 10
+      ephemeral: 0
+      vcpus: 1
+    - flavor_id: 2
+      name: m1.small
+      ram: 2048
+      disk: 20
+      ephemeral: 0
+      vcpus: 1
 
 ceph:
   enabled: false

--- a/playbooks/tests/tasks/controller.yml
+++ b/playbooks/tests/tasks/controller.yml
@@ -124,6 +124,3 @@
 
   - name: nova has a working api
     shell: . /root/stackrc; nova list | grep ID
-
-  - name: m1.tiny flavor has been embiggened
-    shell: mysql -e "select root_gb from nova.instance_types where name='m1.tiny';" | grep 10

--- a/roles/openstack-setup/tasks/flavors.yml
+++ b/roles/openstack-setup/tasks/flavors.yml
@@ -1,17 +1,4 @@
----
-- name: is m1.tiny undersized?
-  shell: mysql -e "select root_gb from nova.instance_types where name='m1.tiny';" | grep 10
-  failed_when: False
-  changed_when: False
-  register: resize_tiny_flavor
-  run_once: true
-
-- name: bump root disk size on m1.tiny
-  shell: mysql -e "update nova.instance_types set root_gb=10 where name='m1.tiny';"
-  when: resize_tiny_flavor|failed
-  run_once: true
-
-- name: Add ironic flavors
+- name: Add nova flavors
   os_nova_flavor:
     name: '{{ item.name }}'
     ram: '{{ item.ram | int }}'
@@ -22,11 +9,11 @@
     ephemeral: '{{ item.ephemeral | default(omit) }}'
     is_public: '{{ item.is_public | default(omit) }}'
     swap: '{{ item.swap | default(omit) }}'
-    state: present
+    state: '{{ item.state | default(omit) }}'
     auth:
       auth_url: "{{ endpoints.auth_uri  }}"
       project_name: admin
       username: admin
       password: "{{ secrets.admin_password  }}"
-  with_items: '{{ ironic.flavors | default([]) }}'
-  when: ironic.enabled | default(False) | bool
+  with_items: '{{ nova.flavors | default([]) }}'
+  run_once: true


### PR DESCRIPTION
It's inappropriate to use MySQL to update these flavors, and
unnecessary. Also since b69296eb74edab12de161fce50e3a65ea18172f0 in
Nova, they're not created by migrations anymore, so we need to make sure
they're present.
