### PR TITLE
update neutron.conf to use dns_domain config opt

### DIFF
--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -25,6 +25,8 @@ global_physnet_mtu = {{ neutron.global_physnet_mtu }}
 
 control_exchange = neutron
 
+dns_domain = {{ stack_env }}
+
 # Plug-ins
 {% if neutron.plugin == 'ml2' %}
 core_plugin = neutron.plugins.ml2.plugin.Ml2Plugin


### PR DESCRIPTION
This patch is based on customer request to support the new Mitaka
feature where you can specify local DNS name of a port you create
e.g. `neutron port-create ... --dns_name=instance.hostname`.

It needs the dns_domain directive to be set in neutron.conf.

I figure stack_env is as good a variable as any for the local DNS
domain.