### PR TITLE
Fix ceph package conflicts on controller and compute nodes.

### DIFF
--- a/roles/ceph-common/meta/main.yml
+++ b/roles/ceph-common/meta/main.yml
@@ -10,3 +10,4 @@ dependencies:
     repos:
       - repo: 'deb {{ apt_repos.ceph.repo }} {{ ansible_lsb.codename }} main'
         key_url: '{{ apt_repos.ceph.key_url }}'
+    when: ('ceph_monitors' in group_names) or ('ceph_osds' in group_names)

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -1,44 +1,48 @@
 ---
 # run once for each host
 - include: upgrade_flags.yml
-  when: ceph_upgrade_flag_done is undefined
-  tags: ['openstack', 'cinder', 'control', 'data', 'cinder-data', 'glance', 'ceph-update']
+  when: 
+    - ceph_upgrade_flag_done is undefined
+    - ('ceph_monitors' in group_names) or ('ceph_osds' in group_names)
+  tags: ['openstack', 'cinder', 'control', 'data', 'nova-data', 'cinder-data', 'glance', 'ceph-update']
 
 - name: create ceph directory
   file:
     path: /etc/ceph
     state: directory
+- block:
+  - name: create ceph log directory
+    file: dest=/var/log/ceph state=directory mode=2750 owner=root group=adm
 
-- name: create ceph log directory
-  file: dest=/var/log/ceph state=directory mode=2750 owner=root group=adm
+  - name: Change ceph log dir acl
+    acl: name=/var/log/ceph state=present default=yes etype={{ item.etype }} permissions={{ item.permission }}
+    with_items:
+      - etype: user
+        permission: rw
+      - etype: group
+        permission: r
+      - etype: other
+        permission: r
 
-- name: Change ceph log dir acl
-  acl: name=/var/log/ceph state=present default=yes etype={{ item.etype }} permissions={{ item.permission }}
-  with_items:
-    - etype: user
-      permission: rw
-    - etype: group
-      permission: r
-    - etype: other
-      permission: r
 
-- name: install dependencies
-  apt: pkg={{ item }}
-       state=present
-       update_cache=yes
-       cache_valid_time=3600
-  with_items: "{{ ceph.debian_pkgs }}"
-  register: result
-  until: result|succeeded
-  retries: 5
+  - name: install dependencies
+    apt: pkg={{ item }}
+         state=present
+         update_cache=yes
+         cache_valid_time=3600
+    with_items: "{{ ceph.debian_pkgs }}"
+    register: result
+    until: result|succeeded
+    retries: 5
 
-- name: install ceph
-  apt: pkg={{ item }}={{ ceph.version }}
-       state=present
-  with_items: "{{ ceph.ceph_pkgs }}"
-  register: result
-  until: result|succeeded
-  retries: 5
+  - name: install ceph
+    apt: pkg={{ item }}={{ ceph.version }}
+         state=present
+    with_items: "{{ ceph.ceph_pkgs }}"
+    register: result
+    until: result|succeeded
+    retries: 5
+  when: ('ceph_monitors' in group_names) or ('ceph_osds' in group_names)
 
 - name: check for a ceph socket
   shell: "stat /var/run/ceph/*.asok > /dev/null 2>&1"
@@ -96,14 +100,16 @@
     - restart ceph mons
     - restart ceph osds
 
-- include: logging.yml
-  tags:
-    - logrotate
-    - logging
-  when: logging.enabled|default('True')|bool
+- block:
+  - include: logging.yml
+    tags:
+      - logrotate
+      - logging
+    when: logging.enabled|default('True')|bool
 
-- include: serverspec.yml
-  tags: 
-    - serverspec
-  when: serverspec.enabled|default('False')|bool
-
+  - include: serverspec.yml
+    tags: 
+      - serverspec
+    when: serverspec.enabled|default('False')|bool
+  when: ('ceph_monitors' in group_names) or ('ceph_osds' in group_names)
+  

--- a/roles/ceph-common/tasks/upgrade_flags.yml
+++ b/roles/ceph-common/tasks/upgrade_flags.yml
@@ -37,19 +37,21 @@
   when: result_ceph_running_version is defined and result_ceph_running_version.rc == 0 and
         result_ceph_running_version.stdout < '10'
 
