### PR TITLE
centos related monitoring change

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -65,6 +65,7 @@ common:
       - vlan
       - lvm2
       - libpam-cracklib
+      - pciutils
   python:
     system_packages:
       - python-pip

--- a/roles/common/tasks/monitoring.yml
+++ b/roles/common/tasks/monitoring.yml
@@ -61,7 +61,7 @@
 
 - name: ensure PATH contains /usr/local/bin (OpenStack clients)
   lineinfile: dest=/etc/default/sensu regexp=^PATH
-              line="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+              line="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/etc/sensu/plugins"
   notify: restart sensu-client
 
 - name: sensu client config

--- a/roles/common/tasks/python.yml
+++ b/roles/common/tasks/python.yml
@@ -73,6 +73,12 @@
   until: result|succeeded
   retries: 5
 
+- name: pip install python-dateutil
+  pip: name=python-dateutil
+  register: result
+  until: result|succeeded
+  retries: 5
+
 - name: install drivers
   command: python setup.py install chdir=/opt/stack/{{ item.name }}
   with_items: "{{ common.python_extra_packages }}"

--- a/roles/common/templates/etc/sensu/stackrc
+++ b/roles/common/templates/etc/sensu/stackrc
@@ -2,8 +2,10 @@ export OS_PASSWORD={{ monitoring.openstack.user.password }}
 export OS_AUTH_URL={{ endpoints.auth_uri }}
 export OS_USERNAME={{ monitoring.openstack.user.username }}
 export OS_TENANT_NAME={{ monitoring.openstack.user.tenant }}
-{% if client.self_signed_cert -%}
+{% if client.self_signed_cert and os == 'ubuntu' -%}
 export OS_CACERT=/opt/stack/ssl/openstack.crt
+{% else %}
+export OS_CACERT={{ ca_bundle }}
 {% endif -%}
 export OS_NO_CACHE=True
 export NOVACLIENT_UUID_CACHE_DIR=/tmp/sensu

--- a/roles/haproxy/tasks/monitoring.yml
+++ b/roles/haproxy/tasks/monitoring.yml
@@ -6,7 +6,7 @@
 
 - name: haproxy check backends
   sensu_check: name=haproxy_servers plugin=check-haproxy.rb
-               args="-p -c 100 -S /var/run/haproxy/stats.sock -A"
+               args="-c 100 -S /var/run/haproxy/stats.sock -A"
   notify: restart sensu-client
 
 - name: haproxy metrics

--- a/roles/horizon/tasks/monitoring.yml
+++ b/roles/horizon/tasks/monitoring.yml
@@ -1,6 +1,7 @@
 ---
 - name: apache2 process check
-  sensu_process_check: service=apache2
+  sensu_process_check: 
+    service: "{{ ( os == 'ubuntu' )| ternary('apache2', 'httpd') }}"
   notify: restart sensu-client
 
 - name: dashboard port check

--- a/roles/rabbitmq/tasks/monitoring.yml
+++ b/roles/rabbitmq/tasks/monitoring.yml
@@ -7,7 +7,7 @@
 
 - name: rabbit server process check
   sensu_process_check:
-    service: rabbitmq-server
+    service: "{{ ( os == 'ubuntu' )| ternary('rabbitmq-server', 'beam.smp') }}"
   notify: restart sensu-client
 
 - name: rabbit cluster check


### PR DESCRIPTION
1. install python-dateutil for check-glance-store, since it face import
error for dateutil
2. modify sensu/stackrc for rhel ( simlar to /root/stackrc logic)
3. haproxy server check,  existing args has issue, which cause critical
threshold is not parsed correctly
4. apache process is different for centos and rhel, one is apache,
another is httpd, so related check should be changed.
5. rhel has no process named as rabbitmq-server, so related process
check should be changed too.
6. add sensu plugin path
7. add pciutils package