### PR TITLE
Add parameters to fix concurrent Centos PR issue

### DIFF
--- a/test/common
+++ b/test/common
@@ -56,6 +56,15 @@ SSH_ARGS=\
 " -i ${KEY_PATH}"
 export ANSIBLE_SSH_ARGS="${SSH_ARGS}"
 
+export SECURITYGROUP_NAME="${testenv_instance_prefix}_ursula"
+export CONTROLLER_0_NAME="${testenv_instance_prefix}-controller-0"
+export CONTROLLER_1_NAME="${testenv_instance_prefix}-controller-1"
+export COMPUTE_0_NAME="${testenv_instance_prefix}-compute-0"
+if [[ $TEST_ENV == "ci-full-centos" ]]; then
+    EXTRA_HEAT_PARAMS="image=${IMAGE_ID};key_name=${KEY_NAME};security_group=${SECURITYGROUP_NAME};controller-0_name=${CONTROLLER_0_NAME};controller-1_name=${CONTROLLER_1_NAME};compute-0_name=${COMPUTE_0_NAME}"
+else
+    EXTRA_HEAT_PARAMS="image=${IMAGE_ID}"
+fi
 
 die() {
   echo "[ERROR] $*"; exit 1

--- a/test/setup
+++ b/test/setup
@@ -73,7 +73,7 @@ eof
 
 echo "booting ${VMS} by heat, then copy files for pre-deployment"
 #sleep 30
-extra_args="--ursula-debug --provisioner=heat --heat-stack-name=${testenv_heat_stack_name} --ursula-user=${LOGIN_USER} --heat-parameters image=${IMAGE_ID}  ${EXTRA_HEAT_PARAMS}"
+extra_args="--ursula-debug --provisioner=heat --heat-stack-name=${testenv_heat_stack_name} --ursula-user=${LOGIN_USER} --heat-parameters ${EXTRA_HEAT_PARAMS}"
 ursula ${extra_args} "envs/test" ${ROOT}/playbooks/${TEST_ENV}/tasks/pre-deploy.yml -u ${LOGIN_USER} "$@" -vvvv
 
 if [[ ${TEST_ENV} == "ci-allinone" ]]; then


### PR DESCRIPTION
According to Paul/Nikki/Niraj's suggestion, I switched another approach: use parameters for key/etc when calling ursula to create heat stack.

//I deleted playbooks/ci-full-centos/templates/heat_stack.yml, and moved envs/example/ci-full-centos/heat_stack.yml to playbooks/ci-full-centos/templates/, then add {{ ansible_env.testenv_instance_prefix }} into the heat_stack.yml (like ci-full does), now no key exists issue is shown.. (Job #111 and #113 are running concurrently)