### PR TITLE
set ceph.journal_guid for ceph-update role

### DIFF
--- a/roles/ceph-update/defaults/main.yml
+++ b/roles/ceph-update/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+ceph:
+  # set this variable according to ceph udev rules
+  journal_guid: 45b0969e-9b03-4f30-b4c6-b4b80ceff106


### PR DESCRIPTION
There is the same variable in roles/ceph-common/defalt/main.yml
but deploy result shows that it can't be accessed in ceph-update

this patch is to add this variable for ceph-updpate