-- name: set upgrade_ceph=true
-  set_fact:
-    upgrade_ceph: true
-  when: result_ceph_running_version is defined and result_ceph_running_version.rc == 0 and
-        result_ceph_running_version.stdout < ceph_pure_version
-
-# set upgrade flag for controller and cinder_volume
-- name: set upgrade flag for controller and cinder_volume
-  set_fact:
-    upgrade_ceph: true
-  register: result_upgrade_ceph_controller
-  when: ('controller' in group_names or 'cinder_volume' in group_names) and
-        (result_ceph_installed_version.rc == 0 and result_ceph_installed_version.stdout < ceph_pure_version)
+#FIXME need to enable this check whenever we move up our ceph version from 10.2.3
+#- name: set upgrade_ceph=true
+#  set_fact:
+#    upgrade_ceph: true
+#  when: result_ceph_running_version is defined and result_ceph_running_version.rc == 0 and
+#        result_ceph_running_version.stdout < ceph_pure_version
+#
+## set upgrade flag for controller and cinder_volume
+#- name: set upgrade flag for controller and cinder_volume
+#  set_fact:
+#    upgrade_ceph: true
+#  register: result_upgrade_ceph_controller
+#  when: ('controller' in group_names or 'cinder_volume' in group_names) and
+#        (result_ceph_installed_version.rc == 0 and result_ceph_installed_version.stdout < ceph_pure_version)
+#
 
 - name: set flag so that this yml will not exected on the same host
   set_fact:

--- a/roles/cinder-common/meta/main.yml
+++ b/roles/cinder-common/meta/main.yml
@@ -1,6 +1,10 @@
 ---
 dependencies:
   - role: endpoints
+  - role: apt-repos
+    repos:
+      - repo: 'deb {{ apt_repos.cloud_archive.repo }} {{ ansible_distribution_release }}-updates/mitaka main'
+        key_package: ubuntu-cloud-keyring
   - role: monitoring-common
     when: monitoring.enabled|default(True)|bool
   - role: logging-config

--- a/roles/cinder-common/tasks/ceph_integration.yml
+++ b/roles/cinder-common/tasks/ceph_integration.yml
@@ -1,4 +1,13 @@
 ---
+- name: Install ceph-common
+  apt: pkg={{ item }} state=latest
+  with_items:
+    - ceph-common
+  register: result
+  until: result|succeeded
+  retries: 5
+  notify: restart cinder services
+
 - name: import rados and rbd modules into cinder
   file:
     src: /usr/lib/python2.7/dist-packages/{{ item }}
@@ -8,8 +17,8 @@
     group: root
     mode: 0644
   with_items:
-    - rados.so
-    - rbd.so
+    - rados.x86_64-linux-gnu.so
+    - rbd.x86_64-linux-gnu.so
 
 - name: remove modules those were used for Hammer
   file:
@@ -20,6 +29,8 @@
     - rados.pyc
     - rbd.py
     - rbd.pyc
+    - rados.so
+    - rbd.so
 
 - name: fetch cinder keyring
   slurp: path=/etc/ceph/ceph.client.cinder.keyring

--- a/roles/cinder-control/tasks/main.yml
+++ b/roles/cinder-control/tasks/main.yml
@@ -22,8 +22,7 @@
     msg: "Triggering service restart for upgrade"
   changed_when: True
   notify: restart cinder services
-  when: (code_has_changed | default('False') | bool and upgrade | default('False') | bool) or
-        (ceph.enabled|default('False')|bool and upgrade_ceph | bool)
+  when: (code_has_changed | default('False') | bool and upgrade | default('False') | bool)
 
 - meta: flush_handlers
 

--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -65,7 +65,7 @@
     - restart cinder services
     - restart cinder backup service
   when: (code_has_changed | default('False') | bool and upgrade | default('False') | bool) or
-        (ceph.enabled|default('False')|bool and upgrade_ceph|bool)
+        (ceph.enabled|default('False')|bool and upgrade_ceph | default('False') | bool)
 
 - meta: flush_handlers
 

--- a/roles/glance/meta/main.yml
+++ b/roles/glance/meta/main.yml
@@ -1,6 +1,10 @@
 ---
 dependencies:
   - role: endpoints
