### PR TITLE
fix ceph metrics checks

### DIFF
--- a/roles/ceph-monitor/tasks/monitoring.yml
+++ b/roles/ceph-monitor/tasks/monitoring.yml
@@ -20,4 +20,5 @@
   sensu_metrics_check:
     name: ceph-usage-metrics
     plugin: metrics-ceph.py
+    prefix: sudo -u ceph
   notify: restart sensu-client

--- a/roles/common/templates/monitoring/sensu-sudoers
+++ b/roles/common/templates/monitoring/sensu-sudoers
@@ -23,3 +23,4 @@ sensu ALL= NOPASSWD: /etc/sensu/plugins/check-ceph.rb
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check-ceph-usage.rb
 sensu ALL= NOPASSWD: /etc/sensu/plugins/metrics-os-api.py
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check-serverspec.rb
+sensu ALL= (ceph) NOPASSWD: /etc/sensu/plugins/metrics-ceph.py


### PR DESCRIPTION
give sensu ability to sudo to ceph in order to read ceph keyring file, repairing
the metrics-ceph.py check's ability to connect to the cluster