### PR TITLE
run metrics-ceph.py by root user

### DIFF
--- a/roles/ceph-monitor/tasks/monitoring.yml
+++ b/roles/ceph-monitor/tasks/monitoring.yml
@@ -20,5 +20,5 @@
   sensu_metrics_check:
     name: ceph-usage-metrics
     plugin: metrics-ceph.py
-    prefix: sudo -u ceph
+    use_sudo: true
   notify: restart sensu-client

--- a/roles/common/templates/monitoring/sensu-sudoers
+++ b/roles/common/templates/monitoring/sensu-sudoers
@@ -23,4 +23,4 @@ sensu ALL= NOPASSWD: /etc/sensu/plugins/check-ceph.rb
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check-ceph-usage.rb
 sensu ALL= NOPASSWD: /etc/sensu/plugins/metrics-os-api.py
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check-serverspec.rb
-sensu ALL= (ceph) NOPASSWD: /etc/sensu/plugins/metrics-ceph.py
+sensu ALL= NOPASSWD: /etc/sensu/plugins/metrics-ceph.py


### PR DESCRIPTION
ceph keyring file /etc/ceph/ceph.client.admin.keyring is owned by root
user(in 3.0.1 or upgrade from 3.0.1) or ceph user in 3.1.0 new installation.

sensu check need to read this keyring file, so we need to run the check with root
permission.

This patch is to make metrics-ceph.py run with root permission.