### PR TITLE
Inspec support for ubuntu and rhel

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -135,6 +135,9 @@ apt_repos:
   collectd:
     repo: http://ppa.launchpad.net/raravena80/collectd5/ubuntu
     key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xE97C3D97792BD34E"
+  chef:
+    repo: https://packages.chef.io/stable-apt
+    key_url: https://downloads.chef.io/packages-chef-io-public.key
 
 client:
   self_signed_cert: true
@@ -632,4 +635,7 @@ magnum:
   debug: True
 
 serverspec:
+  enabled: False
+
+inspec:
   enabled: False

--- a/roles/common/tasks/inspec.yml
+++ b/roles/common/tasks/inspec.yml
@@ -1,0 +1,6 @@
+---
+- name: inspec checks for common role
+  template: src={{ item }}
+            dest=/etc/inspec/controls/
+            mode=0755
+  with_fileglob: ../templates/inspec/*

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -163,3 +163,8 @@
   tags:
     - serverspec
   when: serverspec.enabled|default('False')|bool
+
+- include: inspec.yml
+  tags:
+    - inspec
+  when: inspec.enabled|default('False')|bool

--- a/roles/inspec/defaults/main.yml
+++ b/roles/inspec/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+inspec:
+  version: ~
+  enabled: true
+  interval: 3600

--- a/roles/inspec/meta/main.yml
+++ b/roles/inspec/meta/main.yml
@@ -1,0 +1,10 @@
+---
+dependencies:
+  - role: apt-repos
+    repos:
+      - repo: 'deb {{ apt_repos.chef.repo }} trusty main'
+        key_url: '{{ apt_repos.chef.key_url }}'
+    when: os == 'ubuntu'
+  - role: repos
+    repo: chef
+    when: os == 'rhel'

--- a/roles/inspec/tasks/main.yml
+++ b/roles/inspec/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: install inspec
+  package: name=inspec
+
+- name: ensure inspec directory exists
+  file:
+    dest: "{{ item }}"
+    state: directory
+    owner: root
+    mode: 0755
+  with_items:
+    - /etc/inspec
+    - /etc/inspec/controls
+    - /etc/inspec/libraries
+
+- name: inspec config file
+  template:
+    src: etc/inspec/inspec.yml
+    dest: /etc/inspec/inspec.yml
+    mode: 0644
+
+- name: inspec sensu hook
+  sensu_check: name=inspec-check plugin=check-inspec.rb
+               args='--controls /etc/inspec/controls' use_sudo=true
+               interval={{ inspec.interval }}
+  notify: restart sensu-client
+  when: inspec.enabled|default(True)|bool

--- a/roles/inspec/templates/etc/inspec/inspec.yml
+++ b/roles/inspec/templates/etc/inspec/inspec.yml
@@ -1,0 +1,8 @@
+name: Ursula
+title: Compliance Audit
+maintainer: Ursula Team
+copyright: IBM
+copyright_email:
+license: All Rights Reserved
+summary: An InSpec Compliance Profile
+version: 0.1.0

--- a/roles/repos/defaults/main.yml
+++ b/roles/repos/defaults/main.yml
@@ -61,3 +61,7 @@ yum_repos:
     description: Filebeat repo
     gpgcheck: yes
     key_url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+  chef:
+    repo: https://packages.chef.io/repos/yum/stable/el/7/x86_64/
+    gpgcheck: yes
+    key_url: https://downloads.chef.io/packages-chef-io-public.key

--- a/roles/sensu-check/defaults/main.yml
+++ b/roles/sensu-check/defaults/main.yml
@@ -146,3 +146,10 @@ sensu_checks:
       standalone: true
       command: "sudo check-serverspec.rb -d /etc/serverspec -s warning"
       service_owner: openstack
+    check_inspec:
+      interval: 600
+      handler: default
+      standalone: true
+      command: "sudo check-inspec.rb --control /etc/inspec/controls"
+      service_owner: openstack
+

--- a/site.yml
+++ b/site.yml
@@ -32,6 +32,9 @@
     - role: serverspec
       tags: ['common', 'serverspec']
       when: serverspec.enabled|default("False")|bool
+    - role: inspec
+      tags: ['common', 'inspec']
+      when: inspec.enabled|default("False")|bool
     - role: logging
       tags: ['common', 'logging']
       when: logging.enabled|default("True")|bool


### PR DESCRIPTION
Inspec is a testinf framework for compliance and policy requirements. It will
replace sererspec eventually. As of now it will test rhel stigs.