### PR TITLE
Fix keystone auth in neutron service migration

### DIFF
--- a/roles/client/templates/usr/local/bin/migrate_neutron_services
+++ b/roles/client/templates/usr/local/bin/migrate_neutron_services
@@ -18,7 +18,7 @@ neutron_auth = v3.Password(auth_url=os.environ['OS_AUTH_URL'],
                            username=os.environ['OS_USERNAME'],
                            password=os.environ['OS_PASSWORD'],
                            project_name=os.environ['OS_PROJECT_NAME'],
-                           user_domain_id=os.environ['OS_USER_DOMAIN_NAME'],
+                           user_domain_name=os.environ['OS_USER_DOMAIN_NAME'],
                            project_domain_name=(
                               os.environ['OS_PROJECT_DOMAIN_NAME'])
                            )


### PR DESCRIPTION
A domain name does not always equal a domain ID (Default vs default).
Let the system sort it out by using the right argument.

Change-Id: I77619303efdfe54dfd2cda0624a17714c51098f3