### PR TITLE
[WIP] Add mysql to haproxy

### DIFF
--- a/roles/endpoints/defaults/main.yml
+++ b/roles/endpoints/defaults/main.yml
@@ -2,7 +2,7 @@
 swift_fqdn: "{{ fqdn }}"
 endpoints:
   main: "{{ fqdn }}"
-  db: "{{ undercloud_floating_ip }}"
+  db: "{{ undercloud_floating_ip }}:3307"
   rabbit: "{{ undercloud_floating_ip }}"
   memcache: "{{ undercloud_floating_ip }}:11211"
   magnum: "{{ fqdn }}"

--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -182,3 +182,33 @@ backend {{ name }}
   {% endfor %}
 
 {% endfor %}
+
+# Block for percona. Lifted from
+# https://www.percona.com/doc/percona-xtradb-cluster/5.6/howtos/haproxy.html
+# and
+# https://www.percona.com/doc/percona-xtradb-cluster/5.6/howtos/virt_sandbox.html
+# Mark all but first node as backup, so writes go to a single host.
+#
+# Currently does not protect against a server that is JOINING or DISCONNECTED
+# that will require setting up a http service described in above URLs, but that
+# is beyond the MVP. FIXME
+listen mysql-cluster
+  bind :::3307
+  mode tcp
+  maxconn 4096
+  retries 3
+  option tcplog
+  option tcpka
+  timeout connect 5000
+  timeout client 50000
+  timeout server 50000
+  balance roundrobin
+  option mysql-check user haproxy
+
+{% for host in groups['db'] %}
+{% if loop.first %}
+  server {{ host }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:3306 check
+{% else %}
+  server {{ host }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:3306 check backup
+{% endif %}
+{% endfor %}

--- a/roles/percona-server/tasks/main.yml
+++ b/roles/percona-server/tasks/main.yml
@@ -121,6 +121,17 @@
 - name: install root .my.cnf defaults file
   template: src=root/.my.cnf dest=/root/.my.cnf owner=root group=root mode=0600
 
+- name: add mysql user for haproxy health
+  mysql_user:
+    name: haproxy
+    host: "{{ hostvars[item]['ansible_fqdn'] }}"
+  with_items: "{{ groups['controller'] }}"
+
+- name: add fqdn mysql for haproxy health (because haproxy is dumb)
+  mysql_user:
+    name: haproxy
+    host: "{{ fqdn }}"
+
 - name: remove mysql test database
   mysql_db: state=absent name=test
 


### PR DESCRIPTION
This is a MVP for mysql behind haproxy, so that openstack services can
proxy through and survive a single node's mysql restart. Before this,
all nodes would point at the internal floating IP and connect to the
mysql process there directly. If mysql was restarted, all connections
would die. With a proxy, they can retry / reconnect to another member of
the cluster.

The backend checking isn't completely robust, there is a FIXME in place,
but this gets us started and testing.

Only OpenStack services (things that consume endpoints.db) are set to
use the proxy.

Change-Id: Ibf066ec4f515ab585a85a8061a16db12b8397cb2