+  - role: apt-repos
+    repos:
+      - repo: 'deb {{ apt_repos.cloud_archive.repo }} {{ ansible_distribution_release }}-updates/mitaka main'
+        key_package: ubuntu-cloud-keyring
   - role: monitoring-common
     when: monitoring.enabled|default(True)|bool
   - role: logging-config

--- a/roles/glance/tasks/ceph_integration.yml
+++ b/roles/glance/tasks/ceph_integration.yml
@@ -1,4 +1,13 @@
 ---
+- name: Install ceph-common
+  apt: pkg={{ item }} state=latest
+  with_items:
+    - ceph-common
+  register: result
+  until: result|succeeded
+  retries: 5
+  notify: restart glance services
+
 - name: import rados module into glance
   file:
     src: /usr/lib/python2.7/dist-packages/{{ item }}
@@ -8,8 +17,8 @@
     group: root
     mode: 0644
   with_items:
-    - rados.so
-    - rbd.so
+    - rados.x86_64-linux-gnu.so
+    - rbd.x86_64-linux-gnu.so
 
 - name: remove modules those were used for Hammer
   file:
@@ -20,6 +29,8 @@
     - rados.pyc
     - rbd.py
     - rbd.pyc
+    - rados.so
+    - rbd.so
 
 - name: fetch glance keyring
   slurp: path=/etc/ceph/ceph.client.glance.keyring

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -91,8 +91,7 @@
     msg: "Triggering service restart for upgrade"
   changed_when: True
   notify: restart glance services
-  when: (code_has_changed | default('False') | bool and upgrade | default('False') | bool) or
-        (glance.store_ceph | default('False') | bool and upgrade_ceph | bool)
+  when: (code_has_changed | default('False') | bool and upgrade | default('False') | bool)
 
 - meta: flush_handlers
 
@@ -118,6 +117,6 @@
   when: logging.enabled|default('True')|bool
 
 - include: serverspec.yml
-  tags: 
+  tags:
     - serverspec
   when: serverspec.enabled|default('False')|bool

--- a/roles/nova-data/tasks/monitoring.yml
+++ b/roles/nova-data/tasks/monitoring.yml
@@ -13,4 +13,4 @@
   sensu_metrics_check: name=check-cinder-sessions plugin=check-cinder-sessions.py
                        interval=10
   notify: restart sensu-client
-  when: not ceph.enabled|default('False')|bool or (not ceph_pools.rbd_ssd.enabled and not ceph_pools.rbd_hybrid.enabled)
+  when: not ceph.enabled|default('False')|bool

--- a/roles/preflight-checks/tasks/main.yml
+++ b/roles/preflight-checks/tasks/main.yml
@@ -19,6 +19,14 @@
   run_once: true
 
 - block:
+  #To ensure ceph-common is installed from cloud archive repo and not bbc ceph repo
+  - name: remove ceph repo from controllers and computes
+    apt_repository:
+      repo: 'deb {{ apt_repos.ceph.repo }} {{ ansible_lsb.codename }} main'
+      state: absent
+      update_cache: yes
+    when: ('controller' in group_names) or ('compute' in group_names)
+
   - name: check ceph installed
     command: ceph --version
     register: result_ceph_installed


### PR DESCRIPTION
We have several topology for cloud deployments i.e converge controller, dedicated controller, with/without ceph. Currently, when ceph is enabled, ceph repo get's configured on controller and compute and ceph pkgs are installed to get ceph client, rbd and rados. This get's installed from bbc ceph repo and thus we end up with librbd1 librados2 version as 10.2.3~bbc1. 

On compute nodes, nova-data installs libvirt-bin which bring in rados and other dependencies and this is installed from cloud archive repo which is versioned as 10.2.3-0ubuntu0.16.04.2~cloud0.

This same version pkgs with name differences hosted by 2 repos is causing conflicts.

In this PR, we are ensuring that 
- no bbc ceph repo configured on controller and compute
- install librbd, librados, ceph-common from cloud archive repo
- ensure only absolutely needed ceph related tasks are run on controller and compute nodes
- clean up ceph repos from controller and compute in preflight for upgrade flows
