### PR TITLE
Downrev qemu package version

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -26,7 +26,7 @@ nova:
   scheduler_host_subset_size: 1
   libvirt_bin_version: 1.3.1-1ubuntu10.1~cloud0
   python_libvirt_version: 1.3.1-1ubuntu1~cloud0
-  qemu_kvm_version: 1:2.5+dfsg-5ubuntu10.4~cloud0
+  qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.27
   librdb1_version: 10.2.2-0ubuntu0.16.04.2~cloud0
   glance_endpoint: http://{{ endpoints.main }}:9393
   reserved_host_disk_mb: 51200

--- a/roles/nova-data/tasks/libvirt.yml
+++ b/roles/nova-data/tasks/libvirt.yml
@@ -12,6 +12,8 @@
     - libvirt-bin={{ nova.libvirt_bin_version }}
     - python-libvirt={{ nova.python_libvirt_version }}
     - qemu-kvm={{ nova.qemu_kvm_version }}
+    - qemu-system-x86={{ nova.qemu_kvm_version }}
+    - qemu-system-common={{ nova.qemu_kvm_version }}
     - librbd1={{ nova.librdb1_version }}
     - open-iscsi
     - libvirt-dev={{ nova.libvirt_bin_version }}


### PR DESCRIPTION
The newer package version has some issues with libvirt doing any
managedsave actions (suspend). Until we sort that out, downrev qemu back
to the version we were using before.

Change-Id: I8bedadfd24b88afcaa236ea8d587af9c4c20083c