### PR TITLE
Remove ldap enabled from ci envs.

### DIFF
--- a/envs/example/ci-full-centos/group_vars/all.yml
+++ b/envs/example/ci-full-centos/group_vars/all.yml
@@ -16,9 +16,6 @@ neutron:
     enabled: False
 
 keystone:
-  ldap_domain:
-    enabled: True
-    domain: users
   uwsgi:
     method: port
 

--- a/envs/example/ci-full-rhel/group_vars/all.yml
+++ b/envs/example/ci-full-rhel/group_vars/all.yml
@@ -51,9 +51,6 @@ haproxy:
   stats_group: root
 
 keystone:
-  ldap_domain:
-    enabled: True
-    domain: users
   uwsgi:
     method: port
 


### PR DESCRIPTION
Removing keystone.ldap.enabled from ci envs as it is not applicable to our CI environment.