### PR TITLE
Support ceph jewel installation and upgrading from hammer

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -130,8 +130,8 @@ apt_repos:
     repo: https://apt-mirror.openstack.blueboxgrid.com/erlang/debian
     key_url: https://apt-mirror.openstack.blueboxgrid.com/keys/erlang.key
   ceph:
-    repo: https://apt-mirror.openstack.blueboxgrid.com/ceph/debian-
-    key_url: https://apt-mirror.openstack.blueboxgrid.com/keys/ceph.key
+    repo: https://apt-mirror.openstack.blueboxgrid.com/packagecloud.io/blueboxcloud/ceph-bbg/ubuntu
+    key_url: https://apt-mirror.openstack.blueboxgrid.com/keys/ceph_bbg.key
   collectd:
     repo: http://ppa.launchpad.net/raravena80/collectd5/ubuntu
     key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xE97C3D97792BD34E"

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -8,7 +8,7 @@ ceph:
   #  - sdd
   #bcache_ssd_device: sdg 
 
-  stable_release: hammer
+  version: 10.2.3~bbc1
 
   openstack_keys:
     - { name: client.glance, value: "mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=default'" }
@@ -56,8 +56,6 @@ ceph:
   rbd_default_features: 3
   rbd_default_map_options: rw
   rbd_default_format: 2
-  rbd_url: https://raw.githubusercontent.com/ceph/ceph/v0.94.5/src/pybind/rbd.py
-  rados_url: https://raw.githubusercontent.com/ceph/ceph/v0.94.5/src/pybind/rados.py
 
   # Monitor options
   monitor_interface: bond0
@@ -69,6 +67,7 @@ ceph:
   mon_osd_report_timeout: 300
   mon_pg_warn_max_per_osd: 0 # disable complains about low pgs numbers per osd
   mon_osd_allow_primary_affinity: "true"
+  mon_warn_on_legacy_crush_tunables: "false"
 
   # TCP options
   ms_tcp_rcvbuff: 16777216

--- a/roles/ceph-common/handlers/main.yml
+++ b/roles/ceph-common/handlers/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: restart ceph mons
   service: name=ceph-mon-all state=restarted
-  when: ceph_socket.rc == 0 and not ceph.scaleout|default('False')|bool
+  when: ceph_socket.rc == 0 and not ceph.scaleout|default('False')|bool and not upgrade_ceph|bool
 
 - name: restart ceph osds
   service: name=ceph-osd-all state=restarted
-  when: ceph_socket.rc == 0 and not ceph.scaleout|default('False')|bool
+  when: ceph_socket.rc == 0 and not ceph.scaleout|default('False')|bool and not upgrade_ceph|bool

--- a/roles/ceph-common/meta/main.yml
+++ b/roles/ceph-common/meta/main.yml
@@ -8,6 +8,6 @@ dependencies:
     logdata: "{{ ceph.logs }}"
   - role: apt-repos
     repos:
-      - repo: 'deb {{ apt_repos.ceph.repo }}{{ ceph.stable_release }}/ {{ ansible_lsb.codename }} main'
+      - repo: 'deb {{ apt_repos.ceph.repo }} {{ ansible_lsb.codename }} main'
         key_url: '{{ apt_repos.ceph.key_url }}'
     when: ceph.enabled|bool and ansible_architecture != "ppc64le"

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- include: upgrade_flags.yml
+
 - name: create ceph directory
   file:
     path: /etc/ceph
@@ -28,7 +30,7 @@
   retries: 5
 
 - name: install ceph
-  apt: pkg={{ item }}
+  apt: pkg={{ item }}={{ ceph.version }}
        state=present
   with_items: "{{ ceph.ceph_pkgs }}"
   register: result

