### PR TITLE
Fixed capitalization of OpenStack

### DIFF
--- a/doc/ironic.md
+++ b/doc/ironic.md
@@ -122,7 +122,7 @@ In a minute or so your vbox VM should start up and provision cirros.
 Image Building
 ==============
 
-The Openstack Way
+The OpenStack Way
 -----------------
 
 ```

--- a/doc/vagrant.md
+++ b/doc/vagrant.md
@@ -13,7 +13,7 @@ Prerequistites
 Networking
 ==========
 
-We've strived to keep the networking in the Vagrant install simple.  It _may_ not resemble what you would run in production,  but it does allow for an easier introduction to Openstack.
+We've strived to keep the networking in the Vagrant install simple.  It _may_ not resemble what you would run in production,  but it does allow for an easier introduction to OpenStack.
 
 There are four network interfaces provided in the Vagrantfile.
 
@@ -25,7 +25,7 @@ Vagrant guest IP:  This isn't of any interest to us.
 eth1
 ----
 
-Host Networking:  This is the primary network for the openstack hosts and services.
+Host Networking:  This is the primary network for the OpenStack hosts and services.
 
 eth2
 ----
@@ -52,7 +52,7 @@ Use `$ ursula --provisioner=vagrant envs/example/allinone site.yml`
 allinone
 --------
 
-This will stand up a single monolithic Openstack VM.  It's much quicker than standard, but sacrifices HA and multi-node:
+This will stand up a single monolithic OpenStack VM.  It's much quicker than standard, but sacrifices HA and multi-node:
 
 ```
 $ ursula --provisioner=vagrant envs/example/allinone site.yml

--- a/playbooks/tests/tasks/swift.yml
+++ b/playbooks/tests/tasks/swift.yml
@@ -2,10 +2,10 @@
 - name: tests on a single controller for swift
   hosts: controller[0]
   tasks:
-  - name: Openstack service list should include swift
+  - name: OpenStack service list should include swift
     shell: . /root/stackrc; openstack service list | grep swift
 
-  - name: Openstack endpoint list should include swift
+  - name: OpenStack endpoint list should include swift
     shell: . /root/stackrc; openstack endpoint list | grep swift
 
   - name: swift has a working api


### PR DESCRIPTION
Previously, some of the documentation and one task had incorrect
capitalization of "OpenStack" (either as "openstack" or "Openstack" in
cases where "OpenStack" would have been correct). Now, it has been
corrected.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>