### PR TITLE
set ip_forward to 1 for vagrant and CI based testing

### DIFF
--- a/roles/openstack-network/tasks/main.yml
+++ b/roles/openstack-network/tasks/main.yml
@@ -24,3 +24,7 @@
             owner=root group=root mode=0644
   when: not neutron_external_ifcfg.stat.exists and result.id is defined
   notify: ifup neutron external interface
+
+- name: enable ip forwarding
+  sysctl: name="net.ipv4.ip_forward" value=1 sysctl_set=yes state=present reload=yes
+  when: result.id is defined


### PR DESCRIPTION
CI tests are failing because ip_forwarding is not enabled for bridge and tap interfaces. This setting is required to forward the packet from bridge device to physical ethernet device (eth0) for external connectivity to work.

