### PR TITLE
Update the version of qemu-kvm

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -26,7 +26,7 @@ nova:
   scheduler_host_subset_size: 1
   libvirt_bin_version: 1.3.1-1ubuntu10.1~cloud0
   python_libvirt_version: 1.3.1-1ubuntu1~cloud0
-  qemu_kvm_version: 1:2.5+dfsg-5ubuntu10.2~cloud0
+  qemu_kvm_version: 1:2.5+dfsg-5ubuntu10.4~cloud0
   librdb1_version: 10.2.2-0ubuntu0.16.04.2~cloud0
   glance_endpoint: http://{{ endpoints.main }}:9393
   reserved_host_disk_mb: 51200


### PR DESCRIPTION
This got bumped in cloud_archive for
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5403 but this
doesn't seem to impact us.

Change-Id: I8b8dc4d40957adf25868a7e18ac9a7cc789fafbc