### PR TITLE
Make snapshots live again

### DIFF
--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -84,9 +84,10 @@ reserved_host_disk_mb = {{ nova.reserved_host_disk_mb }}
 compute_driver = {{ nova.compute_driver }}
 resume_guests_state_on_host_boot = True
 
-disable_libvirt_livesnapshot = False
-
 preallocate_images = {{ nova.preallocate_images }}
+
+[workarounds]
+disable_libvirt_livesnapshot = False
 
 [api_database]
 connection = mysql+pymysql://nova_api:{{ secrets.db_password }}@{{ endpoints.db }}/nova_api?charset=utf8


### PR DESCRIPTION
The config path for this changed in one of the last releases and our
setting was being ignored for the upstream default, which disabled live
snapshots. This will make live snapshots happen again.

Change-Id: I973956b77f8b2030f3f9727445cd6def83eb8f91