### PR TITLE
make chown be faster

### DIFF
--- a/playbooks/prep-ceph-chown.yml
+++ b/playbooks/prep-ceph-chown.yml
@@ -1,0 +1,18 @@
+---
+# This playbook is used to meet the ursula 3.1.0 upgrade pre-conditions for
+# ceph service. The owner of ceph data files need to be changed in this
+# upgrade, and it's time consuming to change owner of large mount of files.
+# Because large mount of random read IO requests will be issued. This playbook
+# is to pre-read these metadata, so we can change owner fast in the upgrade.
+# This playbook may take tens of minutes.
+- name: do pre-read before upgrade to 3.1 from 3.0
+  hosts: ceph_osds
+  tasks:
+  - name: pre-read metadata of files in /var/lib/ceph
+    shell: |
+      for osd_sub in $(find /var/lib/ceph/osd -maxdepth 3 -mindepth 3)
+      do
+        ls -lR $osd_sub > /dev/null &
+      done
+      wait
+  environment: "{{ env_vars|default({}) }}"

--- a/roles/ceph-update/files/ceph_owner.sh
+++ b/roles/ceph-update/files/ceph_owner.sh
@@ -1,0 +1,29 @@
+# it's faster to use uid/gid than username/groupname
+uid=$(id -u ceph)
+gid=$(id -g ceph)
+
+chown $uid:$gid /var/lib/ceph
+
+# chown for all dirs under /var/lib/ceph except /var/lib/ceph/osd
+for ceph_sub in $(find /var/lib/ceph/ -maxdepth 1 -mindepth 1 |grep -v "var/lib/ceph/osd")
+do
+	chown -R $uid:$gid $ceph_sub
+done
+
+# deal with osd dir
+chown $uid:$gid /var/lib/ceph/osd
+for osd in $(find /var/lib/ceph/osd -maxdepth 1 -mindepth 1)
+do
+	chown $uid:$gid $osd
+	chown $uid:$gid $osd/current
+	# run this in parallel, because it's time consuming
+	for pg in $(find $osd/current -maxdepth 1 -mindepth 1)
+	do
+		chown -R $uid:$gid $pg &
+	done
+	for osd_sub in $(find $osd -maxdepth 1 -mindepth 1 |grep -v "current")
+	do
+		chown -R $uid:$gid $osd_sub
+	done
+done
+wait

--- a/roles/ceph-update/tasks/ceph_owner.yml
+++ b/roles/ceph-update/tasks/ceph_owner.yml
@@ -20,4 +20,4 @@
   when: "'ceph_osds_ssd' in group_names"
 
 - name: correct ceph dir owner
-  file: path=/var/lib/ceph state=directory owner=ceph group=ceph recurse=yes
+  script: files/ceph_owner.sh


### PR DESCRIPTION
We change owner of files in /var/lib/ceph in ceph-update roles, this is very time consuming when ceph has large mount of data in it.
The bottleneck is the IO, there are so many random read requests when chown.
This patch is to add a new playbook for pre-reading the metadata of files. So that the chown will be much faster.