--- a/roles/ceph-common/tasks/upgrade_flags.yml
+++ b/roles/ceph-common/tasks/upgrade_flags.yml
@@ -1,0 +1,54 @@
+---
+# we shouldn't initial flag again for the case that one node is in multi groups
+- name: initial upgrade flags
+  set_fact:
+    upgrade_ceph: false
+    upgrade_ceph2jewel: false
+  when: upgrade_ceph is undefined
+
+- name: set target version pure number
+  set_fact:
+    ceph_pure_version: '{{ ceph.version | regex_replace("^(\d+\.\d+\.?\d{0,3}).*$", "\1") }}'
+  when: ceph_pure_version is undefined
+
+- name: get installed ceph version
+  shell: ceph --version |grep -oP "\d+\.\d+\.?\d{0,3}"
+  changed_when: false
+  failed_when: false
+  register: result_ceph_installed_version
+
+# result_ceph_running_version is only used for ceph monitors and osds
+- name: get running ceph version
+  shell: ceph daemon `ls /var/run/ceph/*.asok | head -n1` version |grep -oP "\d+\.\d+\.?\d{0,3}"
+  changed_when: false
+  failed_when: false
+  register: result_ceph_running_version
+  when: result_ceph_installed_version.rc == 0 and ( 'ceph_monitors' in group_names or 'ceph_osds' in group_names )
+
+# set flag=true if ceph is installed but not running
+- name: set upgrade flag true
+  set_fact:
+    upgrade_ceph: true
+    upgrade_ceph2jewel: true
+  when: result_ceph_running_version is defined and result_ceph_running_version.rc != 0
+
+- name: set upgrade flags if hammer running
+  set_fact:
+    upgrade_ceph: true
+    upgrade_ceph2jewel: true
+  when: result_ceph_running_version is defined and result_ceph_running_version.rc == 0 and
+        result_ceph_running_version.stdout < '10'
+
+- name: set upgrade_ceph=true
+  set_fact:
+    upgrade_ceph: true
+  when: result_ceph_running_version is defined and result_ceph_running_version.rc == 0 and
+        result_ceph_running_version.stdout < ceph_pure_version
+
+# set upgrade flag for controller and cinder_volume
+- name: set upgrade flag for controller and cinder_volume
+  set_fact:
+    upgrade_ceph: true
+  register: result_upgrade_ceph_controller
+  when: ('controller' in group_names or 'cinder_volume' in group_names) and
+        (result_ceph_installed_version.rc == 0 and result_ceph_installed_version.stdout < ceph_pure_version)

--- a/roles/ceph-common/templates/etc/ceph/ceph.conf
+++ b/roles/ceph-common/templates/etc/ceph/ceph.conf
@@ -78,6 +78,7 @@
   mon osd report timeout = {{ ceph.mon_osd_report_timeout }}
   mon pg warn max per osd = {{ ceph.mon_pg_warn_max_per_osd }}
   mon osd allow primary affinity = {{ ceph.mon_osd_allow_primary_affinity }}
+  mon warn on legacy crush tunables = {{ ceph.mon_warn_on_legacy_crush_tunables }}
 
 {% if ceph.enable_debug_mon %}
   debug mon = {{ ceph.debug_mon_level }}

--- a/roles/ceph-monitor/tasks/main.yml
+++ b/roles/ceph-monitor/tasks/main.yml
@@ -20,18 +20,18 @@
 - name: set initial monitor key permissions
   file: path=/var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
         mode=0600
-        owner=root
-        group=root
+        owner=ceph
+        group=ceph
 
 - name: create monitor directory
   file: path=/var/lib/ceph/mon/ceph-{{ ansible_hostname }}
         state=directory
-        owner=root
-        group=root
+        owner=ceph
+        group=ceph
         mode=0755
 
 - name: ceph monitor mkfs
-  command: ceph-mon --mkfs -i {{ ansible_hostname }}
+  command: ceph-mon --setuser ceph --setgroup ceph --mkfs -i {{ ansible_hostname }}
            --fsid {{ fsid_file.content | b64decode }}
            --keyring /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
            creates=/var/lib/ceph/mon/ceph-{{ ansible_hostname }}/keyring
@@ -53,8 +53,8 @@
 - name: activate monitor with upstart
   file: path=/var/lib/ceph/mon/ceph-{{ ansible_hostname }}/{{ item }}
         state=touch
-        owner=root
-        group=root
+        owner=ceph
+        group=ceph
         mode=0600
   with_items:
     - done

--- a/roles/ceph-osd/tasks/bcache.yml
+++ b/roles/ceph-osd/tasks/bcache.yml
@@ -82,3 +82,4 @@
   ceph_bcache:
     disks: "{{ ceph.disks }}"
     ssd_device: "{{ ceph.bcache_ssd_device }}"
+    journal_guid: 45b0969e-9b03-4f30-b4c6-b4b80ceff106

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -48,11 +48,6 @@
 - include: bcache.yml
   when: ceph.bcache_ssd_device is defined
 
-- name: start and add the osd service(s) to the init sequence
-  service: name=ceph
-           state=started
-           enabled=yes
-
 - name: delete default 'rbd' pool
   command: ceph osd pool delete rbd rbd --yes-i-really-really-mean-it
   register: poolout

--- a/roles/ceph-update/defaults/main.yml
+++ b/roles/ceph-update/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+ceph:
+  # set this variable according to ceph udev rules
+  # ceph community will not change it easily, probably never change it.
+  journal_guid: 45b0969e-9b03-4f30-b4c6-b4b80ceff106

