### PR TITLE
Unbreak nova server suspend operation.

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -26,7 +26,7 @@ nova:
   scheduler_host_subset_size: 1
   libvirt_bin_version: 1.3.1-1ubuntu10.6~cloud0
   python_libvirt_version: 1.3.1-1ubuntu1~cloud0
-  qemu_kvm_version: 1:2.5+dfsg-5ubuntu10.5~cloud0
+  qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.30
   librdb1_version: 10.2.3-0ubuntu0.16.04.2~cloud0
   qemu_system_package: qemu-system-x86
   glance_endpoint: http://{{ endpoints.main }}:9393


### PR DESCRIPTION
When using qemu-kvm=1:2.5+dfsg-5ubuntu10.5~cloud0 from cloud archive repo nova server suspend action fails due to apparmor policy for libvirtd. The error message reported is:

Error: Failed to perform requested operation on instance "bbg-abcde-ds0030", the instance has an error status: Please try again later [Error: internal error: unable to execute QEMU command 'migrate': Migration disabled: failed to allocate shared memory]. 

This PR will avoid qemu-kvm version bump to cloudarchive and use one that we know is working and tested.