### PR TITLE
updates to make neutron networking work on centos in VMs

### DIFF
--- a/envs/example/ci-full-centos/heat_stack.yml
+++ b/envs/example/ci-full-centos/heat_stack.yml
@@ -102,8 +102,16 @@ resources:
           protocol: icmp
         - ethertype: 'IPv4'
           remote_mode: 'remote_group_id'
-        - ethertype: 'IPv6'
+          protocol: tcp
+        - ethertype: 'IPv4'
           remote_mode: 'remote_group_id'
+          protocol: udp
+        - ethertype: 'IPv4'
+          remote_mode: 'remote_group_id'
+          protocol: igmp
+        - ethertype: IPv4
+          remote_ip_prefix: 192.168.0.0/22
+          protocol: igmp
 
   ssh_keypair:
     type: OS::Nova::KeyPair

--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -216,6 +216,9 @@ cinder:
       control_location: front-end
 
 neutron:
+  advertise_mtu: true
+  path_mtu: 1400
+  global_physnet_mtu: 1500
   plugin: ml2
   bridge_mappings: ''
   network_vlan_ranges: ''

--- a/roles/nova-data/tasks/main.yml
+++ b/roles/nova-data/tasks/main.yml
@@ -19,11 +19,22 @@
   until: result|succeeded
   retries: 5
 
+- name: set group membership for nova state_path
+  file:
+    dest: "{{ nova.state_path }}"
+    state: directory
+    owner: nova
+    group: "{{ (os == 'rhel' ) | ternary('qemu', 'nova') }}"
+    mode: 0770
+
+
 - name: nova instances directory
   file:
     dest: "{{ nova.state_path }}/instances"
     state: directory
     owner: nova
+    group: "{{ (os == 'rhel' ) | ternary('qemu', 'nova') }}"
+    mode: 0770
 
 - name: nbd module - ubuntu
   lineinfile: dest=/etc/modules line="nbd"


### PR DESCRIPTION
update MTUs for neutron to fit in < 1500

update heat stack to allow igmp

set ternary operator on nova data ownership ( qemu user need access)