### PR TITLE
Remove a FIXME from upgrade playbook

### DIFF
--- a/upgrade.yml
+++ b/upgrade.yml
@@ -384,23 +384,6 @@
   any_errors_fatal: true
   tags: swift
 
-  pre_tasks:
-    # FIXME Added since we are changing swift init scripts in 3.0.x
-    # This will stop services started by "old" scripts. This can be removed
-    # after all systems have migrated to 3.0.x
-    - name: stop swift services started by swift-init
-      command: swift-init stop all
-      failed_when: false
-
-    # Ownership needs to be changed for future use, do this at upgrade time
-    - name: set swiftops user as owner of ring definition
-      file:
-        path: /etc/swift/ring_definition.yml
-        owner: swiftops
-        group: swiftops
-      run_once: true
-      delegate_to: "{{ groups['swiftnode_primary'][0] }}"
-
   roles:
     - role: haproxy
       haproxy_type: swift


### PR DESCRIPTION
This playbook won't be used until we move to Newton, but I wanted to
remove this FIXME now that we're past 3.0.x and on to 3.1.x. There is no
path from 2.x to 3.1.x so there is no need for this code any more.

Change-Id: Ief5d9cb27e9d59c7b62bf83170833f67aabbc061