### PR TITLE
Reference image by id in ci heat template.

### DIFF
--- a/envs/example/ci-full-centos/heat_stack.yml
+++ b/envs/example/ci-full-centos/heat_stack.yml
@@ -8,7 +8,7 @@ parameters:
   image:
     type: string
     description: Name of image to use for servers
-    default: centos7
+    default: 11760201-107c-4387-a54f-ec738533d71f
   flavor:
     type: string
     description: Flavor to use for servers


### PR DESCRIPTION
Instead of using image name use image id to ensure correct image is being used by CI runs.