### PR TITLE
Add ability to post pip install after project installation

### DIFF
--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -15,6 +15,13 @@ keystone:
       distro: /usr/lib/python2.7/site-packages/keystone
       source: /opt/openstack/current/keystone
       package: /opt/openstack/current/keystone
+  distro:
+    python_post_dependencies: []
+  # Example for distro/source:
+  # python_post_dependencies:
+  #   - name: python-memcached
+  #     version: 1.58
+  #     pip_extra_args: '--extra-index-url https://pypi-mirror.openstack.blueboxgrid.com/root/pypi...'
   source:
     rev: 'stable/newton'
     constrain: True
@@ -24,6 +31,7 @@ keystone:
       - { name: uwsgi }
       - { name: pyldap }
       - { name: ldappool }
+    python_post_dependencies: []
     system_dependencies:
         ubuntu:
         - openssl

--- a/roles/keystone/meta/main.yml
+++ b/roles/keystone/meta/main.yml
@@ -14,15 +14,17 @@ dependencies:
     alternatives: "{{ keystone.alternatives }}"
     system_dependencies: "{{ keystone.source.system_dependencies }}"
     python_dependencies: "{{ keystone.source.python_dependencies }}"
+    python_post_dependencies: "{{ keystone.source.python_post_dependencies }}"
     constrain: "{{ keystone.source.constrain }}"
     upper_constraints: "{{ keystone.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package
     project_name: keystone
     alternatives: "{{ keystone.alternatives }}"
-    when: openstack_install_method == 'package' 
+    when: openstack_install_method == 'package'
   - role: openstack-distro
     project_name: keystone
+    python_post_dependencies: "{{ keystone.distro.python_post_dependencies }}"
     when: openstack_install_method == 'distro'
   - role: collectd-plugin
     when: collectd is defined and collectd.enabled|bool

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -75,6 +75,13 @@ neutron:
     service_provider: LOADBALANCERV2:Haproxy:neutron_lbaas.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default
   service:
     envs: []
+  distro:
+    python_post_dependencies: []
+  # Example for distro/source:
+  # python_post_dependencies:
+  #   - name: python-memcached
+  #     version: 1.58
+  #     pip_extra_args: '--extra-index-url https://pypi-mirror.openstack.blueboxgrid.com/root/pypi...'
   source:
     rev: 'stable/newton'
     constrain: True
@@ -82,6 +89,7 @@ neutron:
     python_dependencies:
       - { name: "git+git://github.com/openstack/neutron-lbaas.git@stable/newton#egg=neutron-lbaas" }
       - { name: PyMySQL }
+    python_post_dependencies: []
     system_dependencies:
       ubuntu: []
         #- conntrack

--- a/roles/neutron-common/meta/main.yml
+++ b/roles/neutron-common/meta/main.yml
@@ -14,6 +14,7 @@ dependencies:
     alternatives: "{{ neutron.alternatives }}"
     system_dependencies: "{{ neutron.source.system_dependencies }}"
     python_dependencies: "{{ neutron.source.python_dependencies }}"
+    python_post_dependencies: "{{ neutron.source.python_post_dependencies }}"
     constrain: "{{ neutron.source.constrain }}"
     upper_constraints: "{{ neutron.source.upper_constraints }}"
     when: openstack_install_method == 'source'
@@ -21,9 +22,10 @@ dependencies:
     project_name: neutron
     rootwrap: True
     alternatives: "{{ neutron.alternatives }}"
-    when: openstack_install_method == 'package' 
+    when: openstack_install_method == 'package'
   - role: openstack-distro
     project_name: neutron
     dependent_packages: "{{ neutron.osp_sys_packages }}"
+    python_post_dependencies: "{{ neutron.distro.python_post_dependencies }}"
     rootwrap: True
     when: openstack_install_method == 'distro'

--- a/roles/openstack-distro/defaults/main.yml
+++ b/roles/openstack-distro/defaults/main.yml
@@ -1,2 +1,4 @@
 openstack_distro:
   osp_package_name: 'openstack-{{ project_name }}'
+  python_post_dependencies: "{{ python_post_dependencies|default([]) }}"
+  pip_extra_args: ""

--- a/roles/openstack-distro/tasks/osp.yml
+++ b/roles/openstack-distro/tasks/osp.yml
@@ -16,3 +16,23 @@
   retries: 5
   with_items: "{{ dependent_packages }}"
   when: dependent_packages is defined
+
+- name: set pip args fact
+  set_fact:
+    pip_extra_args: "{{ openstack_distro.pip_extra_args|default('') }}"
+  when: openstack.pypi_mirror is defined
+
+- name: set pip proxy args
+  set_fact:
+    pip_extra_args: "{{ pip_extra_args }} -i {{ openstack.pypi_mirror }}"
+  when: openstack.pypi_mirror is defined
+
+- name: python post dependencies for project
+  pip:
+    name: "{{ item.name }}"
+    version: "{{ item.version|default(omit) }}"
+    extra_args: "{{ pip_extra_args }} {{ item.pip_extra_args|default('') }}"
+  with_items: "{{ openstack_distro.python_post_dependencies }}"
+  register: result
+  until: result|succeeded
+  retries: 5

--- a/roles/openstack-source/defaults/main.yml
+++ b/roles/openstack-source/defaults/main.yml
@@ -8,4 +8,5 @@ openstack_source:
   rootwrap: "{{ rootwrap|default(False)|bool }}"
   system_dependencies: "{{ system_dependencies|default([]) }}"
   python_dependencies: "{{ python_dependencies|default([]) }}"
+  python_post_dependencies: "{{ python_post_dependencies|default([]) }}"
   pip_extra_args: ""

--- a/roles/openstack-source/tasks/main.yml
+++ b/roles/openstack-source/tasks/main.yml
@@ -52,13 +52,13 @@
       dest: /opt/stack/constraints.txt
       force: true
     when: upper_constraints|bool
-  
+
   - name: set pip constraints args
     set_fact:
       pip_extra_args: "{{ pip_extra_args }} -c /opt/stack/constraints.txt"
 
   when: constrain | bool
-    
+
 - name: set code has changed fact
   set_fact:
     code_has_changed: True
@@ -86,6 +86,17 @@
   delay: 10
   notify:
     - update ca-certs
+
+- name: python post dependencies for project
+  pip:
+    name: "{{ item.name }}"
+    version: "{{ item.version|default(omit) }}"
+    virtualenv: "{{ openstack_source.virtualenv_base }}/{{ project_name }}"
+    extra_args: "{{ pip_extra_args }} {{ item.pip_extra_args|default('') }}"
+  with_items: "{{ openstack_source.python_post_dependencies }}"
+  register: result
+  until: result|succeeded
+  retries: 5
 
 - name: setup openstack current base path
   file:


### PR DESCRIPTION
This adds the ability to install any dependencies which need
to get pip installed after the project gets installed. This
is done for both source and distro install.