### PR TITLE
optional parameters for oauth configuration for federation

### DIFF
--- a/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
+++ b/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
@@ -186,7 +186,7 @@ WEBSSO_CHOICES = (
     ("credentials", _("{{ horizon.websso.choices.credentials }}")),
     {% if keystone.federation.sp.oidc.enabled|bool %}
     {% for sp in keystone.federation.sp.oidc.providers_info %}
-    ("{{ sp.name }}-OIDC-IDP", _("{{ sp.horizon_name }}")),
+    ("{{ sp.idp_name }}-OIDC-IDP", _("{{ sp.horizon_name }}")),
     {% endfor %}
     {% endif %}
     {% if keystone.federation.sp.saml.horizon_enabled|bool %}
@@ -201,7 +201,7 @@ WEBSSO_CHOICES = (
 WEBSSO_IDP_MAPPING = {
       {% if keystone.federation.sp.oidc.enabled|bool %}
       {% for sp in keystone.federation.sp.oidc.providers_info -%}
-      "{{ sp.name }}-OIDC-IDP": ("{{ sp.name }}", "{{ sp.protocol_name}}"),
+      "{{ sp.idp_name }}-OIDC-IDP": ("{{ sp.idp_name }}", "{{ sp.protocol_name}}"),
       {% endfor -%}
       {% endif %}
       {% if keystone.federation.sp.saml.enabled|bool %}

--- a/roles/keystone/templates/etc/apache2/sites-available/keystone.conf
+++ b/roles/keystone/templates/etc/apache2/sites-available/keystone.conf
@@ -52,6 +52,30 @@ Listen {{ endpoints.keystone.port.backend_api }}
     {% if keystone.federation.sp.oidc.oauth.introspection_endpoint_method is defined -%}
     OIDCOAuthIntrospectionEndpointMethod {{ keystone.federation.sp.oidc.oauth.introspection_endpoint_method }}
     {% endif -%}
+    {% if keystone.federation.sp.oidc.oauth.introspection_endpoint_params is defined -%}
+    OIDCOAuthIntrospectionEndpointParams {{ keystone.federation.sp.oidc.oauth.introspection_endpoint_params  }}
+    {% endif -%}
+    {% if keystone.federation.sp.oidc.oauth.introspection_endpoint_auth is defined -%}
+    OIDCOAuthIntrospectionEndpointAuth {{ keystone.federation.sp.oidc.oauth.introspection_endpoint_auth  }}
+    {% endif -%}
+    {% if keystone.federation.sp.oidc.oauth.introspection_endpoint_cert is defined -%}
+    OIDCOAuthIntrospectionEndpointCert {{ keystone.federation.sp.oidc.oauth.introspection_endpoint_cert  }}
+    {% endif -%}
+    {% if keystone.federation.sp.oidc.oauth.introspection_endpoint_key is defined -%}
+    OIDCOAuthIntrospectionEndpointKey {{ keystone.federation.sp.oidc.oauth.introspection_endpoint_key  }}
+    {% endif -%}
+    {% if keystone.federation.sp.oidc.oauth.token_expiry_claim is defined -%}
+    OIDCOAuthTokenExpiryClaim {{ keystone.federation.sp.oidc.oauth.token_expiry_claim  }}
+    {% endif -%}
+    {% if keystone.federation.sp.oidc.oauth.token_introspection_interval is defined -%}
+    OIDCOAuthTokenIntrospectionInterval {{ keystone.federation.sp.oidc.oauth.token_introspection_interval  }}
+    {% endif -%}
+    {% if keystone.federation.sp.oidc.oauth.verify_shared_keys is defined -%}
+    OIDCOAuthVerifySharedKeys {{ keystone.federation.sp.oidc.oauth.verify_shared_keys  }}
+    {% endif -%}
+    {% if keystone.federation.sp.oidc.oauth.verify_cert_files is defined -%}
+    OIDCOAuthVerifyCertFiles {{ keystone.federation.sp.oidc.oauth.verify_cert_files  }}
+    {% endif -%}
     {% if not keystone.federation.sp.oidc.oauth.ssl_validate_server|bool -%}
     OIDCOAuthSSLValidateServer Off
     {% endif -%}
@@ -66,7 +90,7 @@ Listen {{ endpoints.keystone.port.backend_api }}
 
     {% for sp in keystone.federation.sp.oidc.providers_info -%}
     {%- set target_link = 'https://'+fqdn+':5000/v3/auth/OS-FEDERATION/websso/oidc?origin=http://'+fqdn+'/auth/websso/' -%}
-    <Location ~ "/v3/auth/OS-FEDERATION/identity_providers/{{ sp.name }}/protocols/{{ sp.protocol_name }}/websso">
+    <Location ~ "/v3/auth/OS-FEDERATION/identity_providers/{{ sp.idp_name }}/protocols/{{ sp.protocol_name }}/websso">
       OIDCDiscoverURL {{ keystone.federation.sp.oidc.redirect_uri }}?iss={{ sp.issuer }}&target_link_uri={{ target_link }}
       AuthType openid-connect
       Require valid-user
@@ -75,7 +99,7 @@ Listen {{ endpoints.keystone.port.backend_api }}
 
     {% endfor %}
 
-    <LocationMatch /v3/OS-FEDERATION/identity_providers/.*?/protocols/oidc/auth>
+    <LocationMatch /v3/OS-FEDERATION/identity_providers/{{ keystone.federation.sp.oidc.oauth.idp_name}}/protocols/{{ keystone.federation.sp.oidc.oauth.protocol_name }}/auth>
       AuthType oauth20
       Require valid-user
       LogLevel debug


### PR DESCRIPTION
Oauth has many optional values that can be supported in apache/keystone.conf. 