### PR TITLE
Update Neutron for Newton

### DIFF
--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -30,6 +30,8 @@ neutron:
   allow_overlapping_ips: False
   api_workers: 3
   metadata_workers: 3
+  ha_keepalive_threads: 10
+  overlay_ip_version: 4
   agent_down_time: 20
   report_interval: 4
   arp_responder: True

--- a/roles/neutron-common/templates/etc/neutron/api-paste.ini
+++ b/roles/neutron-common/templates/etc/neutron/api-paste.ini
@@ -2,7 +2,7 @@
 
 [composite:neutron]
 use = egg:Paste#urlmap
-/: neutronversions
+/: neutronversions_composite
 /v2.0: neutronapi_v2_0
 
 [composite:neutronapi_v2_0]
@@ -10,6 +10,11 @@ use = call:neutron.auth:pipeline_factory
 noauth = healthcheck cors request_id catch_errors http_proxy_to_wsgi extensions neutronapiapp_v2_0
 
 keystone = healthcheck cors request_id catch_errors http_proxy_to_wsgi authtoken keystonecontext {{ 'audit' if neutron.auditing.enabled|bool else '' }}  {{ 'neutron_rbac' if neutron.jellyroll|bool else '' }} extensions neutronapiapp_v2_0
+
+[composite:neutronversions_composite]
+use = call:neutron.auth:pipeline_factory
+noauth = healthcheck cors neutronversions
+keystone = healthcheck cors neutronversions
 
 {% if neutron.jellyroll|bool %}
 [filter:neutron_rbac]
@@ -25,9 +30,6 @@ paste.filter_factory = oslo_middleware:CatchErrors.factory
 [filter:cors]
 paste.filter_factory = oslo_middleware.cors:filter_factory
 oslo_config_project = neutron
-latent_allow_headers = X-Auth-Token, X-Identity-Status, X-Roles, X-Service-Catalog, X-User-Id, X-Tenant-Id, X-OpenStack-Request-ID
-latent_expose_headers = X-Auth-Token, X-Subject-Token, X-Service-Token, X-OpenStack-Request-ID
-latent_allow_methods = GET, PUT, POST, DELETE, PATCH
 
 [filter:keystonecontext]
 paste.filter_factory = neutron.auth:NeutronKeystoneContext.factory
@@ -52,6 +54,6 @@ paste.app_factory = neutron.api.versions:Versions.factory
 paste.app_factory = neutron.api.v2.router:APIRouter.factory
 
 [filter:healthcheck]
-paste.filter_factory = oslo_middleware:Healthcheck.factory
+use = egg:oslo.middleware#healthcheck
 backends = disable_by_file
 disable_by_file_path = /etc/neutron/healthcheck_disable

--- a/roles/neutron-common/templates/etc/neutron/dhcp_agent.ini
+++ b/roles/neutron-common/templates/etc/neutron/dhcp_agent.ini
@@ -15,7 +15,6 @@ interface_driver = neutron.agent.linux.interface.BridgeInterfaceDriver
 
 # DHCP driver and extra configuration
 dhcp_driver = neutron.agent.linux.dhcp.Dnsmasq
-use_namespaces = True
 
 dnsmasq_config_file = /etc/dnsmasq.conf
 dhcp_delete_namespaces = True

--- a/roles/neutron-common/templates/etc/neutron/l3_agent.ini
+++ b/roles/neutron-common/templates/etc/neutron/l3_agent.ini
@@ -19,3 +19,4 @@ router_delete_namespaces = True
 send_arp_for_ha = 3
 agent_mode = legacy
 ha_confs_path = $state_path/ha_confs
+ha_keepalived_state_change_server_threads = {{ neutron.ha_keepalive_threads }}

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -121,3 +121,8 @@ rabbit_password = {{ secrets.rabbit_password }}
 
 [oslo_middleware]
 enable_proxy_headers_parsing = True
+
+[cors]
+allow_headers = X-Auth-Token,X-Identity-Status,X-Roles,X-Service-Catalog,X-User-Id,X-Tenant-Id,X-OpenStack-Request-ID
+expose_headers = X-Auth-Token,X-Subject-Token,X-Service-Token,X-OpenStack-Request-ID
+allow_methods = GET,PUT,POST,DELETE,PATCH

--- a/roles/neutron-common/templates/etc/neutron/plugins/ml2/ml2_plugin.ini
+++ b/roles/neutron-common/templates/etc/neutron/plugins/ml2/ml2_plugin.ini
@@ -11,6 +11,8 @@
 {% set type_drivers = type_drivers + neutron.tunnel_types %}
 type_drivers = {{ type_drivers|join(',') }}
 
