### PR TITLE
Use a generic path to ubuntu mirror

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -94,7 +94,7 @@ openstack:
     - https://rubygems.org
   git_mirror:  https://github.com/openstack
   git_update: yes
-  ubuntu_mirror: https://apt-mirror.openstack.blueboxgrid.com/archive.ubuntu.com/ubuntu
+  ubuntu_mirror: https://apt-mirror.openstack.blueboxgrid.com/trusty/ubuntu
 
 apt_repos:
   docker:

--- a/envs/example/mirrors/group_vars/all.yml
+++ b/envs/example/mirrors/group_vars/all.yml
@@ -54,7 +54,7 @@ openstack:
   easy_install_mirror: https://pypi-mirror.openstack.blueboxgrid.com/root/pypi/+simple
   gem_sources:
     - https://gem-mirror.openstack.blueboxgrid.com
-  ubuntu_mirror: https://apt-mirror.openstack.blueboxgrid.com/archive.ubuntu.com/ubuntu
+  ubuntu_mirror: https://apt-mirror.openstack.blueboxgrid.com/trusty/ubuntu
 
 logging:
   download:


### PR DESCRIPTION
The specific path was tied to a specific upstream mirror, which we had
to stop using. The "trusty" url is a generic path that points to
whatever we're currently using for an upstream mirror.

Change-Id: I905cc4eb562113493beea9492456c58250e296cb