### PR TITLE
Remove pin on os-client-config

### DIFF
--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -13,6 +13,6 @@ client:
     - python-ironicclient
     - python-swiftclient
     - python-magnumclient
-    - python-openstackclient
+    - python-openstackclient==2.3.0
   apt_packages:
     - python-prettytable

--- a/roles/common/tasks/python.yml
+++ b/roles/common/tasks/python.yml
@@ -73,7 +73,6 @@
   pip:
     name: "{{ item }}"
   with_items:
-    - os-client-config==1.18.0
     - shade>=1.9.0
   register: result
   until: result|succeeded


### PR DESCRIPTION
The upstream bug is fixed, and shade will pull in the version it wants.

Change-Id: I8c25a890ff323a74039c546a5643e938cd660de9