### PR TITLE
Pin neutron client to version in constraints

### DIFF
--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -6,7 +6,7 @@ client:
     - python-keystoneclient<3.0.0
     - python-glanceclient>=1.1.0
     - python-novaclient
-    - python-neutronclient
+    - python-neutronclient==4.1.1
     - python-cinderclient
     - python-heatclient
     - python-ceilometerclient


### PR DESCRIPTION
stable/mitaka is only tested to work with this version, and we've had
problems with the newer version, so pin it down.

Change-Id: I550dcb9d5c56c50d6a201116b439cf26e7872036