### PR TITLE
add preflight check

### DIFF
--- a/roles/preflight-checks/tasks/ceph.yml
+++ b/roles/preflight-checks/tasks/ceph.yml
@@ -1,0 +1,28 @@
+---
+# this yml is executed with ceph installed
+- name: check ceph health
+  command: ceph -s
+  register: result_ceph_status
+  delegate_to: "{{ groups['ceph_monitors'][0] }}"
+
+- name: fail when ceph health is not ok
+  fail: msg="ceph status is not health ok"
+  when: not result_ceph_status.stdout |search("HEALTH_OK")
+
+- name: fail when there is no CEPH in cinder type list
+  shell: . /root/stackrc; cinder type-list |grep CEPH
+  delegate_to: "{{ groups['controller'][0] }}"
+
+# cinder.common_volume_name shouldn't be defined
+# in all.yml with value false
+- name: fail when cinder.common_volume_name is false
+  fail: msg="cinder.common_volume_name is not true"
+  when: not cinder.common_volume_name | default('True') | bool
+
+- name: fail when cinder configuration has rbd_volumes
+  shell: grep rbd_volumes /etc/cinder/cinder.conf
+  register: result
+  failed_when: result.rc == 0
+  delegate_to: "{{ item }}"
+  with_items:
+    - "{{ groups['controller'] }}"

--- a/roles/preflight-checks/tasks/main.yml
+++ b/roles/preflight-checks/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- block:
+  - name: check ceph installed
+    command: ceph --version
+    register: result_ceph_installed
+    failed_when: false
+    delegate_to: "{{ groups['ceph_monitors'][0] }}"
+  
+  - include: ceph.yml
+    when: result_ceph_installed.rc == 0
+
+  when: ceph.enabled | default('False') | bool
+  tags: 'precheck_ceph'
+  run_once: true
+

--- a/site.yml
+++ b/site.yml
@@ -13,6 +13,13 @@
       with_items: "{{ groups['all'] }}"
       when: inventory_hostname == play_hosts[0]
 
+- name: preflight checks
+  hosts: all:!vyatta-*
+  roles:
+    - role: preflight-checks
+      tags: ['always', 'precheck']
+  environment: "{{ env_vars|default({}) }}"  
+
 - name: common role for all hosts
   hosts: all:!vyatta-*
   any_errors_fatal: true


### PR DESCRIPTION
We have to make sure ceph HEADLTH_OK before re-run/upgrade,
this patch is to add preflight check for ceph.
For developers, they can set skip_prechecks_all/skip_prechecks_ceph to skip this preflight check for debug stuff.