### PR TITLE
Removed Ansible prereq from doc/vagrant.md

### DIFF
--- a/doc/vagrant.md
+++ b/doc/vagrant.md
@@ -3,12 +3,11 @@ Ursula on Vagrant
 
 Vagrant is an excellent tool for easily testing out new tools or systems without having to install a bunch of crap to your userland.
 
-Prerequistites
+Prerequisites
 ==============
 
 * Virtualbox
 * Vagrant
-* Ansible ( 1.7ish )
 
 Networking
 ==========


### PR DESCRIPTION
Removed the unnecessary Ansible requirement from the Vagrant
documentation. This line was redundant because Ansible is prerequisite
for Ursula. This line was also confusing because it had listed Ansible
(1.7ish), which was incorrect since the current version of Ursula
requires 2.1.X.

Corrected the spelling of "prerequisites" in the same file.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>