### PR TITLE
Stop aodhi-expirer service before removing service

### DIFF
--- a/roles/aodh/tasks/main.yml
+++ b/roles/aodh/tasks/main.yml
@@ -73,6 +73,12 @@
 - name: add aodh-expirer to cron.daily
   file: src=/usr/local/bin/aodh-expirer dest=/etc/cron.daily/aodh-expirer state=link owner=root group=root mode=0755
 
+- name: stop aodh-expirer service
+  service:
+    name: aodhi-expirer
+    state: stopped
+    must_exist: false
+
 - name: uninstall aodh-expirer services
   upstart_service: name={{ item }}
                    user=aodh


### PR DESCRIPTION
Just removing the upstart service file left the service running. We want
to explicitly stop it (if it exists) and THEN remove the upstart file.

Change-Id: I54f3137d444551a742f08617102962fec816b441