### PR TITLE
Add neutron preflight checks

### DIFF
--- a/roles/preflight-checks/meta/main.yml
+++ b/roles/preflight-checks/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: endpoints

--- a/roles/preflight-checks/tasks/main.yml
+++ b/roles/preflight-checks/tasks/main.yml
@@ -1,5 +1,24 @@
 ---
 - block:
+  - name: check whether neutron-client is installed
+    command: neutron --version
+    register: result_neutron_installed
+    failed_when: false
+
+  - name: check whether neutron endpoint exists
+    shell: . /root/stackrc; openstack endpoint list | grep neutron
+    failed_when: false
+    register: result_neutron_endpoint
+
+  - include: neutron.yml
+    when:
+      - result_neutron_installed.rc == 0
+      - result_neutron_endpoint.rc == 0
+
+  delegate_to: "{{ groups['controller'][0] }}"
+  run_once: true
+
+- block:
   - name: check ceph installed
     command: ceph --version
     register: result_ceph_installed

--- a/roles/preflight-checks/tasks/network.yml
+++ b/roles/preflight-checks/tasks/network.yml
@@ -1,0 +1,39 @@
+---
+- name: checking network {{ item.name }}
+  os_networks_facts:
+    name: "{{ item.name }}"
+    auth:
+      auth_url: "{{ endpoints.auth_uri }}"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
+
+- name: ensure network name
+  assert:
+    that: openstack_networks[0] is defined
+    msg: "The network does not exist or name may have been changed."
+
+- name: ensure provider physical netowrk
+  assert: 
+    that: openstack_networks[0]['provider:physical_network'] == item.provider_physical_network
+    msg: "Could not find matching attribute for provider:physical_network."
+
+- name: ensure segmentation ID
+  assert: 
+    that: openstack_networks[0]['provider:segmentation_id'] == item.segmentation_id
+    msg: "Could not find matching attribute for provider:segmentation_id."
+
+- name: ensure provider network type
+  assert: 
+    that: openstack_networks[0]['provider:network_type'] == item.network_type
+    msg: "Could not find matching attribute for provider:network_type."
+
+- name: ensure router external
+  assert: 
+    that: openstack_networks[0]['router:external'] == item.external
+    msg: "Could not find matching attribute for router:external."
+
+- name: ensure shared 
+  assert: 
+    that: openstack_networks[0]['shared'] == item.shared
+    msg: "Could not find matching attribute for shared."

--- a/roles/preflight-checks/tasks/neutron.yml
+++ b/roles/preflight-checks/tasks/neutron.yml
@@ -1,0 +1,6 @@
+---
+- include: network.yml param={{ item }}
+  with_items: "{{ neutron.networks }}"
+
+- include: subnet.yml param={{ item }}
+  with_items: "{{ neutron.subnets }}"

--- a/roles/preflight-checks/tasks/subnet.yml
+++ b/roles/preflight-checks/tasks/subnet.yml
@@ -1,0 +1,67 @@
+---
+- name: checking neutron subnet {{ item.name }}
+  os_subnets_facts:
+    name: "{{ item.name }}"
+    auth:
+      auth_url: "{{ endpoints.auth_uri }}"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
+
+- name: ensure subnet name
+  assert: 
+    that: openstack_subnets[0] is defined
+    msg: "The subnet does not exist or name may have been changed."
+
+- name: ensure cidr
+  assert: 
+    that: openstack_subnets[0]['cidr'] == item.cidr
+    msg: "Could not find matching attribute for cidr."
+
+- name: ensure gateway_ip
+  assert:
+    that: openstack_subnets[0]['gateway_ip'] == item.gateway_ip
+    msg: "Could not find matching attribute for gateway_ip."
+
+- name: ensure ip_version
+  assert:
+    that: openstack_subnets[0]['ip_version'] == item.ip_version
+    msg: "Could not find matching attribute for ip_version."
+
+- name: ensure enable_dhcp
+  assert:
+    that: openstack_subnets[0]['enable_dhcp'] == {{ item.enable_dhcp | bool }}
+    msg: "Could not find matching attribute for enable_dhcp."
+
+- name: ensure ipv6_ra_mode
+  assert:
+    that: openstack_subnets[0]['ipv6_ra_mode'] == item.ipv6_ra_mode
+    msg: "Could not find matching attribute for ipv6_ra_mode."
+  when: item.ipv6_ra_mode is defined
+
+- name: ensure pool_start
+  assert:
+    that: openstack_subnets[0]['allocation_pools'][0]['start'] == item.pool_start
+    msg: "Could not find matching attribute for pool_start."
+  when: item.pool_start is defined
+
+- name: ensure pool_end
+  assert:
+    that: openstack_subnets[0]['allocation_pools'][0]['end'] == item.pool_end
+    msg: "Could not find matching attribute for pool_end."
+  when: item.pool_end is defined
+
+- name: ensure ipv6_address_mode
+  assert:
+    that: openstack_subnets[0]['ipv6_address_mode'] == item.ipv6_address_mode
+    msg: "Could not find matching attribute for ipv6_address_mode."
+  when: item.ipv6_ra_mode is defined
+
+#FIXME: Add dns_nameservers checks, there could be zero to N number of DNS nameservers.
+#       In most cases, there are two or three. This will require parsing through the array of
+#       DNS nameservers stored in openstack_subnets[0]['dns_nameservers'] and check if each
+#       IP exists in item.dns_nameservers. For example:
+#          openstack_subnets[0]['dns_nameservers'][0] in item.dns_nameservers
+#          openstack_subnets[0]['dns_nameservers'][1] in item.dns_nameservers
+#          ...
+#       For simplicity, this will be skipped for now.


### PR DESCRIPTION
- First draft for neutron preflight checks
- Checks for admin networks and subnets and detects any
discrepancy between openstack-envs neutron networks definition and networks in the stack