### PR TITLE
Update cinder for Newton

### DIFF
--- a/roles/cinder-common/tasks/main.yml
+++ b/roles/cinder-common/tasks/main.yml
@@ -29,7 +29,22 @@
     group: cinder
   with_items:
     - /var/cache/cinder
-    - "{{ cinder.state_path }}/lock"
+
+- name: create shared lock path for nova and cinder
+  file:
+    dest: "{{ state_path_base }}/sharedlock"
+    state: directory
+    mode: 0770
+    owner: root
+    group: root
+
+- name: set acls on shared path
+  acl:
+    name: "{{ state_path_base }}/sharedlock"
+    entity: cinder
+    etype: user
+    permissions: rwx
+    state: present
 
 - name: cinder log dir
   file: dest=/var/log/cinder state=directory mode=2750 owner=cinder group=adm

--- a/roles/cinder-common/templates/etc/cinder/api-paste.ini
+++ b/roles/cinder-common/templates/etc/cinder/api-paste.ini
@@ -43,9 +43,6 @@ paste.filter_factory = oslo_middleware.request_id:RequestId.factory
 [filter:cors]
 paste.filter_factory = oslo_middleware.cors:filter_factory
 oslo_config_project = cinder
-latent_allow_headers = X-Auth-Token, X-Identity-Status, X-Roles, X-Service-Catalog, X-User-Id, X-Tenant-Id, X-OpenStack-Request-ID, X-Trace-Info, X-Trace-HMAC, OpenStack-Volume-microversion
-latent_expose_headers = X-Auth-Token, X-Subject-Token, X-Service-Token, X-OpenStack-Request-ID, OpenStack-Volume-microversion
-latent_allow_methods = GET, PUT, POST, DELETE, PATCH
 
 [filter:faultwrap]
 paste.filter_factory = cinder.api.middleware.fault:FaultWrapper.factory
@@ -57,7 +54,7 @@ paste.filter_factory = osprofiler.web:WsgiMiddleware.factory
 paste.filter_factory = cinder.api.middleware.auth:NoAuthMiddleware.factory
 
 [filter:sizelimit]
-paste.filter_factory = cinder.api.middleware.sizelimit:RequestBodySizeLimiter.factory
+paste.filter_factory = oslo_middleware.sizelimit:RequestBodySizeLimiter.factory
 
 [app:apiv1]
 paste.app_factory = cinder.api.v1.router:APIRouter.factory

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -100,7 +100,9 @@ nimble_subnet_label = {{ backend.nimble_subnet_label }}
 
 
 [oslo_concurrency]
-lock_path = {{ cinder.state_path }}/lock
+# If on a host that runs compute, a shared lock path is needed between
+# nova and cinder for os-brick reasons. So we always use a shared location
+lock_path = {{ state_path_base }}/sharedlock
 
 [oslo_messaging_rabbit]
 {% macro rabbitmq_hosts() -%}
@@ -138,3 +140,8 @@ admin_password = {{ secrets.service_password }}
 signing_dir = /var/cache/cinder/api
 cafile = {{ cinder.cafile }}
 memcached_servers = {{ hostvars|ursula_memcache_hosts(groups, memcached.port) }}
+
+[cors]
+allow_headers = X-Auth-Token,X-Identity-Status,X-Roles,X-Service-Catalog,X-User-Id,X-Tenant-Id,X-OpenStack-Request-ID,X-Trace-Info,X-Trace-HMAC,OpenStack-Volume-microversion
+expose_headers = X-Auth-Token,X-Subject-Token,X-Service-Token,X-OpenStack-Request-ID,OpenStack-Volume-microversion
+allow_methods = GET,PUT,POST,DELETE,PATCH

--- a/roles/cinder-common/templates/etc/cinder/policy.json
+++ b/roles/cinder-common/templates/etc/cinder/policy.json
@@ -11,6 +11,7 @@
     "volume:get": "rule:admin_or_owner",
     "volume:get_all": "rule:admin_or_owner",
     "volume:get_volume_metadata": "rule:admin_or_owner",
+    "volume:create_volume_metadata": "rule:admin_or_owner",
     "volume:delete_volume_metadata": "rule:admin_or_owner",
     "volume:update_volume_metadata": "rule:admin_or_owner",
     "volume:get_volume_admin_metadata": "rule:admin_api",
@@ -20,6 +21,9 @@
     "volume:create_snapshot": "rule:admin_or_owner",
     "volume:delete_snapshot": "rule:admin_or_owner",
     "volume:update_snapshot": "rule:admin_or_owner",
+    "volume:get_snapshot_metadata": "rule:admin_or_owner",
+    "volume:delete_snapshot_metadata": "rule:admin_or_owner",
+    "volume:update_snapshot_metadata": "rule:admin_or_owner",
     "volume:extend": "rule:admin_or_owner",
     "volume:update_readonly_flag": "rule:admin_or_owner",
     "volume:retype": "rule:admin_or_owner",
@@ -53,6 +57,9 @@
     "volume_extension:volume_admin_actions:migrate_volume": "rule:admin_api",
     "volume_extension:volume_admin_actions:migrate_volume_completion": "rule:admin_api",
 
