### PR TITLE
rhel related monitoring change

### DIFF
--- a/roles/cinder-control/tasks/monitoring.yml
+++ b/roles/cinder-control/tasks/monitoring.yml
@@ -1,11 +1,19 @@
 ---
-- name: cinder-api process check
-  sensu_process_check: service=cinder-api
+- name: cinder control process check installation for non-distro installation
+  sensu_process_check: service={{ item }}
+  with_items:
+    - cinder-api
+    - cinder-scheduler
   notify: restart sensu-client
-
-- name: cinder-scheduler process check
-  sensu_process_check: service=cinder-scheduler
+  when: openstack_install_method != 'distro'
+ 
+- name: cinder control process check installation for non-distro installation
+  sensu_process_check: service={{ item }}
+  with_items:
+    - openstack-cinder-api
+    - openstack-cinder-scheduler
   notify: restart sensu-client
+  when: openstack_install_method == 'distro' and os == 'rhel'
 
 - name: cinder services check
   sensu_check: name=check-cinder-services plugin=check-cinder-services.sh

--- a/roles/cinder-data/tasks/monitoring.yml
+++ b/roles/cinder-data/tasks/monitoring.yml
@@ -3,6 +3,12 @@
 - name: cinder-volume process check
   sensu_process_check: service=cinder-volume
   notify: restart sensu-client
+  when: openstack_install_method != 'distro'
+  
+- name: cinder-volume process check
+  sensu_process_check: service=openstack-cinder-volume
+  notify: restart sensu-client
+  when: openstack_install_method == 'distro' and os == 'rhel'
 
 - name: iscsid process check
   sensu_process_check: service=iscsid
@@ -29,4 +35,9 @@
 - name: cinder-backup process check
   sensu_process_check: service=cinder-backup
   notify: restart sensu-client
-  when: swift.enabled|default("False")|bool
+  when: swift.enabled|default("False")|bool and openstack_install_method != 'distro'
+  
+- name: cinder-backup process check
+  sensu_process_check: service=openstack-cinder-backup
+  notify: restart sensu-client
+  when: swift.enabled|default("False")|bool and openstack_install_method == 'distro' and os == 'rhel'

--- a/roles/common/tasks/monitoring.yml
+++ b/roles/common/tasks/monitoring.yml
@@ -61,7 +61,7 @@
 
 - name: ensure PATH contains /usr/local/bin (OpenStack clients)
   lineinfile: dest=/etc/default/sensu regexp=^PATH
-              line="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/etc/sensu/plugins"
+              line="PATH=/opt/sensu/embedded/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/etc/sensu/plugins"
   notify: restart sensu-client
 
 - name: sensu client config

--- a/roles/common/templates/monitoring/config.json
+++ b/roles/common/templates/monitoring/config.json
@@ -6,7 +6,11 @@
       "openstack"
     ],
     "keepalive": {
-      "handler": "{{ monitoring.keepalive.handler }}"
+      "handler": "{{ monitoring.keepalive.handler }}",
+      "thresholds": {
+        "warning": {{ monitoring.keepalive.thresholds.warning }},
+        "critical": {{ monitoring.keepalive.thresholds.critical }}
+      }
     }
   },
   "rabbitmq": {

--- a/roles/glance/tasks/monitoring.yml
+++ b/roles/glance/tasks/monitoring.yml
@@ -1,11 +1,19 @@
 ---
-- name: glance-api process check
-  sensu_process_check: service=glance-api
+- name: glance process check installation for non-distro installation
+  sensu_process_check: service={{ item }}
+  with_items:
+    - glance-api
+    - glance-registry
   notify: restart sensu-client
-
-- name: glance-registry process check
-  sensu_process_check: service=glance-registry
+  when: openstack_install_method != 'distro'
+  
+- name: glance process check installation for non-distro installation
+  sensu_process_check: service={{ item }}
+  with_items:
+    - openstack-glance-api
+    - openstack-glance-registry
   notify: restart sensu-client
+  when: openstack_install_method == 'distro' and os == 'rhel'
 
 - name: glance-api check
   sensu_check: name=check-glance-api plugin=check-os-api.rb

--- a/roles/heat/tasks/monitoring.yml
+++ b/roles/heat/tasks/monitoring.yml
@@ -1,15 +1,21 @@
 ---
-- name: heat-api process check
-  sensu_process_check: service=heat-api
+- name: heat process check installation for non-distro installation
+  sensu_process_check: service={{ item }}
+  with_items:
+    - heat-api
+    - heat-api-cfn
+    - heat-engine
   notify: restart sensu-client
-
-- name: heat-api-cfn process check
-  sensu_process_check: service=heat-api-cfn
+  when: openstack_install_method != 'distro'
+  
+- name: heat process check installation for non-distro installation
+  sensu_process_check: service={{ item }}
+  with_items:
+    - openstack-heat-api
+    - openstack-heat-api-cfn
+    - openstack-heat-engine
   notify: restart sensu-client
-
-- name: heat-engine process check
-  sensu_process_check: service=heat-engine
-  notify: restart sensu-client
+  when: openstack_install_method == 'distro' and os == 'rhel'
 
 - name: heat-api check
   sensu_check: name=check-heat-api plugin=check-os-api.rb

--- a/roles/monitoring-common/defaults/main.yml
+++ b/roles/monitoring-common/defaults/main.yml
@@ -38,3 +38,8 @@ monitoring:
     vhost: /sensu
   check_handler: pagerduty
   metrics_handler: graphite
+  keepalive:
+    handler: default
+    thresholds:
+      warning: 40
+      critical: 60

--- a/roles/neutron-control/meta/main.yml
+++ b/roles/neutron-control/meta/main.yml
@@ -3,5 +3,6 @@ dependencies:
   - role: openstack-database
     database_name: neutron
   - role: neutron-common
+  - role: sensu-check
   - role: collectd-plugin
     when: collectd is defined and collectd.enabled|bool

--- a/roles/neutron-control/tasks/monitoring.yml
+++ b/roles/neutron-control/tasks/monitoring.yml
@@ -29,3 +29,25 @@
         groups['controller'][0] not in groups['compute']) or
         neutron.lbaas.enabled|bool
   notify: restart sensu-client
