### PR TITLE
Bump qemu version to 1.28

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -26,7 +26,7 @@ nova:
   scheduler_host_subset_size: 1
   libvirt_bin_version: 1.3.1-1ubuntu10.3~cloud0
   python_libvirt_version: 1.3.1-1ubuntu1~cloud0
-  qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.27
+  qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.28
   librdb1_version: 10.2.2-0ubuntu0.16.04.2~cloud0
   qemu_system_package: qemu-system-x86
   glance_endpoint: http://{{ endpoints.main }}:9393


### PR DESCRIPTION
In our 3.0.1 release, qemu versions were not capped, and toward the end
of 3.0.1 installs, a newer qemu build was released. Our 3.1.0 release
was pinned to a previous build, which presented a downgrade scenario. To
resolve this, bump the version we pin to.

Change-Id: I53e6193ee6ec51a96229fee90a57afac358f3a3a
(cherry picked from commit dd7515a3b8301432f9e092535ebcd1d4cd537d1d)