--- a/roles/ceph-update/tasks/ceph_owner.yml
+++ b/roles/ceph-update/tasks/ceph_owner.yml
@@ -1,0 +1,23 @@
+---
+- name: set journal partition guid, for bcache env
+  command: sgdisk -t {{ item }}:{{ ceph.journal_guid }} /dev/{{ ceph.bcache_ssd_device }}
+  with_sequence: start=1 end={{ ceph.disks|length }}
+  when: ceph.bcache_ssd_device is defined
+
+- name: correct journal partition owner, for bcache env
+  file: path=/dev/{{ ceph.bcache_ssd_device }}{{ item }} owner=ceph group=ceph
+  with_sequence: start=1 end={{ ceph.disks|length }}
+  when: ceph.bcache_ssd_device is defined
+
+- name: set journal partition guid, for full ssd env
+  command: sgdisk -t 2:{{ ceph.journal_guid }} /dev/{{ item }}
+  with_items: "{{ ceph.disks }}"
+  when: ceph.bcache_ssd_device is not defined
+
+- name: correct journal partition owner, for full ssd env
+  file: path=/dev/{{ item }}2 owner=ceph group=ceph
+  with_items: "{{ ceph.disks }}"
+  when: ceph.bcache_ssd_device is not defined
+
+- name: correct ceph dir owner
+  file: path=/var/lib/ceph state=directory owner=ceph group=ceph recurse=yes

--- a/roles/ceph-update/tasks/main.yml
+++ b/roles/ceph-update/tasks/main.yml
@@ -8,41 +8,77 @@
   delay: 60
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
 
-- name: restart ceph mons
-  service: name=ceph-mon-all state=restarted
+- name: stop ceph mon
+  service: name=ceph-mon-all state=stopped
+  when: "'ceph_monitors' in group_names"
+
+- name: correct ceph dir owner
+  file: path=/var/lib/ceph state=directory owner=ceph group=ceph recurse=yes
+  when: upgrade_ceph2jewel|bool and "ceph_monitors" in group_names
+
+- name: start ceph mons
+  service: name=ceph-mon-all state=started enabled=yes
+  when: "'ceph_monitors' in group_names"
 
 # Setting noout to prevent cluster from rebalancing after service restart
 - name: set osd noout
   command: ceph osd set noout
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  when: inventory_hostname == groups['ceph_osds'][0]
+  when: "'ceph_osds' in group_names"
 
-# Setting osd values for first osd to reduce performance degradation of client I/O
+# Setting osd values to reduce performance degradation of client I/O
 - name: set osd noscrub
   command: ceph osd set noscrub
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  when: inventory_hostname == groups['ceph_osds'][0]
+  when: "'ceph_osds' in group_names"
 
 - name: set osd nodeep scrub
   command: ceph osd set nodeep-scrub
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  when: inventory_hostname == groups['ceph_osds'][0]
+  when: "'ceph_osds' in group_names"
 
-- name: restart ceph osds
-  service: name=ceph-osd-all state=restarted
+- name: stop ceph osd
+  service: name=ceph-osd-all state=stopped
+  when: "'ceph_osds' in group_names"
 
-# Unset the osd values only after ceph on last osd node has restarted
+- include: ceph_owner.yml
+  when: upgrade_ceph2jewel|bool and 'ceph_osds' in group_names
+
+- name: start ceph osds
+  service: name=ceph-osd-all state=started enabled=yes
+  when: "'ceph_osds' in group_names"
+
+# make sure ceph osd services are up before unset noout
+- name: make sure ceph osds are up
+  shell: test `ls /var/run/ceph/*.asok |wc -l` -eq {{ ceph.disks|length }}
+  register: result
+  until: result.rc == 0
+  retries: 5
+  delay: 5
+  when: "'ceph_osds' in group_names"
+
+# Unset the osd values to make heath check pass
 - name: unset osd noout
   command: ceph osd unset noout
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  when: inventory_hostname == groups['ceph_osds'][-1]
+  when: "'ceph_osds' in group_names"
 
 - name: unset osd noscrub
   command: ceph osd unset noscrub
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  when: inventory_hostname == groups['ceph_osds'][-1]
+  when: "'ceph_osds' in group_names"
 
 - name: unset osd nodeep scrub
   command: ceph osd unset nodeep-scrub
+  delegate_to: "{{ groups['ceph_monitors'][0] }}"
+  when: "'ceph_osds' in group_names"
+
+# make sure ceph health ok after update
+- name: wait for ceph cluster to be in health ok state
+  shell: ceph health | egrep -q "HEALTH_OK"
+  register: result
+  until: result.rc == 0
+  retries: 30
+  delay: 60
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
   when: inventory_hostname == groups['ceph_osds'][-1]

--- a/roles/cinder-common/tasks/ceph_integration.yml
+++ b/roles/cinder-common/tasks/ceph_integration.yml
@@ -1,21 +1,25 @@
 ---
-- name: fetch rados.py
-  get_url:
-    url: "{{ ceph.rados_url }}"
-    dest: /opt/openstack/current/cinder/lib/python2.7/site-packages/rados.py
+- name: import rados and rbd modules into cinder
+  file:
+    src: /usr/lib/python2.7/dist-packages/{{ item }}
+    dest: /opt/openstack/current/cinder/lib/python2.7/site-packages/{{ item }}
+    state: link
     owner: root
     group: root
     mode: 0644
