### PR TITLE
set baud rate for main serial port

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -17,6 +17,7 @@ common:
   serial_console:
     enabled: True
     name: ttyS0
+    baud_rate: 9600
   ssh_private_keys: []
   ssh:
     allow_from:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -84,6 +84,7 @@
 
 # Include serial console before kernel-tuning to build serial_console_cmdline
 - include: serial-console.yml tty={{ common.serial_console.name }}
+                              baud_rate={{ common.serial_console.baud_rate }}
   when: common.serial_console.enabled | bool
   tags: ['prereboot']
 


### PR DESCRIPTION
baud rate wasn't able to be set for primary tty port.  this fixes that.