### PR TITLE
Back down sensu to NOVA api 2

### DIFF
--- a/roles/common/templates/etc/sensu/stackrc
+++ b/roles/common/templates/etc/sensu/stackrc
@@ -12,7 +12,6 @@ export OS_VOLUME_API_VERSION=2
 # plugin code that is using the Nova CLI could break since by default the CLI
 # does version negotation and requests the latest microversion available from
 # the server based on the latest version that the client currently supports,
-# which could change request/response semantics. This is why we pin to the 2.1
-# microversion which is backward compatible with the v2.0 API (which is
-# deprecated).
-export OS_COMPUTE_API_VERSION=2.1
+# which could change request/response semantics. This is why we pin to the
+# the v2.0 API (which is deprecated) until they are brought current.
+export OS_COMPUTE_API_VERSION=2


### PR DESCRIPTION
Use of 2.1 was causing client code to try to sort out microversions and
getting an error. Backing down to 2 for now until we sort this out with
all the client code in a future release sprint.

Change-Id: I0a75d10bc241d2fbef7f319bb29223588d32282d