### PR TITLE
Support a repo based install for oidc

### DIFF
--- a/roles/apt-repos/defaults/main.yml
+++ b/roles/apt-repos/defaults/main.yml
@@ -11,6 +11,10 @@ apt_repos:
   blueboxcloud_giftwrap:
     repo: 'https://packagecloud.io/blueboxcloud/giftwrap/ubuntu/'
     key_url: 'https://packagecloud.io/gpg.key'
+  # bluebox_misc is a placeholder URL. It does not have anything useful
+  blueboxcloud_misc:
+    repo: 'https://packagecloud.io/blueboxcloud/giftwrap/ubuntu/'
+    key_url: 'https://packagecloud.io/gpg.key'
   hwraid:
     repo: 'http://hwraid.le-vert.net/ubuntu'
     key_url: 'http://hwraid.le-vert.net/debian/hwraid.le-vert.net.gpg.key'

--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -84,7 +84,8 @@ keystone:
         enabled: False
         remote_id_attribute: 'HTTP_OIDC_CLAIM_ISS'
         download:
-          url: https://file-mirror.openstack.blueboxgrid.com/misc/libapache2-mod-auth-openidc_1.8.3-1_amd64.deb
+          method: file
+          url: https://github.com/pingidentity/mod_auth_openidc/releases/download/v1.8.3/libapache2-mod-auth-openidc_1.8.3-1_amd64.deb
           checksum: sha1:c89585e97ffd6671983b4b62318ed0e7ec7a7b7c
         module_name: libapache2-mod-auth-openidc_1.8.3-1_amd64.deb
         scope: 'openid'

--- a/roles/keystone/meta/main.yml
+++ b/roles/keystone/meta/main.yml
@@ -26,3 +26,14 @@ dependencies:
   - role: openstack-database
     database_name: keystone
   - role: apache
+  - role: apt-repos
+    repos:
+      - repo: 'deb apt_repos.blueboxcloud_misc.repo }} {{ ansible_distribution_release }} main'
+      - key_url: '{{ apt_repos.blueboxcloud_misc.key_url }}'
+    when:
+      - keystone.oidc is defined
+      - keystone.oidc.enabled | default(False)
+      - keystone.oidc.download is defined
+      - keystone.oidc.download.method | default('file') == 'repo'
+    # The default value for this repo does not have the required package,
+    # you'll need to define a value with an appropriate mirror.

--- a/roles/keystone/tasks/openidc.yml
+++ b/roles/keystone/tasks/openidc.yml
@@ -9,19 +9,30 @@
   until: result|succeeded
   retries: 5
 
-- name: download mod_auth_openidc
-  get_url:
-    url: "{{ keystone.federation.sp.oidc.download.url }}"
-    dest: /tmp/{{ keystone.federation.sp.oidc.module_name }}
-    checksum: "{{ keystone.federation.sp.oidc.download.checksum }}"
+- block:
+  - name: download mod_auth_openidc
+    get_url:
+      url: "{{ keystone.federation.sp.oidc.download.url }}"
+      dest: /tmp/{{ keystone.federation.sp.oidc.module_name }}
+      checksum: "{{ keystone.federation.sp.oidc.download.checksum }}"
 
-- name: install mod_auth_openidc
-  apt: deb=/tmp/{{ keystone.federation.sp.oidc.module_name }}
-       install_recommends=yes
-  notify: reload apache
+  - name: install mod_auth_openidc
+    apt: deb=/tmp/{{ keystone.federation.sp.oidc.module_name }}
+         install_recommends=yes
+    notify: reload apache
+    register: result
+    until: result|succeeded
+    retries: 5
+  - when: keystone.oidc.download.method == 'file'
+
+- name: install oidc plugin via repo
+  apt:
+    name: libapache2-mod-auth-openidc
   register: result
   until: result|succeeded
   retries: 5
+  when: keystone.oidc.download.method == 'repo'
+  notify: reload apache
 
 - name: enable apache mod auth_openidc
   apache2_module: name=auth_openidc


### PR DESCRIPTION
Blue Box is no longer going to file mirror the oidc packages, therefor
we need to support a repo method where the package has been introduced
into an apt repo. There is no public repo for this at this time,
therefor the file method remains the default, albiet back to github for
the file URL. A site with a proper repo can change the method and
override the repository values to get the package from a repo.

Change-Id: I2f09444abbe005f7e7e235515eb134078355e8d9
