### PR TITLE
Support adding a failed disk back to Hybrid Ceph Cluster

### DIFF
--- a/playbooks/tests/tasks/network.yml
+++ b/playbooks/tests/tasks/network.yml
@@ -50,9 +50,14 @@
   - name: neutron has the default router
     shell: . /root/stackrc; neutron router-list | grep default
 
+# try ping internet for 5 minutes
   - name: neutron router can ping internet
     shell: ROUTER_NS=$( ip netns show | grep qrouter- ); ip netns
            exec ${ROUTER_NS} ping -c 5 8.8.8.8
+    register: result
+    until: result|success
+    retries: 30
+    delay: 10
 
 - name: network tests across all network nodes
   hosts: network

--- a/roles/ceph-osd/tasks/bcache.yml
+++ b/roles/ceph-osd/tasks/bcache.yml
@@ -28,96 +28,122 @@
 # we check for journal and bcache partitions to skip destructive tasks below
 - name: check if journal partitions exist on ssd device
   shell: "parted --script /dev/{{ ceph.bcache_ssd_device }} print | egrep -sq 'journal'"
-  ignore_errors: true
+  failed_when: false
   changed_when: false
   register: journal_partitions
 
 - name: check if bcache partition exists on ssd device
   shell: "parted --script /dev/{{ ceph.bcache_ssd_device }} print | egrep -sq 'bcache'"
-  ignore_errors: true
+  failed_when: false
   changed_when: false
   register: bcache_partition
 
-- name: initialize ok_to_deploy flag
+- name: initialize ceph_init_ssd flag
   set_fact:
-    ok_to_deploy: false
+    ceph_init_ssd: false
 
-- name: set ok_to_deploy flag
+- name: set ceph_init_ssd flag
   set_fact:
-    ok_to_deploy: true
-  when: journal_partitions.rc != 0 and
-        bcache_partition.rc != 0
+    ceph_init_ssd: true
+  when:
+    - journal_partitions.rc != 0
+    - bcache_partition.rc != 0
 
-- name: mklabel gpt
-  command: "parted -s /dev/{{ ceph.bcache_ssd_device }} mklabel gpt"
-  when: ok_to_deploy
+# block initial ssd disk
+- block:
+  - name: mklabel gpt
+    command: "parted -s /dev/{{ ceph.bcache_ssd_device }} mklabel gpt"
 
-- name: make journal partitions
-  command: parted --script /dev/{{ ceph.bcache_ssd_device }}
-           mkpart journal {{ (item|int * 10000) + 1 }}MiB {{ (item|int * 10000) + 10000 }}MiB
-  with_sequence: "start=0 end={{ ceph.disks|length - 1 }}"
-  when: ok_to_deploy
+  - name: make journal partitions
+    command: parted --script /dev/{{ ceph.bcache_ssd_device }}
+             mkpart journal {{ (item|int * 10000) + 1 }}MiB {{ (item|int * 10000) + 10000 }}MiB
+    with_sequence: "start=0 end={{ ceph.disks|length - 1 }}"
 
-- name: make bcache partition
-  command: parted --script /dev/{{ ceph.bcache_ssd_device }}
-           mkpart bcache {{ ceph.disks|length * 10000 + 1 }}MiB 100%
-  when: ok_to_deploy
+  - name: make bcache partition
+    command: parted --script /dev/{{ ceph.bcache_ssd_device }}
+             mkpart bcache {{ ceph.disks|length * 10000 + 1 }}MiB 100%
 
-- name: make-bcache -C <ssd device>
-  command: make-bcache -C /dev/{{ ceph.bcache_ssd_device }}{{ ceph.disks|length + 1 }}
-  ignore_errors: true
-  when: ok_to_deploy
+  - name: make-bcache -C <ssd device>
+    command: make-bcache -C /dev/{{ ceph.bcache_ssd_device }}{{ ceph.disks|length + 1 }}
+  when: ceph_init_ssd
 
 - name: make-bcache -B <sata disks>
-  command: "make-bcache -B /dev/{{ item }}"
+  command: make-bcache -B /dev/{{ item }}
+           creates=/sys/block/{{ item }}/bcache
+  register: result_bcache_backs
   with_items: "{{ ceph.disks }}"
-  when: ok_to_deploy
-
-- name: udevadm trigger
-  command: "udevadm trigger"
-  when: ok_to_deploy
-
-- name: wait for bcache directories to be created before running next task
-  wait_for: path=/sys/block/bcache{{ item }}
-  with_sequence: "start=0 end={{ ceph.disks|length - 1 }}"
-  when: ok_to_deploy
-
-- name: set cache mode to writeback
-  shell: echo writeback > /sys/block/bcache{{ item }}/bcache/cache_mode
-  with_sequence: "start=0 end={{ ceph.disks|length - 1 }}"
-  when: ok_to_deploy
 
 - name: determine bcache uuid
   shell: bcache-super-show /dev/{{ ceph.bcache_ssd_device }}{{ ceph.disks|length + 1 }} |
          grep cset.uuid | awk '{print $2}'
   changed_when: false
   register: bcache_uuid
-  when: ok_to_deploy
 
