### PR TITLE
Do not log repo urls

### DIFF
--- a/roles/apt-repos/tasks/main.yml
+++ b/roles/apt-repos/tasks/main.yml
@@ -3,17 +3,24 @@
   apt_key:
     url: "{{ item.key_url }}"
     validate_certs: "{{ item.validate_certs|default(omit) }}"
+  no_log: true
   with_items: "{{ repos }}"
-  when: repos is defined and item.key_url is defined
+  when:
+    - repos is defined
+    - item.key_url is defined
   register: result
   until: result|succeeded
   retries: 5
 
 # things like keyrings may come as packages vs. keys
 - name: add any dependent repository key packages
-  apt: pkg="{{ item.key_package }}"
+  apt:
+    pkg: "{{ item.key_package }}"
+  no_log: true
   with_items: "{{ repos }}"
-  when: repos is defined and item.key_package is defined
+  when:
+    - repos is defined
+    - item.key_package is defined
   register: result
   until: result|succeeded
   retries: 5
@@ -23,6 +30,7 @@
     repo: "{{ item.repo }}"
     update_cache: yes
     validate_certs: "{{ item.validate_certs|default(omit) }}"
+  no_log: true
   with_items: "{{ repos }}"
   when: repos is defined
   register: result


### PR DESCRIPTION
Some repo urls may have passwords in them, so we do not want to log
those anywhere.

This also cleans up some of the task formatting for readability.

Change-Id: I1b6e5018e83310f960aac942710c5edd6a40c9c9