### PR TITLE
bump qemu_kvm, libvirt_bin and librdb1 version.

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -24,10 +24,10 @@ nova:
   vnc_keymap: en-us
   scheduler_default_filters: RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,CoreFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,AggregateInstanceExtraSpecsFilter,NUMATopologyFilter
   scheduler_host_subset_size: 1
-  libvirt_bin_version: 1.3.1-1ubuntu10.5~cloud0
+  libvirt_bin_version: 1.3.1-1ubuntu10.6~cloud0
   python_libvirt_version: 1.3.1-1ubuntu1~cloud0
-  qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.30
-  librdb1_version: 10.2.2-0ubuntu0.16.04.2~cloud0
+  qemu_kvm_version: 1:2.5+dfsg-5ubuntu10.5~cloud0
+  librdb1_version: 10.2.3-0ubuntu0.16.04.2~cloud0
   qemu_system_package: qemu-system-x86
   glance_endpoint: http://{{ endpoints.main }}:9393
   reserved_host_disk_mb: 51200


### PR DESCRIPTION
Adjust our defaults to catch-up with Canonical bumping some packages on 1/7/2017 (qemu-kvm, libvirt_bin, and librbd1)