### PR TITLE
Upgrade percona when upgrading cloud

### DIFF
--- a/roles/percona-server/tasks/main.yml
+++ b/roles/percona-server/tasks/main.yml
@@ -72,7 +72,8 @@
     run_once: true
     delegate_to: "{{ item }}"
     with_items: "{{ play_hosts }}"
-  when: dbupgrade | default('False') | bool
+  when: (dbupgrade | default('False') | bool) or
+        (upgrade | default('False') | bool)
 
 - name: mysql log dir
   file: dest=/var/log/mysql state=directory mode=2750 owner=mysql group=adm


### PR DESCRIPTION
We want percona to be upgraded when upgrade=True is passed as well,
simplifying the command argument for operations.

Change-Id: I2601f7497dcd3b2f621c87fba66b3617ef4bdd10