+overlay_ip_version = {{ neutron.overlay_ip_version }}
+
 tenant_network_types = {{ neutron.tenant_network_type }}
 
 {% set mechanism_drivers = ['linuxbridge'] %}

--- a/roles/neutron-common/templates/etc/neutron/policy.json
+++ b/roles/neutron-common/templates/etc/neutron/policy.json
@@ -20,8 +20,12 @@
     "default": "rule:admin_or_owner",
 
     "create_subnet": "rule:admin_only or rule:network_owner",
+    "create_subnet:segment_id": "rule:admin_only",
+    "create_subnet:service_types": "rule:admin_only",
     "get_subnet": "rule:admin_or_owner or rule:shared",
+    "get_subnet:segment_id": "rule:admin_only",
     "update_subnet": "rule:admin_only or rule:network_owner",
+    "update_subnet:service_types": "rule:admin_only",
     "delete_subnet": "rule:admin_only or rule:network_owner",
 
     "create_subnetpool": "",
@@ -64,6 +68,11 @@
     "update_network:provider:segmentation_id": "rule:admin_only",
     "update_network:router:external": "rule:admin_only",
     "delete_network": "rule:admin_only or rule:owner",
+
+    "create_segment": "rule:admin_only",
+    "get_segment": "rule:admin_only",
+    "update_segment": "rule:admin_only",
+    "delete_segment": "rule:admin_only",
 
     "network_device": "field:port:device_owner=~^network:",
     "create_port": "",
@@ -198,7 +207,15 @@
     "create_policy_bandwidth_limit_rule": "rule:admin_only",
     "delete_policy_bandwidth_limit_rule": "rule:admin_only",
     "update_policy_bandwidth_limit_rule": "rule:admin_only",
+    "get_policy_dscp_marking_rule": "rule:regular_user",
+    "create_policy_dscp_marking_rule": "rule:admin_only",
+    "delete_policy_dscp_marking_rule": "rule:admin_only",
+    "update_policy_dscp_marking_rule": "rule:admin_only",
     "get_rule_type": "rule:regular_user",
+    "get_policy_minimum_bandwidth_rule": "rule:regular_user",
+    "create_policy_minimum_bandwidth_rule": "rule:admin_only",
+    "delete_policy_minimum_bandwidth_rule": "rule:admin_only",
+    "update_policy_minimum_bandwidth_rule": "rule:admin_only",
 
     "restrict_wildcard": "(not field:rbac_policy:target_tenant=*) or rule:admin_only",
     "create_rbac_policy": "",
@@ -213,28 +230,17 @@
     "get_flavor_service_profile": "rule:regular_user",
     "get_auto_allocated_topology": "rule:admin_or_owner",
 
-    "get_bgp_speaker": "rule:admin_only",
-    "create_bgp_speaker": "rule:admin_only",
-    "update_bgp_speaker": "rule:admin_only",
-    "delete_bgp_speaker": "rule:admin_only",
-
-    "get_bgp_peer": "rule:admin_only",
-    "create_bgp_peer": "rule:admin_only",
-    "update_bgp_peer": "rule:admin_only",
-    "delete_bgp_peer": "rule:admin_only",
-
-    "add_bgp_peer": "rule:admin_only",
-    "remove_bgp_peer": "rule:admin_only",
+    "create_trunk": "rule:regular_user",
+    "get_trunk": "rule:admin_or_owner",
+    "delete_trunk": "rule:admin_or_owner",
+    "get_subports": "",
+    "add_subports": "rule:admin_or_owner",
+    "remove_subports": "rule:admin_or_owner",
 
     "add_gateway_network": "rule:admin_only",
     "remove_gateway_network": "rule:admin_only",
 
     "get_advertised_routes":"rule:admin_only",
-
-    "add_bgp_speaker_to_dragent": "rule:admin_only",
-    "remove_bgp_speaker_from_dragent": "rule:admin_only",
-    "list_bgp_speaker_on_dragent": "rule:admin_only",
-    "list_dragent_hosting_bgp_speaker": "rule:admin_only",
 
     "create_security_group": "",
     "delete_security_group": "",


### PR DESCRIPTION
- Add config for ha keepalived threads (set lower than default of 1/2
  cores)
- Set default ml2 overlay ip version to 4, but configurable.
- Remove use_namespaces option, which was removed in Mitaka.
- Update policy from upstream
- Update paste from upstream

Change-Id: I229485ae4d3738ce42d6395eac80369966e5817e