+  
+- name: neutron agents check
+  sensu_check_dict:
+    name: "check-neutron-agents"
+    check: "{{ sensu_checks.neutron.check_neutron_agents }}"
+  notify: restart sensu-client missing ok
+
+- name: neutron agents duplicate check
+  sensu_check_dict:
+    name: "check-neutron-agents-duplicate"
+    check: "{{ sensu_checks.neutron.check_neutron_agents_duplicate }}"
+  notify: restart sensu-client missing ok
+
+- name: template neutron l3 router script for ucarp
+  template: src=check-neutron-l3-routers.sh mode=0755 owner=root group=root
+            dest=/etc/sensu/plugins/check-neutron-l3-routers.sh
+
+- name: neutron router check multiple l3 agents active or all standby status
+  sensu_check_dict:
+    name: "check-neutron-l3-routers"
+    check: "{{ sensu_checks.neutron.check_neutron_l3_routers }}"
+  notify: restart sensu-client missing ok

--- a/roles/neutron-control/templates/check-neutron-l3-routers.sh
+++ b/roles/neutron-control/templates/check-neutron-l3-routers.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# check neutron l3 agents on routers
+# only run on node with the floating ip
+
+if ifconfig | grep {{ undercloud_floating_ip | default(floating_ip) }} > /dev/null 2>&1; then
+  /etc/sensu/plugins/check-neutron-l3-routers.py -r {{ sensu_checks.neutron.check_neutron_l3_routers.max_routers }}
+fi;

--- a/roles/neutron-data/tasks/monitoring.yml
+++ b/roles/neutron-data/tasks/monitoring.yml
@@ -1,12 +1,2 @@
 ---
-- name: neutron agents check
-  sensu_check_dict:
-    name: "check-neutron-agents"
-    check: "{{ sensu_checks.neutron.check_neutron_agents }}"
-  notify: restart sensu-client missing ok
 
-- name: neutron agents duplicate check
-  sensu_check_dict:
-    name: "check-neutron-agents-duplicate"
-    check: "{{ sensu_checks.neutron.check_neutron_agents_duplicate }}"
-  notify: restart sensu-client missing ok

--- a/roles/nova-control/tasks/monitoring.yml
+++ b/roles/nova-control/tasks/monitoring.yml
@@ -14,10 +14,26 @@
     - nova-consoleauth
     - nova-scheduler
   notify: restart sensu-client
+  when: openstack_install_method != 'distro'
+  
+- name: nova process checks
+  sensu_process_check: service={{ item }}
+  with_items:
+    - openstack-nova-conductor
+    - openstack-nova-consoleauth
+    - openstack-nova-scheduler
+  notify: restart sensu-client
+  when: openstack_install_method == 'distro' and os == 'rhel'
 
 - name: nova-api process checks
   sensu_process_check: service=nova-api warn_over=20 crit_over=30
   notify: restart sensu-client
+  when: openstack_install_method != 'distro'
+  
+- name: nova-api process checks
+  sensu_process_check: service=openstack-nova-api warn_over=20 crit_over=30
+  notify: restart sensu-client
+  when: openstack_install_method == 'distro' and os == 'rhel'
 
 - name: nova-api check
   sensu_check: name=check-nova-api plugin=check-os-api.rb

--- a/roles/nova-data/tasks/monitoring.yml
+++ b/roles/nova-data/tasks/monitoring.yml
@@ -3,6 +3,12 @@
 - name: compute process check
   sensu_process_check: service=nova-compute
   notify: restart sensu-client
+  when: openstack_install_method != 'distro'
+  
+- name: compute process check
+  sensu_process_check: service=openstack-nova-compute
+  notify: restart sensu-client
+  when: openstack_install_method == 'distro' and os == 'rhel'
 
 - name: neutron linuxbridge agent check
   sensu_process_check: service=neutron-linuxbridge-agent

--- a/roles/sensu-check/defaults/main.yml
+++ b/roles/sensu-check/defaults/main.yml
@@ -87,6 +87,16 @@ sensu_checks:
       command: check-neutron-agents-duplicate.py --criticality critical
       service_owner: openstack
       dependencies: []
+    check_neutron_l3_routers:
+      handler: default
+      notification: "neutron router check multiple l3 agents active or all standby status"
+      occurrences: 1
+      interval: 600
+      max_routers: 100
+      standalone: true
+      command: check-neutron-l3-routers.sh
+      service_owner: openstack
+      dependencies: []
 
   nova:
     check_nova_services:


### PR DESCRIPTION
1. as https://github.com/blueboxgroup/ursula-monitoring/pull/120  sam cooper's suggestion,  I move the ruby path from sensu-plugin to sensu user's path.

2.  will add rhel related monitoring change after https://github.com/blueboxgroup/ursula/pull/2363 merged.
-- openstack_install_method == distro, no need to add external sensu repo;
-- openstack_install_method == distro,  use /etc/sysconfig/sensu to replace /etc/default/sensu
-- openstack_install_method == distro, change openstack related service's process monitoring, like nova-api change to openstack-nova-api