### PR TITLE
make sure os is defined

### DIFF
--- a/roles/preflight-checks/tasks/main.yml
+++ b/roles/preflight-checks/tasks/main.yml
@@ -9,6 +9,10 @@
     os: ubuntu
   when: ansible_distribution in ['Ubuntu']
 
+- name: make sure os is defined
+  fail: msg="We don't support {{ ansible_distribution }} yet. OS should be CentOS, RedHat or Ubuntu."
+  when: os is undefined
+
 - name: set ssh_service fact for ubuntu
   set_fact:
     ssh_service: ssh


### PR DESCRIPTION
We need to assert os is defined to ensure that the OS is in [ ubuntu, centos, redhat].
Otherwise we shouldn't continue the ursula run.

So, we will not support Debian and Fedora, right?