### PR TITLE
Refer image by name instead of id in ci.

### DIFF
--- a/envs/example/ci-full-centos/heat_stack.yml
+++ b/envs/example/ci-full-centos/heat_stack.yml
@@ -8,7 +8,7 @@ parameters:
   image:
     type: string
     description: Name of image to use for servers
-    default: c71af5ba-7992-41c9-82d3-ce24c905ed42
+    default: centos7
   flavor:
     type: string
     description: Flavor to use for servers


### PR DESCRIPTION
Updated ci-full-centos heat.yml to reference image by it's name instead of uuid.