### PR TITLE
Added missing keystone restart on ldap config change

### DIFF
--- a/roles/keystone/tasks/ldap.yml
+++ b/roles/keystone/tasks/ldap.yml
@@ -5,3 +5,4 @@
 - name: keystone ldap domain conf file
   template: src="etc/keystone/domains/keystone.domain.conf"
             dest="/etc/keystone/domains/keystone.{{ keystone.ldap_domain.domain }}.conf"
+  notify: restart keystone

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -128,6 +128,9 @@
   notify:
     - reload apache
 
+- include: ldap.yml
+  when: keystone.ldap_domain.enabled|default('False')|bool
+
 - meta: flush_handlers
 
 - name: start keystone
@@ -161,9 +164,6 @@
   file:
     path: /etc/cron.hourly/drop-expired-keystone-tokens
     state: absent
-
-- include: ldap.yml
-  when: keystone.ldap_domain.enabled|default('False')|bool
 
 - include: monitoring.yml
   tags:


### PR DESCRIPTION
Do not merge

Keystone does not currently pick up ldap config until it is restarted after the ursula run

I'm going to test this on pureapp Austin 2; will update when/if it works

