### PR TITLE
cafile location for rhel

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -490,6 +490,7 @@ keystone:
     enabled: False
 
 ssl:
+  cafile: "{{ (os == 'rhel' ) | ternary('/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt', '/etc/ssl/certs/ca-certificates.crt') }}"
   crt: |
     -----BEGIN CERTIFICATE-----
     MIIDGTCCAgGgAwIBAgIJAMtkDaIzlHvtMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNV


### PR DESCRIPTION
Openstack services were referencing /etc/ssl/certs/ca-certificates.crt which is not created in rhel. 