### PR TITLE
added permissions to cloud_admin role

### DIFF
--- a/roles/neutron-common/templates/etc/neutron/policy.json
+++ b/roles/neutron-common/templates/etc/neutron/policy.json
@@ -25,18 +25,18 @@
     "delete_subnet": "rule:admin_or_network_owner",
 
     "create_subnetpool": "",
-    "create_subnetpool:shared": "rule:admin_only",
-    "create_subnetpool:is_default": "rule:admin_only",
+    "create_subnetpool:shared": "rule:admin_or_cloudadmin",
+    "create_subnetpool:is_default": "rule:admin_or_cloudadmin",
     "get_subnetpool": "rule:admin_or_owner or rule:shared_subnetpools",
     "update_subnetpool": "rule:admin_or_owner",
-    "update_subnetpool:is_default": "rule:admin_only",
+    "update_subnetpool:is_default": "rule:admin_or_owner",
     "delete_subnetpool": "rule:admin_or_owner",
 
     "create_address_scope": "",
-    "create_address_scope:shared": "rule:admin_only",
+    "create_address_scope:shared": "rule:admin_or_cloudadmin",
     "get_address_scope": "rule:admin_or_owner or rule:shared_address_scopes",
     "update_address_scope": "rule:admin_or_owner",
-    "update_address_scope:shared": "rule:admin_only",
+    "update_address_scope:shared": "rule:admin_or_owner",
     "delete_address_scope": "rule:admin_or_owner",
 
     "create_network": "",


### PR DESCRIPTION
This is the first step in granting cloud_admin appropriate role permissions (another update is planned). In neutron, cloud_admin should be able to perform many of the actions admin can, but should not be able to update or delete admin objects.