### PR TITLE
Upgrade percona-xtrabackup along with server

### DIFF
--- a/roles/percona-server/tasks/main.yml
+++ b/roles/percona-server/tasks/main.yml
@@ -56,11 +56,11 @@
 - block:
   - name: upgrade percona to desired version
     apt:
-      pkg: percona-xtradb-cluster-server-{{ xtradb.server_version }}
+      pkg: "{{ item }}"
       state: latest
-    run_once: true
-    delegate_to: "{{ item }}"
-    with_items: "{{ play_hosts }}"
+    with_items:
+      - percona-xtrabackup
+      - percona-xtradb-cluster-server-{{ xtradb.server_version }}
 
   # Make sure the cluster is healthy before moving on
   # NOTE this will fail if we switch to apt packages for sensu plugins!!
@@ -69,9 +69,6 @@
     register: cstat
     until: cstat | succeeded
     retries: 5
-    run_once: true
-    delegate_to: "{{ item }}"
-    with_items: "{{ play_hosts }}"
   when: (dbupgrade | default('False') | bool) or
         (upgrade | default('False') | bool)
 


### PR DESCRIPTION
Turns out the server requires a version of xtrabackup and it may not
properly express the verison requirement. So we want to upgrade it to
the latest at the same time as the server so the restart works.

Also, this play only runs on one host at a time, no need for run_once
and delegate shenanigans.

Change-Id: I840cc7fd78920f8deb06e59a0b50b04a9979a3cb
(cherry picked from commit 21624296c599107ed9977177b51ad4873dfbe5ad)