### PR TITLE
pin six version to 1.10.0 for shade

### DIFF
--- a/roles/common/tasks/python.yml
+++ b/roles/common/tasks/python.yml
@@ -73,6 +73,7 @@
   pip:
     name: "{{ item }}"
   with_items:
+    - six>=1.10.0
     - shade>=1.9.0
   register: result
   until: result|succeeded


### PR DESCRIPTION
Higher six version is breaking our python setup for shade. We need to pin it to 1.10.0