### PR TITLE
Send HUP signal to nova processes after upgrade

### DIFF
--- a/upgrade.yml
+++ b/upgrade.yml
@@ -413,6 +413,36 @@
       when: ironic.enabled == False
   environment: "{{ env_vars|default({}) }}"
 
+# FIXME these need to be tolerant of failures perhaps, like missing service?
+# Probably needs fixing for ironic too
+- name: hup nova control processes
+  hosts: controller
+  max_fail_percentage: 1
+  tags:
+    - nova
+    - nova-control
+  tasks:
+    - name: send HUP signal to nova control processes
+      command: pkill -HUP -f bin/{{ item }}
+      with_items:
+        - nova-api
+        - nova-conductor
+        - nova-consoleauth
+        - nova-scheduler
+        - nova-novncproxy
+
+- name: hup nova control processes
+  hosts: compute
+  max_fail_percentage: 1
+  tags:
+    - nova
+    - nova-compute
+  tasks:
+    - name: send HUP signal to nova control processes
+      command: pkill -HUP -f bin/{{ item }}
+      with_items:
+        - nova-compute
+
 - name: complete online data migrations
   hosts: controller[0]
   max_fail_percentage: 1


### PR DESCRIPTION
This step was missing, and needed to make each nova process re-evaluate
what internal API level it should be talking with other Nova services.

See step 3 in
http://docs.openstack.org/developer/nova/upgrade.html#rolling-upgrade-process

Change-Id: I56117008d00db2935a940f2c6fd8484c9b53bc0d