### PR TITLE
Extend timeout

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,6 +4,7 @@ hash_behaviour = merge
 nocows = 1
 nocolor = 0
 transport = sshbb
+timeout = 60
 host_key_checking = False
 vars_plugins = plugins/vars
 connection_plugins = plugins/connection


### PR DESCRIPTION
We're having SSH stability issues, so I wante to see what changing
the transport to standard 'ssh' would do (or how it fails).