### PR TITLE
Add force_metadata option to dhcp_agent.ini

### DIFF
--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -32,6 +32,7 @@ neutron:
   allow_overlapping_ips: False
   api_workers: 3
   metadata_workers: 3
+  dhcp_force_metadata: True
   ha_keepalive_threads: 10
   overlay_ip_version: 4
   agent_down_time: 20

--- a/roles/neutron-common/templates/etc/neutron/dhcp_agent.ini
+++ b/roles/neutron-common/templates/etc/neutron/dhcp_agent.ini
@@ -4,7 +4,11 @@
 
 debug = {{ neutron.logging.debug }}
 
+{% if not (neutron.dhcp_force_metadata | bool) -%}
 enable_isolated_metadata = True
+{% else -%}
+force_metadata = {{ neutron.dhcp_force_metadata }}
+{% endif -%}
 
 state_path = {{ neutron.state_path }}
 

--- a/roles/neutron-common/templates/etc/neutron/dhcp_agent.ini
+++ b/roles/neutron-common/templates/etc/neutron/dhcp_agent.ini
@@ -4,10 +4,12 @@
 
 debug = {{ neutron.logging.debug }}
 
-{% if not (neutron.dhcp_force_metadata | bool) -%}
-enable_isolated_metadata = True
+{% if neutron.dhcp_force_metadata | bool -%}
+force_metadata = True
+enable_isolated_metadata = False
 {% else -%}
-force_metadata = {{ neutron.dhcp_force_metadata }}
+enable_isolated_metadata = True
+force_metadata = False
 {% endif -%}
 
 state_path = {{ neutron.state_path }}


### PR DESCRIPTION
This option forces the metadata proxy process to be created in every DHCP namespace regardless of whether or not it is a routed network, solving the problem that Perry saw in his RHOSP Newton testing.