### PR TITLE
make admin keyring owned by ceph on cpm

### DIFF
--- a/roles/ceph-monitor/tasks/main.yml
+++ b/roles/ceph-monitor/tasks/main.yml
@@ -69,6 +69,9 @@
 - name: wait for client.admin key exists
   wait_for: path=/etc/ceph/ceph.client.admin.keyring
 
+- name: make admin keyring owned by ceph
+  file: path=/etc/ceph/ceph.client.admin.keyring owner=ceph group=ceph
+
 - name: create openstack keys
   command: ceph auth get-or-create {{ item.name }} {{ item.value }}
            -o /etc/ceph/ceph.{{ item.name }}.keyring

--- a/roles/ceph-update/tasks/main.yml
+++ b/roles/ceph-update/tasks/main.yml
@@ -8,69 +8,64 @@
   delay: 60
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
 
-- name: stop ceph mon
-  service: name=ceph-mon-all state=stopped
+# tasks of ceph monitors
+- block:
+  - name: stop ceph mon
+    service: name=ceph-mon-all state=stopped
+
+  - name: correct ceph dir owner
+    file: path=/var/lib/ceph state=directory owner=ceph group=ceph recurse=yes
+    when: upgrade_ceph2jewel|bool
+
+  - name: start ceph mons
+    service: name=ceph-mon-all state=started enabled=yes
   when: "'ceph_monitors' in group_names"
 
-- name: correct ceph dir owner
-  file: path=/var/lib/ceph state=directory owner=ceph group=ceph recurse=yes
-  when: upgrade_ceph2jewel|bool and "ceph_monitors" in group_names
+# tasks of ceph osds
+- block:
+  # Setting noout to prevent cluster from rebalancing after service restart
+  - name: set osd noout
+    command: ceph osd set noout
+    delegate_to: "{{ groups['ceph_monitors'][0] }}"
 
-- name: start ceph mons
-  service: name=ceph-mon-all state=started enabled=yes
-  when: "'ceph_monitors' in group_names"
+  # Setting osd values to reduce performance degradation of client I/O
+  - name: set osd noscrub
+    command: ceph osd set noscrub
+    delegate_to: "{{ groups['ceph_monitors'][0] }}"
 
-# Setting noout to prevent cluster from rebalancing after service restart
-- name: set osd noout
-  command: ceph osd set noout
-  delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  when: "'ceph_osds' in group_names"
+  - name: set osd nodeep scrub
+    command: ceph osd set nodeep-scrub
+    delegate_to: "{{ groups['ceph_monitors'][0] }}"
 
-# Setting osd values to reduce performance degradation of client I/O
-- name: set osd noscrub
-  command: ceph osd set noscrub
-  delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  when: "'ceph_osds' in group_names"
+  - name: stop ceph osd
+    service: name=ceph-osd-all state=stopped
 
-- name: set osd nodeep scrub
-  command: ceph osd set nodeep-scrub
-  delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  when: "'ceph_osds' in group_names"
+  - include: ceph_owner.yml
+    when: upgrade_ceph2jewel|bool
 
-- name: stop ceph osd
-  service: name=ceph-osd-all state=stopped
-  when: "'ceph_osds' in group_names"
+  - name: start ceph osds
+    service: name=ceph-osd-all state=started enabled=yes
 
-- include: ceph_owner.yml
-  when: upgrade_ceph2jewel|bool and 'ceph_osds' in group_names
+  # make sure ceph osd services are up before unset noout
+  - name: make sure ceph osds are up
+    shell: test `ls /var/run/ceph/*.asok |wc -l` -eq {{ ceph.disks|length }}
+    register: result
+    until: result.rc == 0
+    retries: 5
+    delay: 5
 
-- name: start ceph osds
-  service: name=ceph-osd-all state=started enabled=yes
-  when: "'ceph_osds' in group_names"
+  # Unset the osd values to make heath check pass
+  - name: unset osd noout
+    command: ceph osd unset noout
+    delegate_to: "{{ groups['ceph_monitors'][0] }}"
 
-# make sure ceph osd services are up before unset noout
-- name: make sure ceph osds are up
-  shell: test `ls /var/run/ceph/*.asok |wc -l` -eq {{ ceph.disks|length }}
-  register: result
-  until: result.rc == 0
-  retries: 5
-  delay: 5
-  when: "'ceph_osds' in group_names"
+  - name: unset osd noscrub
+    command: ceph osd unset noscrub
+    delegate_to: "{{ groups['ceph_monitors'][0] }}"
 
-# Unset the osd values to make heath check pass
-- name: unset osd noout
-  command: ceph osd unset noout
-  delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  when: "'ceph_osds' in group_names"
-
-- name: unset osd noscrub
-  command: ceph osd unset noscrub
-  delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  when: "'ceph_osds' in group_names"
-
-- name: unset osd nodeep scrub
-  command: ceph osd unset nodeep-scrub
-  delegate_to: "{{ groups['ceph_monitors'][0] }}"
+  - name: unset osd nodeep scrub
+    command: ceph osd unset nodeep-scrub
+    delegate_to: "{{ groups['ceph_monitors'][0] }}"
   when: "'ceph_osds' in group_names"
 
 # make sure ceph health ok after update


### PR DESCRIPTION
In 3.0.x(ceph version is Hammer), admin keyring is owned by root on cpm.
While in 3.1.0(ceph version is Jewel), admin keyring is owned by ceph user.
Admin keyring is generated by ceph program, but it's used by users.
Ceph program doesn't use it. So it doesn't matter who is the owner of admin keyring.
But it's better to make the owner consistent.
(cherry picked from commit 708194231aae4fc37a0d522a5337fda54513de68)
