### PR TITLE
Support plugin for IPMI sensors checks

### DIFF
--- a/roles/common/tasks/monitoring.yml
+++ b/roles/common/tasks/monitoring.yml
@@ -241,6 +241,12 @@
   notify: restart sensu-client missing ok
   when: common.hwraid.enabled|bool
 
+- name: check IPMI sensors
+  sensu_check: name=check-ipmi-sensors plugin=check-ipmi-sensors.py
+               args="--criticality {{ monitoring.ipmi_checks.criticality }}" use_sudo=True
+  when: monitoring.ipmi_checks.enabled|default(False)|bool
+  notify: restart sensu-client
+
 - block:
     - name: install snmp package on controllers
       apt:

--- a/roles/common/templates/monitoring/sensu-sudoers
+++ b/roles/common/templates/monitoring/sensu-sudoers
@@ -24,3 +24,4 @@ sensu ALL= NOPASSWD: /etc/sensu/plugins/check-ceph-usage.rb
 sensu ALL= NOPASSWD: /etc/sensu/plugins/metrics-os-api.py
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check-serverspec.rb
 sensu ALL= NOPASSWD: /etc/sensu/plugins/metrics-ceph.py
+sensu ALL= NOPASSWD: /etc/sensu/plugins/check-ipmi-sensors.py

--- a/roles/monitoring-common/defaults/main.yml
+++ b/roles/monitoring-common/defaults/main.yml
@@ -27,6 +27,9 @@ monitoring:
           critical: 80
     gems:
       - sys-filesystem
+  ipmi_checks:
+    enabled: False
+    criticality: 'critical'
   graphite:
     cluster_prefix: "stats.bbc.{{ stack_env }}.openstack"
     host_prefix: "stats.bbc.{{ stack_env }}.{{ ansible_nodename|regex_replace('\\\\.*$', '') }}"


### PR DESCRIPTION
Changes in monitoring task and sensu-sudoers to enable IPMI sensor check plug-in https://github.com/blueboxgroup/ursula-monitoring/pull/124

When monitoring.ipmi_checks not defined in env, the check will be skipped.

Running ipmitool requires root privilege thus additional entry in sensu-sudoers is required.