### PR TITLE
Unpin os-client-config

### DIFF
--- a/roles/common/tasks/python.yml
+++ b/roles/common/tasks/python.yml
@@ -73,7 +73,7 @@
   pip:
     name: "{{ item }}"
   with_items:
-    - os-client-config==1.18.0
+    - os-client-config
     - shade>=1.9.0
   register: result
   until: result|succeeded


### PR DESCRIPTION
There's a new python-openstackclient that wants a newer version of
os-client-config then what we've pinned.  Also, the issue that caused us
to pin it in the first place has been resolved and merged.