### PR TITLE
fix ceph upgrade_flag.yml condition check

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # run once for each host
 - include: upgrade_flags.yml
-  when: upgrade_ceph is undefined
+  when: ceph_upgrade_flag_done is undefined
 
 - name: create ceph directory
   file:

--- a/roles/ceph-common/tasks/upgrade_flags.yml
+++ b/roles/ceph-common/tasks/upgrade_flags.yml
@@ -50,3 +50,7 @@
   register: result_upgrade_ceph_controller
   when: ('controller' in group_names or 'cinder_volume' in group_names) and
         (result_ceph_installed_version.rc == 0 and result_ceph_installed_version.stdout < ceph_pure_version)
+
+- name: set flag so that this yml will not exected on the same host
+  set_fact:
+    ceph_upgrade_flag_done: true


### PR DESCRIPTION
```
- include: upgrade_flags.yml
  when: ceph_upgrade_flag_done is undefined
```
The condition will be applied to every task in upgrade_flags.yml,
instead of applying to the single `include upgrade_flags.yml`.

So flag should be set `ceph_upgrade_flag_done` at the end of upgrade_flags.yml,
instead of using an existing variable as flag.
