### PR TITLE
sensu_check_dict to support ucarp primary only

### DIFF
--- a/library/sensu_check_dict.py
+++ b/library/sensu_check_dict.py
@@ -31,7 +31,8 @@ def main():
             name=dict(default=None, required=True),
             check_dir=dict(default='/etc/sensu/conf.d/checks', required=False),
             state=dict(default='present', required=False, choices=['present','absent']),
-            check=dict(type='dict', required=True)
+            check=dict(type='dict', required=True),
+            ucarp_node_only=dict(default=False, required=False)
         )
     )
 
@@ -45,6 +46,11 @@ def main():
                 }
             })
 
+            if module.params['ucarp_node_only']:
+                check['checks'][module.params['name']]['command']=             \
+                         'if ip a | grep ucarp > /dev/null 2>&1; then '        \
+                         + check['checks'][module.params['name']]['command']   \
+                         + '; fi'
 
             if os.path.isfile(check_path):
                 with open(check_path) as fh:


### PR DESCRIPTION
with ucarp_node_only=True, the check will be executed only on ucarp primary node.
default is False, so existing sensu_check_dict function will not be affected.