### PR TITLE
Fix neutron router ping

### DIFF
--- a/playbooks/tests/tasks/network.yml
+++ b/playbooks/tests/tasks/network.yml
@@ -50,9 +50,14 @@
   - name: neutron has the default router
     shell: . /root/stackrc; neutron router-list | grep default
 
+# try ping internet for 5 minutes
   - name: neutron router can ping internet
     shell: ROUTER_NS=$( ip netns show | grep qrouter- ); ip netns
            exec ${ROUTER_NS} ping -c 5 8.8.8.8
+    register: result
+    until: result|success
+    retries: 30
+    delay: 10
 
 - name: network tests across all network nodes
   hosts: network


### PR DESCRIPTION
Adding retries to the neutron router ping test because the ping test fails intermittently due to timing issue. 