-    timeout: 30
+  with_items:
+    - rados.so
+    - rbd.so
 
-- name: fetch rbd.py
-  get_url:
-    url: "{{ ceph.rbd_url }}"
-    dest: /opt/openstack/current/cinder/lib/python2.7/site-packages/rbd.py
-    owner: root
-    group: root
-    mode: 0644
-    timeout: 30
+- name: remove modules those were used for Hammer
+  file:
+    path: /opt/openstack/current/cinder/lib/python2.7/site-packages/{{ item }}
+    state: absent
+  with_items:
+    - rados.py
+    - rados.pyc
+    - rbd.py
+    - rbd.pyc
 
 - name: fetch cinder keyring
   slurp: path=/etc/ceph/ceph.client.cinder.keyring

--- a/roles/cinder-control/tasks/main.yml
+++ b/roles/cinder-control/tasks/main.yml
@@ -30,8 +30,8 @@
     msg: "Triggering service restart for upgrade"
   changed_when: True
   notify: restart cinder services
-  when: code_has_changed | default('False') | bool and
-        upgrade | default('False') | bool
+  when: (code_has_changed | default('False') | bool and upgrade | default('False') | bool) or
+        (ceph.enabled|default('False')|bool and upgrade_ceph | bool)
 
 - meta: flush_handlers
 

--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -64,8 +64,8 @@
   notify:
     - restart cinder services
     - restart cinder backup service
-  when: code_has_changed | default('False') | bool and
-        upgrade | default('False') | bool
+  when: (code_has_changed | default('False') | bool and upgrade | default('False') | bool) or
+        (ceph.enabled|default('False')|bool and upgrade_ceph|bool)
 
 - meta: flush_handlers
 

--- a/roles/glance/tasks/ceph_integration.yml
+++ b/roles/glance/tasks/ceph_integration.yml
@@ -1,21 +1,25 @@
 ---
-- name: fetch rados.py
-  get_url:
-    url: "{{ ceph.rados_url }}"
-    dest: /opt/openstack/current/glance/lib/python2.7/site-packages/rados.py
+- name: import rados module into glance
+  file:
+    src: /usr/lib/python2.7/dist-packages/{{ item }}
+    dest: /opt/openstack/current/glance/lib/python2.7/site-packages/{{ item }}
+    state: link
     owner: root
     group: root
     mode: 0644
-    timeout: 30
+  with_items:
+    - rados.so
+    - rbd.so
 
-- name: fetch rbd.py
-  get_url:
-    url: "{{ ceph.rbd_url }}"
-    dest: /opt/openstack/current/glance/lib/python2.7/site-packages/rbd.py
-    owner: root
-    group: root
-    mode: 0644
-    timeout: 30
+- name: remove modules those were used for Hammer
+  file:
+    path: /opt/openstack/current/glance/lib/python2.7/site-packages/{{ item }}
+    state: absent
+  with_items:
+    - rados.py
+    - rados.pyc
+    - rbd.py
+    - rbd.pyc
 
 - name: fetch glance keyring
   slurp: path=/etc/ceph/ceph.client.glance.keyring

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -91,8 +91,8 @@
     msg: "Triggering service restart for upgrade"
   changed_when: True
   notify: restart glance services
-  when: code_has_changed | default('False') | bool and
-        upgrade | default('False') | bool
+  when: (code_has_changed | default('False') | bool and upgrade | default('False') | bool) or
+        (glance.store_ceph | default('False') | bool and upgrade_ceph | bool)
 
 - meta: flush_handlers
 

--- a/site.yml
+++ b/site.yml
@@ -410,5 +410,5 @@
   roles:
     - role: ceph-update
       tags: ['ceph', 'ceph-update']
-      when: ceph.scaleout|default('False')|bool
+      when: ceph.enabled|default('False')|bool and (ceph.scaleout|default('False')|bool or upgrade_ceph|bool)
   environment: "{{ env_vars|default({}) }}"


### PR DESCRIPTION
This PR is to support installing ceph jewel, upgrading ceph from hammer to jewel.
Differences between ceph hammer and jewel:
1. ceph jewel run daemons as ceph:ceph user group, while hammer run as root:root. So /var/lib/ceph should be accessed by ceph user in jewel.
2. python-rbd and python-rados have been refactored in jewel. rados.py and rbd.py are replaced with rados.so and rbd.so.

Ceph use a whole disk partition as a journal, but disk partitions are owned by root:disk by default.
To make journal partitions owned by ceph:ceph, we need to change partitions' GUID, so that the udev rules can change partitions' owner in every OS reboot.

After upgrade, all ceph services and cinder services should be restarted. 