### PR TITLE
Add Remote rsyslog Forwarding for 3.1.x

### DIFF
--- a/roles/logging/defaults/main.yml
+++ b/roles/logging/defaults/main.yml
@@ -13,6 +13,40 @@ logging:
           - /var/log/syslog
         fields:
           type: syslog
+  syslog_forwarding:
+    enabled: false
+    # selector is a list of facilities and their priorities
+    selector: auth,authpriv.*,local6.*
+    work_directory: /var/spool/rsyslog
+    config_vars:
+      - name: ActionResumeRetryCount
+        value: -1
+      - name: ActionResumeInterval
+        value: 10
+      - name: ActionQueueType
+        value: LinkedList
+      - name: ActionQueueFileName
+        value: auth_authpriv_audit_0
+      - name: ActionQueueMaxDiskSpace
+        value: 1m
+      - name: ActionQueueLowWaterMark
+        value: 500
+      - name: ActionQueueHighWaterMark
+        value: 10000
+      - name: ActionQueueTimeoutEnqueue
+        value: 0
+      - name: ActionQueueSaveOnShutdown
+        value: on
+      - name: ActionQueueSize
+        value: 10000
+      - name: ActionQueueDiscardMark
+        value: 9750
+      - name: ActionQueueDiscardSeverity
+        value: 8
+      - name: ActionQueueCheckpointInterval
+        value: 100
+    host: null
+    port: 514
   forward:
     host: null
     port: 4560

--- a/roles/logging/tasks/main.yml
+++ b/roles/logging/tasks/main.yml
@@ -63,3 +63,11 @@
 
 - name: start and enable logstash-forwarder service
   service: name=logstash-forwarder state=started enabled=yes
+
+- name: configure remote syslog forwarding
+  template:
+      src: etc/rsyslog.d/60-remote-syslog.conf
+      dest: /etc/rsyslog.d
+      mode: 0640
+  notify: restart rsyslog
+  when: logging.syslog_forwarding.enabled

--- a/roles/logging/templates/etc/rsyslog.d/60-remote-syslog.conf
+++ b/roles/logging/templates/etc/rsyslog.d/60-remote-syslog.conf
@@ -1,0 +1,7 @@
+$WorkDirectory {{ logging.syslog_forwarding.work_directory }}
+
+{% for action_var in logging.syslog_forwarding.config_vars %}
+${{ action_var.name}} {{ action_var.value }}
+{% endfor %}
+
+{{ logging.syslog_forwarding.selector }} @@{{ logging.syslog_forwarding.host }}:{{ logging.syslog_forwarding.port }}


### PR DESCRIPTION
This allows configuration of rsyslog to forward events
to a remote host.