### PR TITLE
Do not print cloud credentials to stdout

### DIFF
--- a/test/common
+++ b/test/common
@@ -1,7 +1,10 @@
-set -xe
-
+set -e
+set -x
 export STACK_RC=${STACK_RC:-~/.stackrc}
+# Do not print credentials to log
+set +x
 [[ -f ${STACK_RC} ]] && source ${STACK_RC}
+set -x
 
 export ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 


### PR DESCRIPTION
It's not essential to print cloud credentials to stdout, so let's not
do it.