### PR TITLE
Narrow rabbit process check to rabbitmq-server

### DIFF
--- a/roles/rabbitmq/tasks/monitoring.yml
+++ b/roles/rabbitmq/tasks/monitoring.yml
@@ -1,6 +1,13 @@
 ---
-- name: rabbit process check
-  sensu_process_check: service=rabbitmq
+- name: remove overly greedy rabbit process check
+  sensu_process_check:
+    service: rabbitmq
+    state: absent
+  notify: restart sensu-client
+
+- name: rabbit server process check
+  sensu_process_check:
+    service: rabbitmq-server
   notify: restart sensu-client
 
 - name: rabbit cluster check


### PR DESCRIPTION
The existing check, while it would ignore its own process, was finding
many other processes with "rabbitmq" in the name, like other sensu
checks. This was causing the process count to baloon with false
positives. Narrowing down the process search to "rabbitmq-server"
appears to correctly select just the server processes and avoid the
other sensu processes.

Fixes #2200

Change-Id: I0d2bcdd5a9af7b0fb7dd3ec2569d910d89fcd012