### PR TITLE
[WIP] Fix ansible 2.1.1+ variable plugin issue

### DIFF
--- a/plugins/vars/default_vars.py
+++ b/plugins/vars/default_vars.py
@@ -53,10 +53,13 @@ class VarsModule(object):
 
     def run(self, host, vault_password=None):
         default_vars = self._get_defaults()
-        if hasattr(host, 'get_group_vars'):
-            group_vars = host.get_group_vars()
-        else:
-            group_vars = host.get_variables()
+        # This call to the variable_manager will get the variables of
+        # a given host, with the variable precedence already sorted out.
+        # This references some "private" like objects and may need to be
+        # adjusted in the future if/when this all gets overhauled.
+        # See also https://github.com/ansible/ansible/pull/17067
+        inv_vars = self.inventory._variable_manager.get_vars(
+                                 loader=self.inventory._loader, host=host)
         if default_vars:
-            return deep_update_dict(default_vars, group_vars)
+            return deep_update_dict(default_vars, inv_vars)
         return group_vars

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ tox
 pep8
 oslo.utils
 shade>=1.7.0
-ansible==2.1.0.0
+ansible>=2.1.0.0,<3
 python-novaclient
 python-glanceclient
 python-cinderclient

--- a/roles/ironic-data/meta/main.yml
+++ b/roles/ironic-data/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - role: ironic-common
+  - role: apache


### PR DESCRIPTION
With 2.1.1.0 there was a code change that broke our default vars plugin.
Our default variables would win over inventory specific group variables.
With guidance from upstream, we're now accessing the existing variables
a different way which appears to retain our ability to not override
group specific variables, only supply defaults.

Change-Id: I11fb684785730ff275390a866315cc54e12836f8