### PR TITLE
Remove unwanted Ceph pkgs from Controller and Compute.

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -6,9 +6,10 @@ ceph:
   #  - sdb
   #  - sdc
   #  - sdd
-  #bcache_ssd_device: sdg 
+  #bcache_ssd_device: sdg
 
   version: 10.2.3~bbc1
+  ceph_cloud_archive_version: 10.2.3-0ubuntu0.16.04.2~cloud0
 
   openstack_keys:
     - { name: client.glance, value: "mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx'" }

--- a/roles/cinder-common/tasks/ceph_integration.yml
+++ b/roles/cinder-common/tasks/ceph_integration.yml
@@ -1,8 +1,8 @@
 ---
 - name: Install ceph-common
-  apt: pkg={{ item }} state=latest
+  apt: pkg={{ item }}
   with_items:
-    - ceph-common
+    - ceph-common={{ ceph.ceph_cloud_archive_version }}
   register: result
   until: result|succeeded
   retries: 5

--- a/roles/glance/tasks/ceph_integration.yml
+++ b/roles/glance/tasks/ceph_integration.yml
@@ -1,8 +1,8 @@
 ---
 - name: Install ceph-common
-  apt: pkg={{ item }} state=latest
+  apt: pkg={{ item }}
   with_items:
-    - ceph-common
+    - ceph-common={{ ceph.ceph_cloud_archive_version }}
   register: result
   until: result|succeeded
   retries: 5

--- a/roles/preflight-checks/tasks/main.yml
+++ b/roles/preflight-checks/tasks/main.yml
@@ -43,9 +43,15 @@
   run_once: true
 
 #To ensure ceph-common is installed from cloud archive repo and not bbc ceph repo
-- name: remove ceph repo from controllers and computes
-  apt_repository:
-    repo: 'deb {{ apt_repos.ceph.repo }} {{ ansible_lsb.codename }} main'
-    state: absent
-    update_cache: yes
+- block:
+  - name: remove ceph repo from controllers and computes
+    apt_repository:
+      repo: 'deb {{ apt_repos.ceph.repo }} {{ ansible_lsb.codename }} main'
+      state: absent
+      update_cache: yes
+
+  #Remove unwanted ceph pkgs without removing dependecies to avoid impacts to libivrt
+  - name: remove unwanted ceph packages from controller and compute nodes
+    command: dpkg -P ceph ceph-osd ceph-mon ceph-mds ceph-fuse ceph-fs-common ceph-base
+
   when: ('controller' in group_names) or ('compute' in group_names)


### PR DESCRIPTION
Unbreak update path by removing unwanted ceph pkgs from controller and computes. We have to leverage dpkg -r to remove ceph, ceph-osd, ceph-mon etc without removing other dependencies and they will impact libvirt.