### PR TITLE
Do not install python-numpy for VNC proxy

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -38,7 +38,6 @@ nova:
   heartbeat_timeout_threshold: 30
   floating_pool: external
   install_packages:
-    - python-numpy
     - virt-top
   driver:
     docker:


### PR DESCRIPTION
From openstack/puppet-nova:

    In the context of noVNC, numpy adds little performance according
    to websockify maintainer: kanaka/websockify#77

By removing python-numpy we remove the Fortran dependency.