### PR TITLE
move tag precheck into preflight-checks role from site.yml

### DIFF
--- a/roles/preflight-checks/tasks/main.yml
+++ b/roles/preflight-checks/tasks/main.yml
@@ -51,5 +51,5 @@
       - result_cinder_endpoint.rc == 0
 
   when: ceph.enabled | default('False') | bool
-  tags: 'precheck_ceph'
+  tags: ['precheck', 'precheck_ceph']
   run_once: true

--- a/site.yml
+++ b/site.yml
@@ -17,7 +17,7 @@
   hosts: all:!vyatta-*
   roles:
     - role: preflight-checks
-      tags: ['always', 'precheck']
+      tags: ['always']
   environment: "{{ env_vars|default({}) }}"
 
 - name: common role for all hosts


### PR DESCRIPTION
Sometimes, developers run ursula with `--skip-tags precheck` for debug.
But there are tasks those never should be skipped in preflight-checks
role. For example, the task for setting variable `os`.

This patch is to move the precheck tag into role, so we will only skip
the tasks we mean to.