### PR TITLE
add precheck of ceph version

### DIFF
--- a/roles/preflight-checks/defaults/main.yml
+++ b/roles/preflight-checks/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+preflight_checks:
+  ceph_version_larger_than: 0.899

--- a/roles/preflight-checks/tasks/ceph.yml
+++ b/roles/preflight-checks/tasks/ceph.yml
@@ -26,3 +26,8 @@
   delegate_to: "{{ item }}"
   with_items:
     - "{{ groups['controller'] }}"
+
+- name: fail if current ceph version is less than hammer
+  shell: test $(ceph --version |grep -oP "\d+\.\d+\.?\d{0,3}") \>
+         "{{ preflight_checks.ceph_version_larger_than }}"
+  delegate_to: "{{ groups['ceph_monitors'][0] }}"

--- a/roles/preflight-checks/tasks/main.yml
+++ b/roles/preflight-checks/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+# We do preflight checks to ensure the cluster is in good state before *re-run*.
+# Otherwise, re-run may bring cluster into a very bad state.
+# But we should know this is a re-run or first-run by some conditions, such as endpoint.
 - block:
   - name: check whether neutron-client is installed
     command: neutron --version
@@ -35,7 +38,6 @@
     when:
       - result_ceph_installed.rc == 0
       - result_cinder_endpoint.rc == 0
-
   when: ceph.enabled | default('False') | bool
   tags: 'precheck_ceph'
   run_once: true


### PR DESCRIPTION
To upgrade ceph to `jewel`, we must make sure current ceph is at least `hammer`.