### PR TITLE
secure trusted dashboard

### DIFF
--- a/roles/keystone/templates/etc/keystone/keystone.conf
+++ b/roles/keystone/templates/etc/keystone/keystone.conf
@@ -103,7 +103,7 @@ methods = external,password,token{{ ',saml2' if keystone.federation.enabled|bool
 
 [federation]
 driver = sql
-trusted_dashboard = http://{{ fqdn }}/auth/websso/
+trusted_dashboard = https://{{ fqdn }}/auth/websso/
 
 {% if keystone.federation.enabled|bool and keystone.federation.sp.oidc.enabled|bool -%}
 {% for sp in keystone.federation.sp.oidc.providers_info -%}


### PR DESCRIPTION
Since we changed SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https') in openstack-dashboard it broke verification of trusted dashboard. 