### PR TITLE
Initial drop of playbook for openstack-ansible-security and defaults

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -638,3 +638,12 @@ serverspec:
 
 inspec:
   enabled: False
+
+#openstack-ansible-security overrides
+security_enable_chrony: false
+security_ssh_permit_root_login: 'no'
+security_ssh_client_alive_count_max: 0
+security_password_minimum_length: 8
+security_password_minimum_days: 1
+security_password_maximum_days: 90
+security_password_warn_age: 7

--- a/playbooks/run-openstack-ansible-security.yml
+++ b/playbooks/run-openstack-ansible-security.yml
@@ -1,0 +1,6 @@
+---
+- name: os-hardening for all hosts
+  hosts: all:!vyatta-*
+  any_errors_fatal: true
+  roles:
+    - role: ../../openstack-ansible-security


### PR DESCRIPTION
This is an initial drop of playbook to enable use of openstack-ansible-security role.