-- name: attach to bcache devices
-  shell: echo {{ bcache_uuid.stdout }} > /sys/block/bcache{{ item }}/bcache/attach
-  with_sequence: "start=0 end={{ ceph.disks|length - 1 }}"
-  when: ok_to_deploy
+# deal with bcache devices when back devices are changed
+- block:
+  - name: udevadm trigger
+    command: "udevadm trigger"
 
-- name: make xfs on bcache devices
-  command: "mkfs -t xfs -f -i size=2048 -- /dev/bcache{{ item }}"
-  with_sequence: "start=0 end={{ ceph.disks|length - 1 }}"
-  when: ok_to_deploy
+  - name: wait for bcache directories to be created before running next task
+    wait_for: path=/sys/block/bcache{{ item }} timeout=30
+    with_sequence: "start=0 end={{ ceph.disks|length - 1 }}"
 
-- name: make sure all uuids of bcaches exist
-  shell: test `ls -l /dev/disk/by-uuid/ |grep bcache |wc -l` -eq "{{ ceph.disks|length }}"
-  register: result
-  until: result.rc == 0
-  retries: 6
-  delay: 10
-  when: ok_to_deploy
+  - name: get changed bcaches
+    shell: grep -oP "bcache\d+" /sys/block/{{ item.item }}/bcache/dev/uevent
+    when: item.changed
+    with_items: "{{ result_bcache_backs.results }}"
+    register: result_cache_nums
+
+  - name: set cache mode to writeback
+    shell: echo writeback > /sys/block/{{ item.stdout }}/bcache/cache_mode
+    when: item.changed
+    with_items: "{{ result_cache_nums.results }}"
+
+  - name: attach to bcache devices
+    shell: echo {{ bcache_uuid.stdout }} > /sys/block/{{ item.stdout }}/bcache/attach
+    when: item.changed
+    with_items: "{{ result_cache_nums.results }}"
+
+  - name: make sure cache tier is ok
+    wait_for: path=/sys/block/{{ item.stdout }}/bcache/cache timeout=10
+    when: item.changed
+    with_items: "{{ result_cache_nums.results }}"
+
+  - name: make xfs on bcache devices
+    command: mkfs -t xfs -f -i size=2048 -- /dev/{{ item.stdout }}
+    when: item.changed
+    with_items: "{{ result_cache_nums.results }}"
+
+  - name: make sure all uuids of bcaches exist
+    shell: test `ls -l /dev/disk/by-uuid/ |grep bcache |wc -l` -eq "{{ ceph.disks|length }}"
+    register: result
+    until: result.rc == 0
+    retries: 6
+    delay: 10
+  when: result_bcache_backs.changed
+
+# deal with bcache devices when ssd disk is changed
+- block:
+  - name: attach to bcache devices
+    shell: echo {{ bcache_uuid.stdout }} > /sys/block/bcache{{ item }}/bcache/attach
+           creates=/sys/block/bcache{{ item }}/bcache/cache
+    with_sequence: "start=0 end={{ ceph.disks|length - 1 }}"
+
+  - name: make sure cache tier is ok
+    wait_for: path=/sys/block/bcache{{ item }}/bcache/cache timeout=10
+    with_sequence: "start=0 end={{ ceph.disks|length - 1 }}"
+  when: ceph_init_ssd
 
 - name: activate osds
   ceph_bcache:
     disks: "{{ ceph.disks }}"
     ssd_device: "{{ ceph.bcache_ssd_device }}"
+    ceph_init_ssd: "{{ ceph_init_ssd }}"
     journal_guid: "{{ ceph.journal_guid }}"
-  when: ok_to_deploy
+  when: ceph_init_ssd or result_bcache_backs.changed
+
+- name: make sure ceph-osd-all started
+  service: name=ceph-osd-all state=started
 
 # pool pg number is based on osd amount
 # we should create pool when all osds are up
@@ -126,15 +152,11 @@
     pool_name: "{{ hybrid_pool }}"
     osds: "{{ groups['ceph_osds_hybrid']|length * ceph.disks|length }}"
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  when:
-    - ok_to_deploy
-    - inventory_hostname == groups['ceph_osds_hybrid'][-1]
+  when: inventory_hostname == groups['ceph_osds_hybrid'][-1]
 
 # not sure is there a better way to get ruleset id
 - name: set ruleset for pool
   shell: ceph osd pool set {{ hybrid_pool }} crush_ruleset
          $(ceph osd crush rule dump |grep {{ hybrid_ruleset }} -A1 |grep -oP '\d+')
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  when:
-    - ok_to_deploy
-    - inventory_hostname == groups['ceph_osds_hybrid'][-1]
+  when: inventory_hostname == groups['ceph_osds_hybrid'][-1]


### PR DESCRIPTION
cherry picked from PR  (#2275)
We have several osds on each osd node.
For hybrid ceph, we can't run ursula deploy against a single osd.
We have to run against all osds on the node.

So we can't add a failed disk back to hybrid ceph cluster by ursula.

This patch is to support this feature.
(cherry picked from commit 101423a1b05a842fd6cae3ffbdd1dcb10aa93ef2)