### PR TITLE
Upgrade percona-xtradb-cluster-galera along with server.

### DIFF
--- a/roles/percona-server/tasks/main.yml
+++ b/roles/percona-server/tasks/main.yml
@@ -58,9 +58,11 @@
     apt:
       pkg: "{{ item }}"
       state: latest
+      update_cache: yes
     with_items:
       - percona-xtrabackup
       - percona-xtradb-cluster-server-{{ xtradb.server_version }}
+      - percona-xtradb-cluster-galera-{{ xtradb.galera_version }}
 
   # Make sure the cluster is healthy before moving on
   # NOTE this will fail if we switch to apt packages for sensu plugins!!


### PR DESCRIPTION
Turns out the server requires a version of galera and it may not
properly express the verison requirement. So we want to upgrade it to
the latest at the same time as the server so the restart works.