### PR TITLE
Add ceph usage metrics to ceph-monitor

### DIFF
--- a/roles/ceph-monitor/tasks/monitoring.yml
+++ b/roles/ceph-monitor/tasks/monitoring.yml
@@ -15,3 +15,9 @@
                        args='-S ceph --scheme {{ monitoring.graphite.host_prefix }}'
                        use_sudo=true
   notify: restart sensu-client
+
+- name: ceph usage metrics
+  sensu_metrics_check:
+    name: ceph-usage-metrics
+    plugin: metrics-ceph.py
+  notify: restart sensu-client


### PR DESCRIPTION
These nodes should have enough to query the ceph system to get the
metrics we want displayed.

Change-Id: I1d46b84f431185cf8c0ca16a37837d226ad00ff0