### PR TITLE
Use apache's built in signals for restarts/reloads

### DIFF
--- a/roles/apache/handlers/main.yml
+++ b/roles/apache/handlers/main.yml
@@ -1,9 +1,11 @@
 ---
 - name: restart apache
-  service: name=apache2 state=restarted must_exist=false
+  command: apachectl restart
+  register: restart_apache_out
 
 - name: reload apache
-  service: name=apache2 state=reloaded must_exist=false
+  command: apachectl graceful
+  when: restart_apache_out is not defined
 
 - name: stop apache
   service: name=apache2 state=stopped

--- a/roles/horizon/handlers/main.yml
+++ b/roles/horizon/handlers/main.yml
@@ -1,11 +1,4 @@
 ---
-# not really a "horizon service" but horizon is the outlier
-- name: restart horizon services
-  service: name=apache2 state=restarted must_exist=false
-
-- name: restart apache
-  service: name=apache2 state=restarted must_exist=false
-
 - name: compress horizon assets
   command: tools/with_venv.sh ./manage.py compress
   args:

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -22,10 +22,6 @@
 - name: create horizon config directory
   file: dest=/etc/openstack-dashboard state=directory
 
-
-- name: create horizon config directory
-  file: dest=/etc/openstack-dashboard state=directory
-
 - name: openstack dashboard config (12.04)
   template: src=etc/apache2/sites-available/openstack_dashboard.conf
             dest=/etc/apache2/sites-available/openstack_dashboard


### PR DESCRIPTION
The init script is heavy handed, and on restart often fails. This will
ensure that we only do a heavy restart if we absolutely must.

Also removes a duplicate task, and removes the horizon overload of
handlers defined in the apache role.

Change-Id: I032eb24782827f6faa61e8b3aeb600a81d7ba3ce
(cherry picked from commit bd3038bdfd433984dfd130e42e3854e6cb23f234)
