### PR TITLE
Add index-url and extra-index-url for installing swifttool

### DIFF
--- a/roles/swift-common/tasks/main.yml
+++ b/roles/swift-common/tasks/main.yml
@@ -42,7 +42,7 @@
   pip:
     name: swifttool
     version: "{{ swift.swifttool_version }}"
-    extra_args: "-i {{ swift.swifttool_pypi_mirror | default(omit) }}"
+    extra_args: "-i {{ openstack.pypi_mirror }} --extra-index-url {{ swift.swifttool_pypi_mirror | default(omit) }}"
     virtualenv: "{{ swift.venv_dir }}"
   register: result
   until: result|success
@@ -113,4 +113,3 @@
   tags:
     - serverspec
   when: serverspec.enabled|default('False')|bool
-


### PR DESCRIPTION
https://pypi.python.org/simple/ should still be used for `-i`,
which is needed to install dependencies. 

`--extra-index-url` should point to the swifttool index. 