+    "volume_extension:volume_actions:upload_public": "rule:admin_api",
+    "volume_extension:volume_actions:upload_image": "rule:admin_or_owner",
+
     "volume_extension:volume_host_attribute": "rule:admin_api",
     "volume_extension:volume_tenant_attribute": "rule:admin_or_owner",
     "volume_extension:volume_mig_status_attribute": "rule:admin_api",
@@ -62,21 +69,22 @@
 
     "volume_extension:volume_manage": "rule:admin_api",
     "volume_extension:volume_unmanage": "rule:admin_api",
+    "volume_extension:list_manageable": "rule:admin_api",
 
     "volume_extension:capabilities": "rule:admin_api",
 
     "volume:create_transfer": "rule:admin_or_owner",
     "volume:accept_transfer": "",
     "volume:delete_transfer": "rule:admin_or_owner",
+    "volume:get_transfer": "rule:admin_or_owner",
     "volume:get_all_transfers": "rule:admin_or_owner",
 
     "volume_extension:replication:promote": "rule:admin_api",
     "volume_extension:replication:reenable": "rule:admin_api",
 
-    "volume:enable_replication": "rule:admin_api",
-    "volume:disable_replication": "rule:admin_api",
-    "volume:failover_replication": "rule:admin_api",
-    "volume:list_replication_targets": "rule:admin_api",
+    "volume:failover_host": "rule:admin_api",
+    "volume:freeze_host": "rule:admin_api",
+    "volume:thaw_host": "rule:admin_api",
 
     "backup:create": "",
     "backup:delete": "rule:admin_or_owner",
@@ -85,10 +93,12 @@
     "backup:restore": "rule:admin_or_owner",
     "backup:backup-import": "rule:admin_or_cloudadmin",
     "backup:backup-export": "rule:admin_or_cloudadmin",
+    "backup:update": "rule:admin_or_owner",
 
     "snapshot_extension:snapshot_actions:update_snapshot_status": "",
     "snapshot_extension:snapshot_manage": "rule:admin_api",
     "snapshot_extension:snapshot_unmanage": "rule:admin_api",
+    "snapshot_extension:list_manageable": "rule:admin_api",
 
     "consistencygroup:create": "group:nobody",
     "consistencygroup:delete": "group:nobody",
@@ -101,5 +111,29 @@
     "consistencygroup:get_cgsnapshot": "group:nobody",
     "consistencygroup:get_all_cgsnapshots": "group:nobody",
 
-    "scheduler_extension:scheduler_stats:get_pools" : "rule:admin_api"
+    "group:group_types_manage": "rule:admin_api",
+    "group:group_types_specs": "rule:admin_api",
+    "group:access_group_types_specs": "rule:admin_api",
+    "group:group_type_access": "rule:admin_or_owner",
+
+    "group:create" : "",
+    "group:delete": "rule:admin_or_owner",
+    "group:update": "rule:admin_or_owner",
+    "group:get": "rule:admin_or_owner",
+    "group:get_all": "rule:admin_or_owner",
+
+    "group:create_group_snapshot": "",
+    "group:delete_group_snapshot": "rule:admin_or_owner",
+    "group:update_group_snapshot": "rule:admin_or_owner",
+    "group:get_group_snapshot": "rule:admin_or_owner",
+    "group:get_all_group_snapshots": "rule:admin_or_owner",
+
+    "scheduler_extension:scheduler_stats:get_pools" : "rule:admin_api",
+    "message:delete": "rule:admin_or_owner",
+    "message:get": "rule:admin_or_owner",
+    "message:get_all": "rule:admin_or_owner",
+
+    "clusters:get": "rule:admin_api",
+    "clusters:get_all": "rule:admin_api",
+    "clusters:update": "rule:admin_api"
 }

--- a/roles/nova-common/tasks/main.yml
+++ b/roles/nova-common/tasks/main.yml
@@ -21,8 +21,21 @@
 - name: create nova config dir
   file: dest=/etc/nova state=directory
 
-- name: create nova lock dir (and parents)
-  file: dest={{ nova.state_path }}/lock state=directory owner=nova
+- name: create shared lock path for nova and cinder
+  file:
+    dest: "{{ state_path_base }}/sharedlock"
+    state: directory
+    mode: 0770
+    owner: root
+    group: root
+
+- name: set acls on shared path
+  acl:
+    name: "{{ state_path_base }}/sharedlock"
+    entity: nova
+    etype: user
+    permissions: rwx
+    state: present
 
 - name: create nova cache dir
   file: dest=/var/cache/nova state=directory mode=0700 owner=nova group=nova

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -173,7 +173,9 @@ service_metadata_proxy = True
 metadata_proxy_shared_secret = {{ secrets.metadata_proxy_shared_secret }}
 
 [oslo_concurrency]
-lock_path = {{ nova.state_path }}/lock
+# If on a host that runs cinder, a shared lock path is needed between
+# nova and cinder for os-brick reasons. So we always use a shared location
+lock_path = {{ state_path_base }}/sharedlock
 
 [oslo_messaging_rabbit]
 {% macro rabbitmq_hosts() -%}


### PR DESCRIPTION
- Use a shared lock path for cinder/nova to avoid race conditions with
  os-brick usage.
- Change the sizelimit middleware
- Move cors settings out of paste and into config
- Update policy from upstream

Change-Id: I473eb25c9a9893ca119f4dd916dba3854eb39655