### PR TITLE
add tags for upgrade_flags tasks

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -2,6 +2,7 @@
 # run once for each host
 - include: upgrade_flags.yml
   when: ceph_upgrade_flag_done is undefined
+  tags: ['openstack', 'cinder', 'control', 'data', 'cinder-data', 'glance', 'ceph-update']
 
 - name: create ceph directory
   file:


### PR DESCRIPTION
As variables set in upgrade_flags.yml are used in other tasks,
so we should make sure these variables are set in upgrade_flags.yml even
when users run deploy with tags.

=This patch is to add related tags to tasks in upgrade_flags.yml, to make sure variables are defined when users run deploy with these tags.