### PR TITLE
code cleanp and enable services auto-start on reboot.

### DIFF
--- a/envs/example/ci-full-rhel/heat_stack.yml
+++ b/envs/example/ci-full-rhel/heat_stack.yml
@@ -24,11 +24,11 @@ parameters:
   key_name:
     type: string
     description: Name of the ssh keypair to use for servers
-    default: centos_key
+    default: rhel_key
   security_group:
     type: string
     description: Name of the security group to use for servers
-    default: centos_ursula
+    default: rhel_ursula
   controller-0_name:
     type: string
     description: Name of controller-0 server

--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -1,6 +1,11 @@
 ---
 project_name: cinder
 cinder:
+  services:
+    cinder_api: "{{ openstack_meta.cinder.services.cinder_api[os] }}"
+    cinder_scheduler: "{{ openstack_meta.cinder.services.cinder_scheduler[os] }}"
+    cinder_volume: "{{ openstack_meta.cinder.services.cinder_volume[os] }}"
+    cinder_backup: "{{ openstack_meta.cinder.services.cinder_backup[os] }}"
   enabled: True
   enabled_backends: [] # determined automatically by Ceph roles
   default_backend:
@@ -13,6 +18,22 @@ cinder:
   create_vg: False
   common_volume_name: True
   allow_availability_zone_fallback: True
+  data_pkgs:
+    ubuntu:
+      - cryptsetup
+      - lvm2
+      - tgt
+      - nbd-client
+      - open-iscsi
+      - qemu-utils
+    #FIXME do we need these pkgs on rhel?
+    rhel:
+      - cryptsetup
+      - lvm2
+      - targetcli
+      - nbd
+      - iscsi-initiator-utils
+      - qemu-kvm-tools
   iscsi_helper:
     ubuntu: tgtadm
     rhel: targetcli

--- a/roles/cinder-common/handlers/main.yml
+++ b/roles/cinder-common/handlers/main.yml
@@ -5,49 +5,29 @@
 # triggered each particular notification handler. Re-test with 2.0
 - name: restart cinder services
   service:
-    name: "{{ item[1] }}"
+    name: "{{ item[1].name }}"
     state: restarted
     must_exist: false
   run_once: True
   failed_when: false
   delegate_to: "{{ item[0] }}"
-  when: restart|default('True') and openstack_install_method != 'distro'
+  when: restart|default('True')
   with_nested:
     - "{{ play_hosts }}"
-    - ['cinder-api', 'cinder-scheduler', 'cinder-volume']
-
-- name: restart cinder services
-  service:
-    name: "{{ item[1] }}"
-    state: restarted
-    must_exist: false
-  run_once: True
-  failed_when: false
-  delegate_to: "{{ item[0] }}"
-  when: restart|default('True') and openstack_install_method == 'distro' 
-  with_nested:
-    - "{{ play_hosts }}"
-    - ['openstack-cinder-api', 'openstack-cinder-scheduler', 'openstack-cinder-volume']
+    - ["{{ cinder.services.cinder_api }}",
+       "{{ cinder.services.cinder_scheduler }}",
+       "{{ cinder.services.cinder_volume }}"]
 
 - name: restart cinder backup service
   service:
-    name: cinder-backup
+    name: "{{ cinder.services.cinder_backup.name }}"
     state: restarted
     must_exist: false
   run_once: True
   delegate_to: "{{ item }}"
-  when: restart|default('True') and swift.enabled|default('False') and openstack_install_method != 'distro'
-  with_items: "{{ play_hosts }}"
-  
-- name: restart cinder backup service
-  service:
-    name: openstack-cinder-backup
-    state: restarted
-    must_exist: false
-  run_once: True
-  delegate_to: "{{ item }}"
-  when: restart|default('True') and swift.enabled|default('False') and openstack_install_method == 'distro'
+  when: restart|default('True') and swift.enabled|default('False')
   with_items: "{{ play_hosts }}"
 
+# FIXME variablize by OS
 - name: restart tgt service
   service: name="{{ cinder.tgt_service[os] }}" state=restarted

--- a/roles/cinder-common/meta/main.yml
+++ b/roles/cinder-common/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: openstack-meta
   - role: endpoints
   - role: monitoring-common
     when: monitoring.enabled|default(True)|bool

--- a/roles/cinder-control/tasks/main.yml
+++ b/roles/cinder-control/tasks/main.yml
@@ -1,23 +1,43 @@
 ---
-- name: install cinder controller services
-  upstart_service: name={{ item }}
-                   user=cinder
-                   cmd=/usr/local/bin/{{ item }}
-                   config_dirs=/etc/cinder
-  when: os == 'ubuntu'
-  with_items:
-    - cinder-api
-    - cinder-scheduler
+- block:
+  - name: install cinder controller services (ubuntu)
+    upstart_service:
+      name: "{{ item.name }}"
+      user: "{{ item.user }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+    with_items:
+      - "{{ cinder.services.cinder_api }}"
+      - "{{ cinder.services.cinder_scheduler }}"
 
-- name: install cinder controller services (rhel source)
-  systemd_service: name={{ item }}
-                   user=cinder
-                   cmd=/usr/local/bin/{{ item }}
-                   config_dirs=/etc/cinder
-  when: os == 'rhel' and openstack_install_method == 'source'
-  with_items:
-    - cinder-api
-    - cinder-scheduler
+  - name: Permit access to Cinder (ubuntu)
+    ufw: rule=allow to_port={{ endpoints.cinder.port.haproxy_api }} proto=tcp
+    tags: firewall
+  when: os == 'ubuntu'
+
+- block:
+  - name: install cinder controller services (rhel)
+    systemd_service:
+      name: "{{ item.name }}"
+      description: "{{ item.desc }}"
+      type: "{{ item.type }}"
+      user: "{{ item.user }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+      config_files: "{{ item.config_files }}"
+      restart: "{{ item.restart }}"
+    with_items:
+      - "{{ cinder.services.cinder_api }}"
+      - "{{ cinder.services.cinder_scheduler }}"
+
+  - name: Permit access to Cinder (rhel)
+    firewalld:
+      state: enabled
+      permanent: true
+      immediate: true
+      port: "{{ endpoints.cinder.port.haproxy_api }}/tcp"
+    tags: firewall
+  when: os == 'rhel'
 
 - name: sync cinder database
   command: cinder-manage db sync
@@ -39,32 +59,10 @@
 - meta: flush_handlers
 
 - name: start cinder controller services
-  service: name={{ item }} state=started
+  service: name={{ item.name }} state=started enabled=true
   with_items:
-    - cinder-api
-    - cinder-scheduler
-  when: openstack_install_method != 'distro'
-
-- name: start cinder controller services (rhel osp)
-  service: name={{ item }} state=started
-  with_items:
-    - openstack-cinder-api
-    - openstack-cinder-scheduler
-  when: openstack_install_method == 'distro'
-
-- name: Permit access to Cinder
-  ufw: rule=allow to_port={{ endpoints.cinder.port.haproxy_api }} proto=tcp
-  tags: ufw
-  when: os == 'ubuntu'
-
-- name: Permit access to Cinder
-  firewalld:
-    state: enabled
-    permanent: true
-    immediate: true
-    port: "{{ endpoints.cinder.port.haproxy_api }}/tcp"
-  tags: firewall
-  when: os == 'rhel'
+    - "{{ cinder.services.cinder_api }}"
+    - "{{ cinder.services.cinder_scheduler }}"
 
 - include: monitoring.yml
   tags:

--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -1,28 +1,7 @@
 ---
 - name: install cinder-data required packages
   package: name={{ item }}
-  with_items:
-    - cryptsetup
-    - lvm2
-    - tgt
-    - nbd-client
-    - open-iscsi
-    - qemu-utils
-  when: os == 'ubuntu'
-  register: result
-  until: result|succeeded
-  retries: 5
-
-- name: install cinder-data required packages
-  package: name={{ item }}
-  when: os == 'rhel'
-  with_items:
-    - cryptsetup
-    - lvm2
-    - targetcli
-    - nbd
-    - iscsi-initiator-utils
-    - qemu-kvm-tools
+  with_items: "{{ cinder.data_pkgs[os] }}"
   register: result
   until: result|succeeded
   retries: 5
@@ -62,46 +41,58 @@
   when: cinder.fixed_key is not defined
 
 #When OS is Ubuntu
-- name: install cinder-volume service
-  upstart_service: name=cinder-volume user=cinder
-                   cmd=/usr/local/bin/cinder-volume
-                   config_dirs=/etc/cinder
+- block:
+  - name: install cinder-volume service (ubuntu)
+    upstart_service:
+      name: "{{ item.name }}"
+      user: "{{ item.user }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+    with_items:
+      - "{{ cinder.services.cinder_volume }}"
+
+  - name: install cinder backup service (ubuntu)
+    upstart_service:
+      name: "{{ item.name }}"
+      user: "{{ item.user }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+    when: swift.enabled|default("false")|bool
+    with_items:
+      - "{{ cinder.services.cinder_backup }}"
   when: os == 'ubuntu'
 
-- name: install cinder backup service
-  upstart_service: name=cinder-backup
-                   user=cinder
-                   cmd=/usr/local/bin/cinder-backup
-                   config_dirs=/etc/cinder
-  when: os == 'ubuntu' and swift.enabled|default("false")|bool
 
 #When OS is Rhel
-- name: install cinder-volume service
-  systemd_service: name=cinder-volume user=cinder
-                   cmd=/usr/local/bin/cinder-volume
-                   config_dirs=/etc/cinder
-  when: os == 'rhel' and openstack_install_method != 'distro'
+- block:
+  - name: install cinder-volume service (rhel)
+    systemd_service:
+      name: "{{ item.name }}"
+      description: "{{ item.desc }}"
+      type: "{{ item.type }}"
+      user: "{{ item.user }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+      config_files: "{{ item.config_files }}"
+      restart: "{{ item.restart }}"
+      kill_mode: "{{ item.kill_mode }}"
+    with_items:
+      - "{{ cinder.services.cinder_volume }}"
 
-- name: install cinder backup service
-  systemd_service: name=cinder-backup
-                   user=cinder
-                   cmd=/usr/local/bin/cinder-backup
-                   config_dirs=/etc/cinder
-  when: os == 'rhel' and swift.enabled|default("false")|bool and openstack_install_method !=distro
-
-- name: install cinder-volume service
-  systemd_service: name=cinder-volume user=cinder
-                   cmd=/usr/local/bin/cinder-volume
-                   config_dirs=/etc/cinder
+  - name: install cinder backup service (rhel)
+    systemd_service:
+      name: "{{ item.name }}"
+      description: "{{ item.desc }}"
+      type: "{{ item.type }}"
+      user: "{{ item.user }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+      config_files: "{{ item.config_files }}"
+      restart: "{{ item.restart }}"
+    when: swift.enabled|default("false")|bool
+    with_items:
+      - "{{ cinder.services.cinder_backup }}"
   when: os == 'rhel'
-
-- name: install cinder backup service
-  systemd_service: name=cinder-backup
-                   user=cinder
-                   cmd=/usr/local/bin/cinder-backup
-                   config_dirs=/etc/cinder
-  when: os == 'rhel' and swift.enabled|default("false")|bool
-
 
 - name: trigger restart on upgrades
   debug:
@@ -117,38 +108,21 @@
 
 - name: start cinder-volume
   service:
-    name: cinder-volume
+    name: "{{ cinder.services.cinder_volume.name }}"
     state: started
+    enabled: True
   delegate_to: "{{ item }}"
   run_once: True
   with_items: "{{ play_hosts }}"
-  when: openstack_install_method != 'distro'
-  
-- name: start cinder-volume (rhel osp)
-  service:
-    name: openstack-cinder-volume
-    state: started
-  delegate_to: "{{ item }}"
-  run_once: True
-  with_items: "{{ play_hosts }}"
-  when: openstack_install_method == 'distro'
 
 - name: start cinder backup
   service:
-    name: cinder-backup
+    name: "{{ cinder.services.cinder_backup.name }}"
     state: started
+    enabled: True
   delegate_to: "{{ item }}"
   run_once: True
-  when: swift.enabled|default("false")|bool and openstack_install_method != 'distro'
-  with_items: "{{ play_hosts }}"
-
-- name: start cinder backup (rhel osp)
-  service:
-    name: openstack-cinder-backup
-    state: started
-  delegate_to: "{{ item }}"
-  run_once: True
-  when: swift.enabled|default("false")|bool and openstack_install_method == 'distro'
+  when: swift.enabled|default("false")|bool
   with_items: "{{ play_hosts }}"
 
 - include: monitoring.yml

--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 project_name: glance
 glance:
+  services:
+    glance_api: "{{ openstack_meta.glance.services.glance_api[os] }}"
+    glance_registry: "{{ openstack_meta.glance.services.glance_registry[os] }}"
   api_workers: 5
   rbd_store_chunk_size: 8
   registry_workers: 5

--- a/roles/glance/handlers/main.yml
+++ b/roles/glance/handlers/main.yml
@@ -1,17 +1,11 @@
 ---
 - name: restart glance services
-  service: name={{ item }} state=restarted must_exist=false
-  when: restart|default('True') and openstack_install_method != 'distro'
+  service: name={{ item.name }} state=restarted must_exist=false
+  when: restart|default('True')
   with_items:
-    - glance-api
-    - glance-registry
+    - "{{ glance.services.glance_api }}"
+    - "{{ glance.services.glance_registry }}"
 
-- name: restart glance services (rhel osp)
-  service: name={{ item }} state=restarted must_exist=false
-  when: restart|default('True') and openstack_install_method == 'distro'
-  with_items:
-    - openstack-glance-api
-    - openstack-glance-registry
 # Restarting rsync 3.0.9-1ubuntu1 on 12.04.4 was failing:
 #     bind () failed: Address already in use (address-family 2)
 # Adding retry logic to workaround

--- a/roles/glance/meta/main.yml
+++ b/roles/glance/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: openstack-meta
   - role: endpoints
   - role: monitoring-common
     when: monitoring.enabled|default(True)|bool

--- a/roles/glance/tasks/image-sync.yml
+++ b/roles/glance/tasks/image-sync.yml
@@ -1,4 +1,5 @@
 ---
+# FIXME move to defaults
 # set facts to deal with cross platform
 - set_fact:
     rsync_defaults: /etc/sysconfig/rsyncd

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -43,6 +43,7 @@
     - etype: other
       permission: r
 
+# FIXME - Probably do not need this as we now overwriting systemd
 #Glance-manage in OSP is creating the api.log with incorrect permissions
 # this prohibits glance-api from starting
 - name: glance fixme acl
@@ -55,43 +56,50 @@
     etype: user
     recursive: yes
 
-- name: permit access to glance
-  ufw: rule=allow to_port={{ item }} proto=tcp
-  tags: ufw
-  with_items:
-    - "{{ endpoints.glance.port.haproxy_api }}"
-    - "{{ endpoints.glance.port.backend_api }}"
+- block:
+  - name: permit access to glance (ubuntu)
+    ufw: rule=allow to_port={{ item }} proto=tcp
+    tags: ufw
+    with_items:
+      - "{{ endpoints.glance.port.haproxy_api }}"
+      - "{{ endpoints.glance.port.backend_api }}"
+
+  - name: install glance services (ubuntu)
+    upstart_service:
+      name: "{{ item.name }}"
+      user: "{{ item.user }}"
+      cmd: "{{ item.cmd }}"
+    with_items:
+      - "{{ glance.services.glance_api }}"
+      - "{{ glance.services.glance_registry }}"
   when: os == 'ubuntu'
 
-- name: Permit access to glance
-  firewalld:
-    state: enabled
-    permanent: true
-    immediate: true
-    port: "{{ item }}/tcp"
-  with_items:
-    - "{{ endpoints.glance.port.haproxy_api }}"
-    - "{{ endpoints.glance.port.backend_api }}"
-  tags: firewall
+- block:
+  - name: Permit access to glance (rhel)
+    firewalld:
+      state: enabled
+      permanent: true
+      immediate: true
+      port: "{{ item }}/tcp"
+    with_items:
+      - "{{ endpoints.glance.port.haproxy_api }}"
+      - "{{ endpoints.glance.port.backend_api }}"
+    tags: firewall
+
+  - name: install glance services (rhel)
+    systemd_service:
+      name: "{{ item.name }}"
+      description: "{{ item.desc }}"
+      type: "{{ item.type }}"
+      user: "{{ item.user }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+      config_files: "{{ item.config_files }}"
+      restart: "{{ item.restart }}"
+    with_items:
+      - "{{ glance.services.glance_api }}"
+      - "{{ glance.services.glance_registry }}"
   when: os == 'rhel'
-
-- name: install glance services
-  systemd_service: name={{ item }}
-                   user=glance
-                   cmd=/usr/local/bin/{{ item }}
-  with_items:
-    - glance-api
-    - glance-registry
-  when: openstack_install_method != 'distro' and os == 'rhel'
-
-- name: install glance services
-  upstart_service: name={{ item }}
-                   user=glance
-                   cmd=/usr/local/bin/{{ item }}
-  with_items:
-    - glance-api
-    - glance-registry
-  when: os == 'ubuntu'
 
 - name: glance config
   template: src={{ item }} dest=/etc/glance mode={{ 0644 if 'policy.json' in item else 0640 }}
@@ -101,19 +109,11 @@
     - restart glance services
 
 - name: stop glance services before db sync
-  service: name={{ item }} state=stopped
+  service: name={{ item.name }} state=stopped
   with_items:
-    - glance-api
-    - glance-registry
-  when: (database_create.changed or force_sync|default('false')|bool) and openstack_install_method != 'distro'
-  tags: db-migrate
-
-- name: stop glance services before db sync (rhel osp)
-  service: name={{ item }} state=stopped
-  with_items:
-    - openstack-glance-api
-    - openstack-glance-registry
-  when: (database_create.changed or force_sync|default('false')|bool) and openstack_install_method == 'distro'
+    - "{{ glance.services.glance_api }}"
+    - "{{ glance.services.glance_registry }}"
+  when: (database_create.changed or force_sync|default('false')|bool)
   tags: db-migrate
 
 - name: sync glance database
@@ -125,7 +125,6 @@
     - restart glance services
   # we want this to always be changed so that it can notify the service restart
   tags: db-migrate
-
 
 - include: ceph_integration.yml
   when: ceph.enabled|bool
@@ -141,18 +140,10 @@
 - meta: flush_handlers
 
 - name: start glance services
-  service: name={{ item }} state=started
+  service: name={{ item.name }} state=started enabled=true
   with_items:
-    - glance-api
-    - glance-registry
-  when: openstack_install_method != 'distro'
-
-- name: start glance services (rhel osp)
-  service: name={{ item }} state=started
-  with_items:
-    - openstack-glance-api
-    - openstack-glance-registry
-  when: openstack_install_method == 'distro'
+    - "{{ glance.services.glance_api }}"
+    - "{{ glance.services.glance_registry }}"
 
 - include: image-sync.yml
   when: glance.sync.enabled

--- a/roles/keystone-setup/handlers/main.yml
+++ b/roles/keystone-setup/handlers/main.yml
@@ -1,4 +1,7 @@
 ---
 - name: restart keystone services
-  service: name=keystone state=restarted must_exist=false
+  service:
+    name: "{{ openstack_meta.keystone.services.keystone_api[os].name }}"
+    state: restarted
+    must_exist: false
   when: restart|default('True')

--- a/roles/keystone-setup/meta/main.yml
+++ b/roles/keystone-setup/meta/main.yml
@@ -1,4 +1,5 @@
 ---
 dependencies:
+  - role: openstack-meta
   - role: keystone-defaults
   - role: endpoints

--- a/roles/keystone/handlers/main.yml
+++ b/roles/keystone/handlers/main.yml
@@ -2,7 +2,7 @@
 # Restart serially as to not take keystone completely offline
 - name: restart keystone services
   service:
-    name: keystone
+    name: "{{ openstack_meta.keystone.services.keystone_api[os].name }}"
     state: restarted
     must_exist: false
   run_once: True

--- a/roles/keystone/meta/main.yml
+++ b/roles/keystone/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: openstack-meta
   - role: keystone-defaults
   - role: endpoints
   - role: monitoring-common

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -45,16 +45,46 @@
     uwsgi_path: "/usr/sbin/uwsgi"
   when: openstack_install_method == 'distro'
 
-- name: install keystone uwsgi service
-  template: src=etc/init/keystone.conf
-            dest=/etc/init/keystone.conf mode=0644
+- block:
+  - name: install keystone uwsgi service (ubuntu)
+    template: src=etc/init/keystone.conf
+              dest=/etc/init/keystone.conf mode=0644
+
+  - name: permit access to keystone (ubuntu)
+    ufw: rule=allow to_port={{ item }} proto=tcp
+    tags: ufw
+    with_items:
+      - "{{ endpoints.keystone.port.haproxy_api }}"
+      - "{{ endpoints.keystone_admin.port.haproxy_api }}"
+      - "{{ endpoints.keystone_legacy.port.haproxy_api }}"
+    tags: firewall
   when: os == 'ubuntu'
 
-- name: install keystone uwsgi service
-  systemd_service:
-    name: keystone
-    cmd: "{{ uwsgi_path }}"
-    args: "--uid keystone --gid keystone --master --emperor /etc/keystone/uwsgi"
+- block:
+  - name: install keystone uwsgi service (rhel)
+    systemd_service:
+      name: "{{ item.name }}"
+      description: "{{ item.desc }}"
+      cmd: "{{ uwsgi_path }}"
+      args: "{{ item.args }}"
+      user: "{{ item.user }}"
+      type: "{{ item.type }}"
+      notify_access: "{{ item.notify_access }}"
+      restart: "{{ item.restart }}"
+    with_items:
+      - "{{ openstack_meta.keystone.services.keystone_api[os] }}"
+
+  - name: Permit access to keystone (rhel)
+    firewalld:
+      state: enabled
+      permanent: true
+      immediate: true
+      port: "{{ item }}/tcp"
+    with_items:
+      - "{{ endpoints.keystone.port.haproxy_api }}"
+      - "{{ endpoints.keystone_admin.port.haproxy_api }}"
+      - "{{ endpoints.keystone_legacy.port.haproxy_api }}"
+    tags: firewall
   when: os == 'rhel'
 
 - name: Creates keystone uwsgi and httpd directories
@@ -83,7 +113,7 @@
 - include: openidc.yml
   when: keystone.federation.enabled|bool and keystone.federation.sp.oidc.enabled|bool
 
-- name: keystone apache vhost
+- name: keystone apache vhost (ubuntu)
   template: src=etc/apache2/sites-available/keystone.conf
             dest=/etc/apache2/sites-available/keystone.conf
   when: os == 'ubuntu'
@@ -91,7 +121,7 @@
     - reload apache
   tags: keystone-federation
 
-- name: keystone apache vhost
+- name: keystone apache vhost (rhel)
   template: src=etc/apache2/sites-available/keystone.conf
             dest=/etc/httpd/conf.d/keystone.conf
   when: os == 'rhel'
@@ -142,34 +172,16 @@
 - meta: flush_handlers
 
 - name: start keystone
-  service: name=keystone state=started enabled=true
+  service:
+    name: "{{ openstack_meta.keystone.services.keystone_api[os].name }}"
+    state: started
+    enabled: true
 
 - name: start shibboleth service
   service: name=shibd state=started enabled=true
   when: keystone.federation.enabled|bool and keystone.federation.sp.saml.enabled|bool
 
-- name: permit access to keystone
-  ufw: rule=allow to_port={{ item }} proto=tcp
-  tags: ufw
-  with_items:
-    - "{{ endpoints.keystone.port.haproxy_api }}"
-    - "{{ endpoints.keystone_admin.port.haproxy_api }}"
-    - "{{ endpoints.keystone_legacy.port.haproxy_api }}"
-  when: os == 'ubuntu'
-
-- name: Permit access to keystone
-  firewalld:
-    state: enabled
-    permanent: true
-    immediate: true
-    port: "{{ item }}/tcp"
-  with_items:
-    - "{{ endpoints.keystone.port.haproxy_api }}"
-    - "{{ endpoints.keystone_admin.port.haproxy_api }}"
-    - "{{ endpoints.keystone_legacy.port.haproxy_api }}"
-  tags: firewall
-  when: os == 'rhel'
-
+# FIXME adjust template for /us/bin on rhel
 - name: add cron job to clean up expired tokens
   template:
     src: etc/cron.d/drop-expired-keystone-tokens

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -1,6 +1,14 @@
 ---
 project_name: neutron
 neutron:
+  services:
+    neutron_server: "{{ openstack_meta.neutron.services.neutron_server[os] }}"
+    neutron_dhcp_agent: "{{ openstack_meta.neutron.services.neutron_dhcp_agent[os] }}"
+    neutron_l3_agent: "{{ openstack_meta.neutron.services.neutron_l3_agent[os] }}"
+    neutron_openvswitch_agent: "{{ openstack_meta.neutron.services.neutron_openvswitch_agent[os] }}"
+    neutron_linuxbridge_agent: "{{ openstack_meta.neutron.services.neutron_linuxbridge_agent[os] }}"
+    neutron_metadata_agent: "{{ openstack_meta.neutron.services.neutron_metadata_agent[os] }}"
+    neutron_lbaasv2_agent: "{{ openstack_meta.neutron.services.neutron_lbaasv2_agent[os] }}"
   jellyroll: False
   enable_fatal_deprecations: True
   l2_population: False

--- a/roles/neutron-common/handlers/main.yml
+++ b/roles/neutron-common/handlers/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: restart neutron services
-  service: name={{ item }} state=restarted_if_running must_exist=false
+  service: name={{ item.name }} state=restarted_if_running must_exist=false
   when: restart|default('True')
   failed_when: false
   with_items:
-    - neutron-server
-    - neutron-dhcp-agent
-    - neutron-l3-agent
-    - neutron-openvswitch-agent
-    - neutron-linuxbridge-agent
-    - neutron-metadata-agent
-    - neutron-lbaasv2-agent
+    - "{{ neutron.services.neutron_server }}"
+    - "{{ neutron.services.neutron_dhcp_agent }}"
+    - "{{ neutron.services.neutron_l3_agent }}"
+    - "{{ neutron.services.neutron_openvswitch_agent }}"
+    - "{{ neutron.services.neutron_linuxbridge_agent }}"
+    - "{{ neutron.services.neutron_metadata_agent }}"
+    - "{{ neutron.services.neutron_lbaasv2_agent }}"

--- a/roles/neutron-common/meta/main.yml
+++ b/roles/neutron-common/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: openstack-meta
   - role: endpoints
   - role: monitoring-common
     when: monitoring.enabled|default(True)|bool

--- a/roles/neutron-common/tasks/main.yml
+++ b/roles/neutron-common/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+  # FIXME Do we need this pkg on rhel?
 - name: install common neutron packages
   package: name=bridge-utils
   register: result
@@ -140,4 +141,3 @@
   tags:
     - serverspec
   when: serverspec.enabled|default('False')|bool
-

--- a/roles/neutron-common/templates/etc/neutron/neutron.conf
+++ b/roles/neutron-common/templates/etc/neutron/neutron.conf
@@ -63,7 +63,7 @@ ha_vrrp_auth_password = {{ neutron.l3ha.password }}
 [agent]
 report_interval = {{ neutron.report_interval }}
 {% if openstack_install_method == 'distro' %}
-root_helper = "sudo /bin/neutron-rootwrap /etc/neutron/rootwrap.conf""
+root_helper = "sudo /bin/neutron-rootwrap /etc/neutron/rootwrap.conf"
 {% else %}
 root_helper = "sudo /usr/local/bin/neutron-rootwrap /etc/neutron/rootwrap.conf"
 {% endif %}

--- a/roles/neutron-common/templates/usr/local/bin/neutron-restart-all
+++ b/roles/neutron-common/templates/usr/local/bin/neutron-restart-all
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-restart neutron-server
-restart neutron-linuxbridge-agent
-restart neutron-metadata-agent
+restart {{ neutron.services.neutron_server.name }}
+restart {{ neutron.services.neutron_linuxbridge_agent.name }}
+restart {{ neutron.services.neutron_metadata_agent.name }}
 
 # neutron-dhcp-agent and neutron-l3-agent will be restarted
 # when neutron-linuxbridge-agent is restarted due to service deps

--- a/roles/neutron-common/templates/usr/local/bin/neutron-start-all
+++ b/roles/neutron-common/templates/usr/local/bin/neutron-start-all
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-start neutron-server
-start neutron-linuxbridge-agent
-start neutron-metadata-agent
+start {{ neutron.services.neutron_server.name }}
+start {{ neutron.services.neutron_linuxbridge_agent.name }}
+start {{ neutron.services.neutron_metadata_agent.name }}
 
 # neutron-dhcp-agent and neutron-l3-agent will be started
 # when neutron-linuxbridge-agent is started due to service deps

--- a/roles/neutron-common/templates/usr/local/bin/neutron-stop-all
+++ b/roles/neutron-common/templates/usr/local/bin/neutron-stop-all
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-stop neutron-server
-stop neutron-linuxbridge-agent
-stop neutron-metadata-agent
+stop {{ neutron.services.neutron_server.name }}
+stop {{ neutron.services.neutron_linuxbridge_agent.name }}
+stop {{ neutron.services.neutron_metadata_agent.name }}
 
 # neutron-dhcp-agent and neutron-l3-agent will be stopped
 # when neutron-linuxbridge-agent is stopped due to service deps

--- a/roles/neutron-control/tasks/main.yml
+++ b/roles/neutron-control/tasks/main.yml
@@ -2,38 +2,55 @@
 - name: neutron api cache dir
   file: dest=/var/cache/neutron/api owner=neutron state=directory
 
-- name: install neutron-server service ( ubuntu source )
-  upstart_service:
-    name: neutron-server
-    user: neutron
-    cmd: /usr/local/bin/neutron-server
-    config_dirs: /etc/neutron
-    config_files: /etc/neutron/plugins/ml2/ml2_plugin.ini
-    envs: "{{ neutron.service.envs }}"
+- block:
+  - name: install neutron-server service ( ubuntu )
+    upstart_service:
+      name: "{{ item.name }}"
+      user: "{{ item.user }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+      config_files: "{{ item.config_files }}"
+      envs: "{{ neutron.service.envs }}"
+    with_items:
+      - "{{ neutron.services.neutron_server }}"
+
+  - name: Permit access to Neutron (ubuntu)
+    ufw: rule=allow to_port={{ endpoints.neutron.port.haproxy_api }} proto=tcp
+    tags: firewall
   when: os == 'ubuntu'
 
-- name: install neutron-server service (rhel source)
-  systemd_service:
-    name: neutron-server
-    user: neutron
-    cmd: /usr/local/bin/neutron-server
-    config_dirs: /etc/neutron
-    config_files: /etc/neutron/plugins/ml2/ml2_plugin.ini
-    #envs: "{{ neutron.service.envs }}"
-  when: os == 'rhel' and openstack_install_method == 'source'
+- block:
+  - name: install neutron-server service (rhel)
+    systemd_service:
+      name: "{{ item.name }}"
+      description: "{{ item.desc }}"
+      type: "{{ item.type }}"
+      notify_access: "{{ item.notify_access|default(omit) }}"
+      user: "{{ item.user }}"
+      #envs: "{{ neutron.service.envs }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+      config_files: "{{ item.config_files }}"
+      restart: "{{ item.restart }}"
+      kill_mode: "{{ item.kill_mode }}"
+    with_items:
+      - "{{ neutron.services.neutron_server }}"
 
-- name: install neutron-server service (rhel osp)
-  systemd_service:
-    name: neutron-server
-    user: neutron
-    cmd: /bin/neutron-server
-    config_dirs: /etc/neutron
-    config_files: /etc/neutron/plugins/ml2/ml2_plugin.ini
-    #envs: "{{ neutron.service.envs }}"
-  when: os == 'rhel' and openstack_install_method == 'distro'
+  - name: Permit access to neutron (rhel)
+    firewalld:
+      state: enabled
+      permanent: true
+      immediate: true
+      port: "{{ item }}/tcp"
+    with_items:
+      - "{{ endpoints.neutron.port.haproxy_api }}"
+    tags: firewall
+  when: os == 'rhel'
 
 - name: stop neutron service before db sync
-  service: name=neutron-server state=stopped
+  service:
+    name: "{{ neutron.services.neutron_server.name }}"
+    state: stopped
   when: database_create.changed or force_sync|default('false')|bool
   tags: db-migrate
 
@@ -58,23 +75,10 @@
 - meta: flush_handlers
 
 - name: start neutron-server
-  service: name=neutron-server state=started
-
-- name: Permit access to Neutron
-  ufw: rule=allow to_port={{ endpoints.neutron.port.haproxy_api }} proto=tcp
-  tags: ufw
-  when: os == 'ubuntu'
-
-- name: Permit access to Neutron
-  firewalld:
-    state: enabled
-    permanent: true
-    immediate: true
-    port: "{{ item }}/tcp"
-  with_items:
-    - "{{ endpoints.neutron.port.haproxy_api }}"
-  tags: firewall
-  when: os == 'rhel'
+  service:
+    name: "{{ neutron.services.neutron_server.name }}"
+    state: started
+    enabled: true
 
 - include: monitoring.yml
   tags:

--- a/roles/neutron-data-network/handlers/main.yml
+++ b/roles/neutron-data-network/handlers/main.yml
@@ -4,7 +4,9 @@
   failed_when: False
 
 - name: restart neutron lbaas agent
-  service: name=neutron-lbaasv2-agent state=restarted_if_running
+  service:
+    name: "{{ neutron.services.neutron_lbaasv2_agent.name }}"
+    state: restarted_if_running
   when: restart|default('True') and ((neutron.lbaas.enabled == "smart" and
                      groups['controller'][0] not in groups['compute']) or
                      neutron.lbaas.enabled|bool)

--- a/roles/neutron-data-network/tasks/dnsmasq.yml
+++ b/roles/neutron-data-network/tasks/dnsmasq.yml
@@ -1,11 +1,11 @@
 ---
-- name: prevent dnsmasq from add itself to /etc/resolv.conf via resolvconf
-  lineinfile: dest=/etc/default/dnsmasq regexp="^DNSMASQ_EXCEPT="
-              line="DNSMASQ_EXCEPT=lo"
-  when: os == 'ubuntu'
+- block:
+  - name: prevent dnsmasq from add itself to /etc/resolv.conf via resolvconf
+    lineinfile: dest=/etc/default/dnsmasq regexp="^DNSMASQ_EXCEPT="
+                line="DNSMASQ_EXCEPT=lo"
 
-- name: delete localhost dnsmask nameserver
-  command: resolvconf -d lo.dnsmasq
+  - name: delete localhost dnsmask nameserver
+    command: resolvconf -d lo.dnsmasq
   when: os == 'ubuntu'
 
 - name: neutron dnsmasq config

--- a/roles/neutron-data-network/tasks/ipchanged.yml
+++ b/roles/neutron-data-network/tasks/ipchanged.yml
@@ -16,8 +16,10 @@
 - name: ipchanged systemd service
   systemd_service:
     name: ipchanged
+    type: simple
     cmd: /usr/local/sbin/ipchanged
-
+    wanted_by: multi-user.target
+  when: os == 'rhel'
 
 - name: ipchanged dirs - undercloud
   file: dest=/etc/ipchanged/{{ item }} state=directory

--- a/roles/neutron-data-network/tasks/main.yml
+++ b/roles/neutron-data-network/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+  #FIXME Do we need these pkgs on Rhel?
 - name: install neutron-data-network packages
   package: name={{ item }}
   with_items:
@@ -10,33 +11,23 @@
   until: result|succeeded
   retries: 5
 
-- name: install arping - ubuntu
-  package:
-    name: iputils-arping
+#FIXME can we move this to common systen_tools?
+- block:
+  - name: install arping (ubuntu)
+    package:
+      name: iputils-arping
+
+  - name: install resolvconf (ubuntu)
+    package:
+      name: resolvconf
   when: os == 'ubuntu'
 
-- name: install resolvconf - ubuntu
-  package:
-    name: resolvconf
-  when: os == 'ubuntu'
-
-- name: install arping - rhel
+- name: install arping (rhel)
   package:
     name: iputils
   when: os == 'rhel'
 
-- name: install custom ucarp scripts - rhel
-  template:
-    src: "usr/local/libexec/{{ item }}"
-    dest: "/usr/local/libexec/{{ item }}"
-    owner: root
-    group: root
-    mode: 0700
-  with_items:
-    - ucarp-vip-up
-    - ucarp-vip-down
-  when: ucarp is defined and os == 'rhel'
-
+#FIXME Do we need this for RHEL?
 - name: install packages for l3ha
   package: name=keepalived
   when: neutron.l3ha.enabled|bool
@@ -70,80 +61,79 @@
   failed_when: iproute_out.rc == 255
   when: "'vxlan' in neutron.tunnel_types"
 
-- name: install neutron-data-network services
-  upstart_service:
-    name: "{{ item.key }}"
-    user: neutron
-    cmd: "/usr/local/bin/{{ item.key }}"
-    pidfile: "{{ item.value.pidfile|default(omit) }}"
-    start_on: "starting neutron-linuxbridge-agent"
-    stop_on: "stopping neutron-linuxbridge-agent"
-    config_dirs: /etc/neutron
-    config_files: /etc/neutron/neutron.conf,{{ item.value.config_files }}
-    envs: "{{ neutron.service.envs }}"
+- block:
+  - name: install neutron-data-network services (ubuntu)
+    upstart_service:
+      name: "{{ item.name }}"
+      start_on: "{{ item.start_on|default(omit) }}"
+      stop_on: "{{ item.stop_on|default(omit) }}"
+      user: "{{ item.user }}"
+      pidfile: "{{ item.pidfile|default(omit) }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+      config_files: "{{ item.config_files|default(omit) }}"
+      envs: "{{ neutron.service.envs }}"
+    with_items:
+      - "{{ neutron.services.neutron_dhcp_agent }}"
+      - "{{ neutron.services.neutron_l3_agent }}"
+      - "{{ neutron.services.neutron_metadata_agent }}"
+
+  - name: install neutron lbaas service (ubuntu)
+    upstart_service:
+      name: "{{ item.name }}"
+      start_on: "{{ item.start_on|default(omit) }}"
+      stop_on: "{{ item.stop_on|default(omit) }}"
+      user: "{{ item.user }}"
+      pidfile: "{{ item.pidfile|default(omit) }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+      config_files: "{{ item.config_files|default(omit) }}"
+      envs: "{{ neutron.service.envs }}"
+    when: ((neutron.lbaas.enabled == "smart" and
+           groups['controller'][0] not in groups['compute']) or
+           neutron.lbaas.enabled|bool)
+    with_items:
+      - "{{ neutron.services.neutron_lbaasv2_agent }}"
   when: os == 'ubuntu'
-  with_dict:
-    neutron-dhcp-agent:
-      config_files: /etc/neutron/dhcp_agent.ini
-    neutron-l3-agent:
-      config_files: /etc/neutron/l3_agent.ini
-      pidfile: /var/run/neutron-l3-agent.pid
-    neutron-metadata-agent:
-      config_files: /etc/neutron/metadata_agent.ini
 
-- name: install neutron-data-network services (rhel source)
-  systemd_service:
-    name: "{{ item.key }}"
-    user: neutron
-    cmd: "/usr/local/bin/{{ item.key }}"
-    config_dirs: /etc/neutron
-    config_files: /etc/neutron/neutron.conf,{{ item.value.config_files }}
-    #envs: "{{ neutron.service.envs }}"
-  when: os == 'rhel' and openstack_install_method == 'source'
-  with_dict:
-    neutron-dhcp-agent:
-      config_files: /etc/neutron/dhcp_agent.ini
-    neutron-l3-agent:
-      config_files: /etc/neutron/l3_agent.ini
-      pidfile: /var/run/neutron-l3-agent.pid
-    neutron-metadata-agent:
-      config_files: /etc/neutron/metadata_agent.ini
+- block:
+  - name: install neutron-data-network services (rhel)
+    systemd_service:
+      name: "{{ item.name }}"
+      description: "{{ item.desc }}"
+      type: "{{ item.type }}"
+      user: "{{ item.user }}"
+      #envs: "{{ neutron.service.envs }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+      config_files: "{{ item.config_files }}"
+      pidfile: "{{ item.pidfile|default(omit) }}"
+      restart: "{{ item.restart }}"
+      kill_mode: "{{ item.kill_mode }}"
+    with_items:
+      - "{{ neutron.services.neutron_dhcp_agent }}"
+      - "{{ neutron.services.neutron_l3_agent }}"
+      - "{{ neutron.services.neutron_metadata_agent }}"
 
-- name: install neutron-data-network services (rhel osp)
-  systemd_service:
-    name: "{{ item.key }}"
-    user: neutron
-    cmd: "/bin/{{ item.key }}"
-    config_dirs: /etc/neutron
-    config_files: /etc/neutron/neutron.conf,{{ item.value.config_files }}
-    #envs: "{{ neutron.service.envs }}"
-  when: os == 'rhel' and openstack_install_method == 'distro'
-  with_dict:
-    neutron-dhcp-agent:
-      config_files: /etc/neutron/dhcp_agent.ini
-    neutron-l3-agent:
-      config_files: /etc/neutron/l3_agent.ini
-      pidfile: /var/run/neutron-l3-agent.pid
-    neutron-metadata-agent:
-      config_files: /etc/neutron/metadata_agent.ini
-
-- name: install neutron-data-network services (rhel package)
-  systemd_service:
-    name: "{{ item.key }}"
-    user: neutron
-    cmd: "/bin/{{ item.key }}"
-    config_dirs: /etc/neutron
-    config_files: /etc/neutron/neutron.conf,{{ item.value.config_files }}
-    #envs: "{{ neutron.service.envs }}"
-  when: os == 'rhel' and openstack_install_method == 'package'
-  with_dict:
-    neutron-dhcp-agent:
-      config_files: /etc/neutron/dhcp_agent.ini
-    neutron-l3-agent:
-      config_files: /etc/neutron/l3_agent.ini
-      pidfile: /var/run/neutron-l3-agent.pid
-    neutron-metadata-agent:
-      config_files: /etc/neutron/metadata_agent.ini
+  - name: install neutron lbaas service (rhel)
+    systemd_service:
+      name: "{{ item.name }}"
+      description: "{{ item.desc }}"
+      type: "{{ item.type }}"
+      user: "{{ item.user }}"
+      #envs: "{{ neutron.service.envs }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+      config_files: "{{ item.config_files }}"
+      pidfile: "{{ item.pidfile|default(omit) }}"
+      restart: "{{ item.restart }}"
+      kill_mode: "{{ item.kill_mode }}"
+    when: ((neutron.lbaas.enabled == "smart" and
+           groups['controller'][0] not in groups['compute']) or
+           neutron.lbaas.enabled|bool)
+    with_items:
+      - "{{ neutron.services.neutron_lbaasv2_agent }}"
+  when: os == 'rhel'
 
 - name: create lbaas templates folder
   file:
@@ -205,63 +195,6 @@
   notify:
     - restart neutron lbaas agent
 
-- name: install neutron lbaas service
-  upstart_service:
-    name: "{{ item.key }}"
-    user: neutron
-    cmd: "/usr/local/bin/{{ item.key }}"
-    pidfile: "{{ item.value.pidfile|default(omit) }}"
-    start_on: "starting neutron-linuxbridge-agent"
-    stop_on: "stopping neutron-linuxbridge-agent"
-    config_dirs: /etc/neutron
-    config_files: "{{ item.value.config_files|join(',') }}"
-    envs: "{{ neutron.service.envs }}"
-  when: os == 'ubuntu' and ((neutron.lbaas.enabled == "smart" and
-         groups['controller'][0] not in groups['compute']) or
-         neutron.lbaas.enabled|bool)
-  with_dict:
-    neutron-lbaasv2-agent:
-      config_files:
-        - /etc/neutron/neutron.conf
-        - /etc/neutron/services/loadbalancer/haproxy/lbaas_agent.ini
-        - /etc/neutron/neutron_lbaas.conf
-
-- name: install neutron lbaas service (rhel source)
-  systemd_service:
-    name: "{{ item.key }}"
-    user: neutron
-    cmd: "/usr/local/bin/{{ item.key }}"
-    config_dirs: /etc/neutron
-    config_files: "{{ item.value.config_files|join(',') }}"
-    #envs: "{{ neutron.service.envs }}"
-  when: os == 'rhel' and openstack_install_method == 'source' and ((neutron.lbaas.enabled == "smart" and
-         groups['controller'][0] not in groups['compute']) or
-         neutron.lbaas.enabled|bool)
-  with_dict:
-    neutron-lbaasv2-agent:
-      config_files:
-        - /etc/neutron/neutron.conf
-        - /etc/neutron/services/loadbalancer/haproxy/lbaas_agent.ini
-        - /etc/neutron/neutron_lbaas.conf
-        
-- name: install neutron lbaas service (rhel package)
-  systemd_service:
-    name: "{{ item.key }}"
-    user: neutron
-    cmd: "/bin/{{ item.key }}"
-    config_dirs: /etc/neutron
-    config_files: "{{ item.value.config_files|join(',') }}"
-    #envs: "{{ neutron.service.envs }}"
-  when: os == 'rhel' and openstack_install_method == 'package' and ((neutron.lbaas.enabled == "smart" and
-         groups['controller'][0] not in groups['compute']) or
-         neutron.lbaas.enabled|bool)
-  with_dict:
-    neutron-lbaasv2-agent:
-      config_files:
-        - /etc/neutron/neutron.conf
-        - /etc/neutron/services/loadbalancer/haproxy/lbaas_agent.ini
-        - /etc/neutron/neutron_lbaas.conf
-
 - name: kill namespaced neutron processes on upgrade
   command: pkill -f {{ item }}
   failed_when: False
@@ -282,14 +215,20 @@
 - meta: flush_handlers
 
 - name: start neutron-data-network services
-  service: name={{ item }} state=started
+  service:
+    name: "{{ item.name }}"
+    state: started
+    enabled: True
   with_items:
-    - neutron-l3-agent
-    - neutron-dhcp-agent
-    - neutron-metadata-agent
+    - "{{ neutron.services.neutron_l3_agent }}"
+    - "{{ neutron.services.neutron_dhcp_agent }}"
+    - "{{ neutron.services.neutron_metadata_agent }}"
 
 - name: start neutron lbaas agent
-  service: name=neutron-lbaasv2-agent state=started
+  service:
+    name: "{{ neutron.services.neutron_lbaasv2_agent.name }}"
+    state: started
+    enabled: True
   when: (neutron.lbaas.enabled == "smart" and
          groups['controller'][0] not in groups['compute']) or
          neutron.lbaas.enabled|bool

--- a/roles/neutron-data/tasks/main.yml
+++ b/roles/neutron-data/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+  #FIXME do we need this on rhel?
 - name: install required packages and diagnostic tools
   package:
     name: "{{ item }}"
@@ -10,18 +11,56 @@
   until: result|succeeded
   retries: 5
 
-- name: update iproute2 to latest ppa
-  package: name=iproute2 state=latest
-  when: os == 'ubuntu'
-  register: result
-  until: result|succeeded
-  retries: 5
+- block:
+  - name: update iproute2 to latest ppa (ubuntu)
+    package: name=iproute2 state=latest
+    register: result
+    until: result|succeeded
+    retries: 5
 
-- name: permit VXLAN traffic
-  ufw: rule=allow to_port=4789 proto=udp
-  tags: ufw
-  when:  os == 'ubuntu' and
-         neutron.plugin == 'ml2' and 'vxlan' in neutron.tunnel_types
+  - name: permit VXLAN traffic (ubuntu)
+    ufw: rule=allow to_port=4789 proto=udp
+    tags: firewall
+    when:  neutron.plugin == 'ml2' and 'vxlan' in neutron.tunnel_types
+
+  - name: install neutron-linuxbridge-agent service (ubuntu)
+    upstart_service:
+      name: "{{ item.name }}"
+      user: "{{ item.user }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+      config_files: "{{ item.config_files|default(omit) }}"
+    with_items:
+      - "{{ neutron.services.neutron_linuxbridge_agent }}"
+    when: neutron.plugin == 'ml2'
+  when: os == 'ubuntu'
+
+- block:
+  - name: permit VXLAN traffic (rhel)
+    firewalld:
+      state: enabled
+      permanent: true
+      port: 4789/udp
+    tags: firewall
+
+  - name: install neutron-linuxbridge-agent service (rhel package)
+    systemd_service:
+      name: "{{ item.name }}"
+      description: "{{ item.desc }}"
+      type: "{{ item.type }}"
+      user: "{{ item.user }}"
+      #envs: "{{ neutron.service.envs }}"
+      #FIXME added prestart to match up osp systemd
+      #prestart_script: "{{ item.prestart_script }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+      config_files: "{{ item.config_files }}"
+      restart: "{{ item.restart }}"
+      kill_mode: "{{ item.kill_mode }}"
+    with_items:
+      - "{{ neutron.services.neutron_linuxbridge_agent }}"
+    when: neutron.plugin == 'ml2'
+  when: os == 'rhel'
 
 - name: ml2 dataplane config
   template: src=etc/neutron/plugins/ml2/ml2_plugin_dataplane.ini
@@ -30,30 +69,6 @@
   when: neutron.plugin == 'ml2'
   notify:
     - restart neutron services
-
-- name: install neutron-linuxbridge-agent service
-  upstart_service: name=neutron-linuxbridge-agent
-                   user=neutron
-                   cmd=/usr/local/bin/neutron-linuxbridge-agent
-                   config_dirs=/etc/neutron
-                   config_files=/etc/neutron/neutron.conf,/etc/neutron/plugins/ml2/ml2_plugin.ini,/etc/neutron/plugins/ml2/ml2_plugin_dataplane.ini
-  when: os == 'ubuntu' and neutron.plugin == 'ml2'
-
-- name: install neutron-linuxbridge-agent service (rhel source)
-  systemd_service: name=neutron-linuxbridge-agent
-                   user=neutron
-                   cmd=/usr/local/bin/neutron-linuxbridge-agent
-                   config_dirs=/etc/neutron
-                   config_files=/etc/neutron/neutron.conf,/etc/neutron/plugins/ml2/ml2_plugin.ini,/etc/neutron/plugins/ml2/ml2_plugin_dataplane.ini
-  when: os == 'rhel' and neutron.plugin == 'ml2' and openstack_install_method == 'source'
-
-- name: install neutron-linuxbridge-agent service (rhel package)
-  systemd_service: name=neutron-linuxbridge-agent
-                   user=neutron
-                   cmd=/bin/neutron-linuxbridge-agent
-                   config_dirs=/etc/neutron
-                   config_files=/etc/neutron/neutron.conf,/etc/neutron/plugins/ml2/ml2_plugin.ini,/etc/neutron/plugins/ml2/ml2_plugin_dataplane.ini
-  when: os == 'rhel' and neutron.plugin == 'ml2' and openstack_install_method == 'distro'
 
 - name: trigger restart on upgrades
   debug:
@@ -66,9 +81,13 @@
 - meta: flush_handlers
 
 - name: start neutron-linuxbridge-agent
-  service: name=neutron-linuxbridge-agent state=started
+  service:
+    name: "{{ neutron.services.neutron_linuxbridge_agent.name }}"
+    state: started
+    enabled: True
   when: neutron.plugin == 'ml2'
 
+#FIXME validate cron job on rhel
 - name: cleanup interface logs
   template: src=etc/cron.daily/cleanup-neutron-interfaces
             dest=/etc/cron.daily/cleanup-neutron-interfaces

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -1,6 +1,25 @@
 ---
 project_name: nova
 nova:
+  services:
+    nova_api: "{{ openstack_meta.nova.services.nova_api[os] }}"
+    nova_conductor: "{{ openstack_meta.nova.services.nova_conductor[os] }}"
+    nova_compute: "{{ openstack_meta.nova.services.nova_compute[os] }}"
+    nova_consoleauth: "{{ openstack_meta.nova.services.nova_consoleauth[os] }}"
+    nova_novncproxy: "{{ openstack_meta.nova.services.nova_novncproxy[os] }}"
+    nova_scheduler: "{{ openstack_meta.nova.services.nova_scheduler[os] }}"
+    nova_cert: "{{ openstack_meta.nova.services.nova_cert[os] }}"
+    nova_cells: "{{ openstack_meta.nova.services.nova_cells[os] }}"
+    libvirt: "{{ openstack_meta.nova.services.libvirt[os] }}"
+  libvirt:
+    ubuntu:
+      config_file: libvirtd.conf
+      defaults: /etc/default/libvirt
+      group: libvirtd
+    rhel:
+      config_file: libvirt.conf
+      defaults: /etc/sysconfig/libvirtd
+      group: libvirt
   enable_fatal_deprecations: True
   patches:
   compute_driver: libvirt.LibvirtDriver

--- a/roles/nova-common/handlers/main.yml
+++ b/roles/nova-common/handlers/main.yml
@@ -3,28 +3,18 @@
 # Only really matters for nova-api, fix this up later.
 - name: restart nova services
   service:
-    name: "{{ item[1] }}"
+    name: "{{ item[1].name }}"
     state: restarted
     must_exist: false
   failed_when: false
   run_once: True
   delegate_to: "{{ item[0] }}"
-  when: restart|default('True') and openstack_install_method == 'distro'
+  when: restart|default('True')
   with_nested:
     - "{{ play_hosts }}"
-    - ['nova-api', 'nova-conductor', 'nova-compute',
-       'nova-consoleauth', 'nova-novncproxy', 'nova-scheduler']
-
-- name: restart nova services (rhel osp)
-  service:
-    name: "{{ item[1] }}"
-    state: restarted
-    must_exist: false
-  failed_when: false
-  run_once: True
-  delegate_to: "{{ item[0] }}"
-  when: restart|default('True') and openstack_install_method == 'distro'
-  with_nested:
-    - "{{ play_hosts }}"
-    - ['openstack-nova-api', 'openstack-nova-conductor', 'openstack-nova-compute',
-       'openstack-nova-consoleauth', 'openstack-nova-novncproxy', 'openstack-nova-scheduler']
+    - ["{{ nova.services.nova_api }}",
+       "{{ nova.services.nova_conductor }}",
+       "{{ nova.services.nova_compute }}",
+       "{{ nova.services.nova_consoleauth }}",
+       "{{ nova.services.nova_novncproxy }}",
+       "{{ nova.services.nova_scheduler }}"]

--- a/roles/nova-common/meta/main.yml
+++ b/roles/nova-common/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: openstack-meta
   - role: endpoints
   - role: apt-repos
     repos:

--- a/roles/nova-common/tasks/main.yml
+++ b/roles/nova-common/tasks/main.yml
@@ -1,11 +1,15 @@
 ---
-- set_fact:
-    libvirt_service: libvirt-bin
-  when: os == 'ubuntu'
+#FIXME, find a better way to handle this
+- stat:
+    path: /etc/httpd/conf.d/00-nova-placement-api.conf
+  register: np
 
-- set_fact:
-    libvirt_service: libvirtd
-  when: os == 'rhel'
+- name: disable nova placement API
+  command: mv /etc/httpd/conf.d/00-nova-placement-api.conf /etc/httpd/conf.d/00-nova-placement-api.disabled
+  when:
+    - np.stat.exists == True
+    - os == 'rhel'
+    - openstack_install_method == 'distro'
 
 - name: nova user
   user:
@@ -25,18 +29,6 @@
   register: result
   until: result|succeeded
   retries: 5
-
-#FIXME, find a better way to handle this
-- stat:
-    path: /etc/httpd/conf.d/00-nova-placement-api.conf
-  register: np
-
-- name: disable nova placement API
-  command: mv /etc/httpd/conf.d/00-nova-placement-api.conf /etc/httpd/conf.d/00-nova-placement-api.disabled
-  when: 
-    - np.stat.exists == True 
-    - os == 'rhel' 
-    - openstack_install_method == 'distro'
 
 - name: create nova config dir
   file: dest=/etc/nova state=directory

--- a/roles/nova-control/tasks/main.yml
+++ b/roles/nova-control/tasks/main.yml
@@ -5,49 +5,72 @@
 - block:
   - name: remove retired nova controller services
     upstart_service:
-      name: "{{ item }}"
-      user: nova
-      cmd: /usr/local/bin/{{ item }}
-      config_dirs: /etc/nova
-      state: absent
+      name: "{{ item.name }}"
+      user: "{{ item.user }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+      state: "{{ item.state }}"
     with_items:
-      - nova-cert
+      - "{{ nova.services.nova_cert }}"
 
-  - name: install nova controller services
-    upstart_service: name={{ item }} user=nova
-                     cmd=/usr/local/bin/{{ item }}
-                     config_dirs=/etc/nova
+  - name: install nova controller services (ubuntu)
+    upstart_service:
+      name: "{{ item.name }}"
+      user: "{{ item.user }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
     with_items:
-      - nova-api
-      - nova-conductor
-      - nova-consoleauth
-      - nova-scheduler
-      - nova-novncproxy
+      - "{{ nova.services.nova_api }}"
+      - "{{ nova.services.nova_conductor }}"
+      - "{{ nova.services.nova_consoleauth }}"
+      - "{{ nova.services.nova_scheduler }}"
+      - "{{ nova.services.nova_novncproxy }}"
+
+  - name: permit access to nova api (ubuntu)
+    ufw: rule=allow to_port={{ endpoints.nova.port.haproxy_api }} proto=tcp
+    tags: firewall
   when: os == 'ubuntu'
 
 - block:
   - name: remove retired nova controller services
     systemd_service:
-      name: "{{ item }}"
-      user: nova
-      cmd: /usr/local/bin/{{ item }}
-      config_dirs: /etc/nova
-      state: absent
+      name: "{{ item.name }}"
+      cmd: "{{ item.cmd }}"
+      state: "{{ item.state }}"
     with_items:
-      - nova-cert
+      - "{{ nova.services.nova_cert }}"
+      - "{{ nova.services.nova_cells }}"
 
-  - name: install nova controller services
-    systemd_service: name={{ item }} user=nova
-                     cmd=/usr/local/bin/{{ item }}
-                     config_dirs=/etc/nova
+  - name: install nova controller services (rhel)
+    systemd_service:
+      name: "{{ item.name }}"
+      description: "{{ item.desc }}"
+      type: "{{ item.type }}"
+      notify_access: "{{ item.notify_access|default(omit) }}"
+      user: "{{ item.user }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+      config_files: "{{ item.config_files }}"
+      restart: "{{ item.restart }}"
     with_items:
-      - nova-api
-      - nova-conductor
-      - nova-consoleauth
-      - nova-scheduler
-      - nova-novncproxy
-    when: os == 'rhel' and openstack_install_method == 'source'
+      - "{{ nova.services.nova_api }}"
+      - "{{ nova.services.nova_conductor }}"
+      - "{{ nova.services.nova_consoleauth }}"
+      - "{{ nova.services.nova_scheduler }}"
+      - "{{ nova.services.nova_novncproxy }}"
 
+  - name: Permit access to nova (rhel)
+    firewalld:
+      state: enabled
+      permanent: true
+      immediate: true
+      port: "{{ item }}/tcp"
+    with_items:
+      - "{{ endpoints.nova.port.haproxy_api }}"
+    tags: firewall
+  when: os == 'rhel'
+
+#FIXME do we need this on rhosp?
 - name: install nova-quota-sync script
   copy: src=nova-quota-sync
         dest=/usr/local/sbin/nova-quota-sync
@@ -83,40 +106,16 @@
 - meta: flush_handlers
 
 - name: start nova controller services
-  service: name={{ item }} state=started
-  when: openstack_install_method != 'distro'
+  service:
+    name: "{{ item.name }}"
+    state: started
+    enabled: True
   with_items:
-    - nova-api
-    - nova-conductor
-    - nova-consoleauth
-    - nova-scheduler
-    - nova-novncproxy
-
-- name: start nova controller services (rhel osp)
-  service: name={{ item }} state=started
-  when: openstack_install_method == 'distro'
-  with_items:
-    - openstack-nova-api
-    - openstack-nova-conductor
-    - openstack-nova-consoleauth
-    - openstack-nova-scheduler
-    - openstack-nova-novncproxy
-
-- name: permit access to nova api
-  ufw: rule=allow to_port={{ endpoints.nova.port.haproxy_api }} proto=tcp
-  when: os == 'ubuntu'
-  tags: ufw
-
-- name: Permit access to nova
-  firewalld:
-    state: enabled
-    permanent: true
-    immediate: true
-    port: "{{ item }}/tcp"
-  with_items:
-    - "{{ endpoints.nova.port.haproxy_api }}"
-  tags: firewall
-  when: os == 'rhel'
+    - "{{ nova.services.nova_api }}"
+    - "{{ nova.services.nova_conductor }}"
+    - "{{ nova.services.nova_consoleauth }}"
+    - "{{ nova.services.nova_scheduler }}"
+    - "{{ nova.services.nova_novncproxy }}"
 
 - include: monitoring.yml
   tags:

--- a/roles/nova-control/tasks/novnc.yml
+++ b/roles/nova-control/tasks/novnc.yml
@@ -6,32 +6,39 @@
        update={{ openstack.git_update }}
   when: nova.novnc_method == 'git'
 
-- name: novnc staging dir
-  file: dest=/opt/stack/novnc state=directory
+#For novnc+method=file
+- block:
+  - name: novnc staging dir
+    file: dest=/opt/stack/novnc state=directory
+
+  - name: fetch novnc tarball
+    get_url: url={{ nova.novnc_url }} dest=/opt/stack/novnc/novnc-0.5.1.tgz
+
+  - name: unzip novnc tarball
+    unarchive: src=/opt/stack/novnc/novnc-0.5.1.tgz dest=/opt/stack/novnc/ copy=no
+
+  - name: is /usr/share/novnc a symlink or a dir
+    stat: path=/usr/share/novnc
+    register: sym
+
+  - name: rm novnc if not a symlink
+    file: path=/usr/share/novnc state=absent
+    when: sym.stat.islnk is defined and sym.stat.islnk == False
+
+  - name: ensure novnc dir exists
+    file: src=/opt/stack/novnc/noVNC-0.5.1 dest=/usr/share/novnc state=link
+    when: not sym.stat.exists
   when: nova.novnc_method == 'file'
 
-
-- name: fetch novnc tarball
-  get_url: url={{ nova.novnc_url }} dest=/opt/stack/novnc/novnc-0.5.1.tgz
-  when: nova.novnc_method == 'file'
-
-- name: unzip novnc tarball
-  unarchive: src=/opt/stack/novnc/novnc-0.5.1.tgz dest=/opt/stack/novnc/ copy=no
-  when: nova.novnc_method == 'file'
-
-- name: is /usr/share/novnc a symlink or a dir
-  stat: path=/usr/share/novnc
-  register: sym
-
-- name: rm novnc if not a symlink
-  file: path=/usr/share/novnc state=absent
-  when: nova.novnc_method == 'file' and sym.stat.islnk is defined and sym.stat.islnk == False
-
-- name: ensure novnc dir exists
-  file: src=/opt/stack/novnc/noVNC-0.5.1 dest=/usr/share/novnc state=link
-  when: nova.novnc_method == 'file' and not sym.stat.exists
-
-- name: Permit access to NoVNC
+- name: Permit access to NoVNC (ubuntu)
   ufw: rule=allow to_port={{ endpoints.novnc.port.haproxy_api }} proto=tcp
   when: os == 'ubuntu'
-  tags: ufw
+  tags: firewalld
+
+- name: permit access to NoVNC (rhel)
+  firewalld:
+    state: enabled
+    permanent: true
+    port: "{{ endpoints.novnc.port.haproxy_api }}/udp"
+  when: os == 'rhel'
+  tags: firewall

--- a/roles/nova-data/handlers/main.yml
+++ b/roles/nova-data/handlers/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: restart libvirt-bin
   service:
-    name: "{{ libvirt_service }}"
+    name: "{{ nova.services.libvirt.name }}"
     state: restarted
 
 - name: novadocker rootwrap
   command: rsync -avh {{ nova.driver.docker.dest }}/etc/nova/rootwrap.d/ /etc/nova/rootwrap.d/
 
 - name: restart nova compute
-  service: name={{ item }} state=restarted must_exist=false
+  service: name={{ item.name }} state=restarted must_exist=false
   with_items:
-    - nova-compute
+    - "{{ nova.services.nova_compute }}"

--- a/roles/nova-data/tasks/libvirt.yml
+++ b/roles/nova-data/tasks/libvirt.yml
@@ -5,7 +5,7 @@
             dest=/etc/modprobe.d/kvm-nested.conf owner=root group=root
             mode=0644
 
-- name: install nova-compute packages
+- name: install nova-compute packages (ubuntu)
   package: name={{ item }}
   with_items:
     - cpu-checker
@@ -26,6 +26,7 @@
   until: result|succeeded
   retries: 5
 
+#FIXME Do we need to install this in rhosp?
 - name: install nova-compute packages
   package: name={{ item }}
   with_items:
@@ -69,22 +70,9 @@
   notify: restart nova services
   when: openstack_install_method == 'source'
 
-- set_fact:
-    libvirt_conf: libvirt.conf
-  when: os == 'rhel'
-- set_fact:
-    libvirt_conf: libvirtd.conf
-  when: os == 'ubuntu'
-- set_fact:
-    libvirt_defaults: /etc/sysconfig/libvirtd
-  when: os == 'rhel'
-- set_fact:
-    libvirt_defaults: /etc/default/libvirt
-  when: os == 'ubuntu'
-
 - name: delete lines in libvirtd.conf
   lineinfile:
-    dest: "/etc/libvirt/{{ libvirt_conf }}"
+    dest: "/etc/libvirt/{{ nova.libvirt[os].config_file }}"
     regexp: "{{ item.value.regexp }}"
     line: "{{ item.value.line }}"
     state: absent
@@ -99,7 +87,7 @@
 
 - name: add/update various lines in libvirtd.conf
   lineinfile:
-    dest: "/etc/libvirt/{{ libvirt_conf }}"
+    dest: "/etc/libvirt/{{ nova.libvirt[os].config_file }}"
     regexp: "{{ item.value.regexp }}"
     line: "{{ item.value.line }}"
   with_dict:
@@ -110,7 +98,7 @@
 
 - name: remove libvirtd defaults
   lineinfile:
-    dest: "{{ libvirt_defaults }}"
+    dest: "{{ nova.libvirt[os].defaults }}"
     regexp: '^libvirtd_opts\s*='
     line: 'libvirtd_opts=\"-d -l\"'
     state: absent
@@ -123,14 +111,14 @@
     line: 'allow_incoming_qemukvm = 1'
   notify: restart libvirt-bin
 
-- name: ensure kvm is supported by cpu and enabled in bios - ubuntu
+- name: ensure kvm is supported by cpu and enabled in bios (ubuntu)
   command: kvm-ok
   when:
     - nova.libvirt_type == 'kvm'
     - os == 'ubuntu'
   changed_when: False
 
-- name: ensure kvm is supported by cpu and enabled in bios - rhel
+- name: ensure kvm is supported by cpu and enabled in bios (rhel)
   command: egrep '(vmx|svm)' /proc/cpuinfo
   when:
     - nova.libvirt_type == 'kvm'
@@ -171,10 +159,5 @@
 - name: disable libvirt default network autostart
   file: dest=/etc/libvirt/qemu/networks/autostart/default.xml state=absent
 
-- name: add nova to the libvirtd group
-  user: name=nova groups=libvirtd append=true system=yes createhome=no
-  when: os == 'ubuntu'
-
-- name: add nova to the libvirt group
-  user: name=nova groups=libvirt append=true system=yes createhome=no
-  when: os == 'rhel'
+- name: add nova to the {{ nova.libvirt[os].group }} group
+  user: name=nova groups={{ nova.libvirt[os].group }} append=true system=yes createhome=no

--- a/roles/nova-data/tasks/main.yml
+++ b/roles/nova-data/tasks/main.yml
@@ -13,6 +13,7 @@
 - include: docker.yml
   when: nova.compute_driver == "novadocker.virt.docker.DockerDriver"
 
+#FIXME Do we need this on RHOSP
 - name: install nova data plan requirements
   package: name=sysfsutils
   register: result
@@ -27,7 +28,6 @@
     group: "{{ (os == 'rhel' ) | ternary('qemu', 'nova') }}"
     mode: 0755
 
-
 - name: nova instances directory
   file:
     dest: "{{ nova.state_path }}/instances"
@@ -36,32 +36,34 @@
     group: "{{ (os == 'rhel' ) | ternary('qemu', 'nova') }}"
     mode: 0755
 
-- name: nbd module - ubuntu
-  lineinfile: dest=/etc/modules line="nbd"
+- block:
+  - name: nbd module - ubuntu
+    lineinfile: dest=/etc/modules line="nbd"
+    when: os == 'ubuntu'
+
+  - name: probe nbd - ubuntu
+    modprobe: name=nbd state=present
   when: os == 'ubuntu'
 
-- name: probe nbd - ubuntu
-  modprobe: name=nbd state=present
-  when: os == 'ubuntu'
-
+#FIXME do we need this on rhosp?
 - name: install nbd package - rhel
   package:
     name: nbd
   when: os == 'rhel'
 
-- name: check if SMT is enabled
-  command: "ppc64_cpu --smt"
-  failed_when: False
-  changed_when: False
-  register: smt
-  when: ansible_architecture == "ppc64le"
+- block:
+  - name: check if SMT is enabled
+    command: "ppc64_cpu --smt"
+    failed_when: False
+    changed_when: False
+    register: smt
 
-- name: disable SMT for ppc64le
-  command: "ppc64_cpu --smt=off"
-  when: ansible_architecture == "ppc64le" and not smt.stdout|search("SMT is off")
+  - name: disable SMT for ppc64le
+    command: "ppc64_cpu --smt=off"
+    when: not smt.stdout|search("SMT is off")
 
-- name: ensure that SMT is off at runtime before we startup libvirt (ppc64)
-  lineinfile: dest=/etc/default/libvirt-bin line="ppc64_cpu --smt=off"
+  - name: ensure that SMT is off at runtime before we startup libvirt (ppc64)
+    lineinfile: dest=/etc/default/libvirt-bin line="ppc64_cpu --smt=off"
   when: ansible_architecture == "ppc64le"
 
 - name: enable cinder encryption
@@ -70,20 +72,37 @@
   notify: restart nova compute
   when: cinder.fixed_key is defined
 
-- name: disable  cinder encryption
+- name: disable cinder encryption
   file: dest=/etc/nova/nova.cinder_encryption.conf state=absent
   notify: restart nova compute
   when: cinder.fixed_key is not defined
 
-- name: install nova-compute service
-  upstart_service: name=nova-compute user=nova cmd=/usr/local/bin/nova-compute
-                   config_dirs=/etc/nova
+- name: install nova-compute service (ubuntu)
+  upstart_service:
+    name: "{{ item.name }}"
+    user: "{{ item.user }}"
+    cmd: "{{ item.cmd }}"
+    config_dirs: "{{ item.config_dirs }}"
+  with_items:
+    - "{{ nova.services.nova_compute }}"
   when: os == 'ubuntu'
 
-- name: install nova-compute service (rhel source)
-  systemd_service: name=nova-compute user=nova cmd=/usr/local/bin/nova-compute
-                   config_dirs=/etc/nova
-  when: os == 'rhel' and openstack_install_method == 'source'
+- name: install nova-compute service (rhel)
+  systemd_service:
+    name: "{{ item.name }}"
+    description: "{{ item.desc }}"
+    after: "{{ item.after }}"
+    type: "{{ item.type }}"
+    notify_access: "{{ item.notify_access|default(omit) }}"
+    user: "{{ item.user }}"
+    environment: "{{ item.environment }}"
+    cmd: "{{ item.cmd }}"
+    config_dirs: "{{ item.config_dirs }}"
+    config_files: "{{ item.config_files }}"
+    restart: "{{ item.restart }}"
+  with_items:
+    - "{{ nova.services.nova_compute }}"
+  when: os == 'rhel'
 
 - name: trigger restart on upgrades
   debug:
@@ -96,12 +115,10 @@
 - meta: flush_handlers
 
 - name: start nova-compute
-  when: openstack_install_method != 'distro'
-  service: name=nova-compute state=started
-
-- name: start nova-compute (rhel osp)
-  when: openstack_install_method == 'distro'
-  service: name=openstack-nova-compute state=started
+  service:
+    name: "{{ nova.services.nova_compute.name }}"
+    state: started
+    enabled: True
 
 - include: monitoring.yml
   tags:

--- a/roles/nova-data/tasks/ssh.yml
+++ b/roles/nova-data/tasks/ssh.yml
@@ -62,6 +62,7 @@
     group: nova
     mode: 0755
 
+#FIXME WHy only ubuntu?
 - name: verify ssh among compute nodes
   command: "{{ nova.state_path }}/bin/verify-ssh"
   become: yes

--- a/roles/openstack-meta/defaults/main.yml
+++ b/roles/openstack-meta/defaults/main.yml
@@ -1,0 +1,400 @@
+---
+openstack_meta:
+  keystone:
+    services:
+      keystone_api:
+        ubuntu:
+          name: keystone
+          desc: OpenStack Identity Service
+        rhel:
+            name: openstack-keystone
+            desc: OpenStack Identity Service
+            type: notify
+            notify_access: all
+            user: keystone
+            args: --uid keystone --gid keystone --master --emperor /etc/keystone/uwsgi
+            restart: always
+  glance:
+    services:
+      glance_api:
+        ubuntu:
+          name: glance-api
+          desc: OpenStack Image API Service
+          user: glance
+          cmd: /usr/local/bin/glance-api
+        rhel:
+          name: openstack-glance-api
+          desc: OpenStack Image API Service
+          type: simple
+          user: glance
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}glance-api"
+          config_dirs: /etc/glance
+          config_files: /etc/glance/glance-api.conf
+          restart: on-failure
+      glance_registry:
+        ubuntu:
+          name: glance-registry
+          desc: OpenStack Image Registry Service
+          user: glance
+          cmd: /usr/local/bin/glance-registry
+        rhel:
+          name: openstack-glance-registry
+          desc: OpenStack Image Registry Service
+          type: simple
+          user: glance
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}glance-registry"
+          config_dirs: /etc/glance
+          config_files: /etc/glance/glance-registry.conf
+          restart: on-failure
+  cinder:
+    services:
+      cinder_api:
+        ubuntu:
+          name: cinder-api
+          desc: OpenStack Cinder API Service
+          user: cinder
+          cmd: /usr/local/bin/cinder-api
+          config_dirs: /etc/cinder
+        rhel:
+          name: openstack-cinder-api
+          desc: OpenStack Cinder API Service
+          type: simple
+          user: cinder
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}cinder-api"
+          config_dirs: /etc/cinder
+          config_files: /etc/cinder/cinder.conf
+          restart: on-failure
+      cinder_scheduler:
+        ubuntu:
+          name: cinder-scheduler
+          desc: OpenStack Cinder Scheduler Service
+          user: cinder
+          cmd: /usr/local/bin/cinder-scheduler
+          config_dirs: /etc/cinder
+        rhel:
+          name: openstack-cinder-scheduler
+          desc: OpenStack Cinder Scheduler Service
+          type: simple
+          user: cinder
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}cinder-scheduler"
+          config_dirs: /etc/cinder
+          config_files: /etc/cinder/cinder.conf
+          restart: on-failure
+      cinder_volume:
+        ubuntu:
+          name: cinder-volume
+          desc: OpenStack Cinder Volume Service
+          user: cinder
+          cmd: /usr/local/bin/cinder-volume
+          config_dirs: /etc/cinder
+        rhel:
+          name: openstack-cinder-volume
+          desc: OpenStack Cinder Volume Service
+          type: simple
+          user: cinder
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}cinder-volume"
+          config_dirs: /etc/cinder
+          config_files: /etc/cinder/cinder.conf
+          restart: on-failure
+          kill_mode: process
+      cinder_backup:
+        ubuntu:
+          name: cinder-backup
+          desc: OpenStack Cinder Backup Service
+          user: cinder
+          cmd: /usr/local/bin/cinder-backup
+          config_dirs: /etc/cinder
+        rhel:
+          name: openstack-cinder-backup
+          desc: OpenStack Cinder Backup Service
+          type: simple
+          user: cinder
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}cinder-backup"
+          config_dirs: /etc/cinder
+          config_files: /etc/cinder/cinder.conf
+          restart: on-failure
+  nova:
+    services:
+      nova_api:
+        ubuntu:
+          name: nova-api
+          desc: OpenStack Nova API Service
+          user: nova
+          cmd: /usr/local/bin/nova-api
+          config_dirs: /etc/nova
+        rhel:
+          name: openstack-nova-api
+          desc: OpenStack Nova API Service
+          type: notify
+          notify_access: all
+          user: nova
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}nova-api"
+          config_dirs: /etc/nova
+          config_files: /etc/nova/nova.conf
+          restart: always
+      nova_conductor:
+        ubuntu:
+          name: nova-conductor
+          desc: OpenStack Nova Conductor Service
+          user: nova
+          cmd: /usr/local/bin/nova-conductor
+          config_dirs: /etc/nova
+        rhel:
+          name: openstack-nova-conductor
+          desc: OpenStack Nova Conductor Service
+          type: notify
+          notify_access: all
+          user: nova
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}nova-conductor"
+          config_dirs: /etc/nova
+          config_files: /etc/nova/nova.conf
+          restart: always
+      nova_compute:
+        ubuntu:
+          name: nova-compute
+          desc: OpenStack Nova Compute Service
+          user: nova
+          cmd: /usr/local/bin/nova-compute
+          config_dirs: /etc/nova
+        rhel:
+          name: openstack-nova-compute
+          desc: OpenStack Nova Compute Service
+          after: syslog.target network.target libvirtd.service
+          type: notify
+          notify_access: all
+          user: nova
+          environment: "LIBGUESTFS_ATTACH_METHOD=appliance"
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}nova-compute"
+          config_dirs: /etc/nova
+          config_files: /etc/nova/nova.conf
+          restart: always
+      nova_consoleauth:
+        ubuntu:
+          name: nova-consoleauth
+          desc: OpenStack Nova Console Auth Service
+          user: nova
+          cmd: /usr/local/bin/nova-consoleauth
+          config_dirs: /etc/nova
+        rhel:
+          name: openstack-nova-consoleauth
+          desc: OpenStack Nova Console Auth Service
+          type: notify
+          notify_access: all
+          user: nova
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}nova-consoleauth"
+          config_dirs: /etc/nova
+          config_files: /etc/nova/nova.conf
+          restart: always
+      nova_novncproxy:
+        ubuntu:
+          name: nova-novncproxy
+          desc: OpenStack Nova NOVNCPROXY Service
+          user: nova
+          cmd: /usr/local/bin/nova-novncproxy
+          config_dirs: /etc/nova
+        rhel:
+          name: openstack-nova-novncproxy
+          desc: OpenStack Nova NOVNCPROXY Service
+          type: simple
+          user: nova
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}nova-novncproxy"
+          config_dirs: /etc/nova
+          config_files: /etc/nova/nova.conf
+          restart: always
+      nova_scheduler:
+        ubuntu:
+          name: nova-scheduler
+          desc: OpenStack Nova Scheduler Service
+          user: nova
+          cmd: /usr/local/bin/nova-scheduler
+          config_dirs: /etc/nova
+        rhel:
+          name: openstack-nova-scheduler
+          desc: OpenStack Nova Schedule Service
+          type: notify
+          notify_access: all
+          user: nova
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}nova-scheduler"
+          config_dirs: /etc/nova
+          config_files: /etc/nova/nova.conf
+          restart: always
+      nova_cert:
+        ubuntu:
+          name: nova-cert
+          desc: OpenStack Nova Cert Service
+          user: nova
+          cmd: /usr/local/bin/nova-cert
+          config_dirs: /etc/nova
+          state: absent
+        rhel:
+          name: openstack-nova-cert
+          desc: OpenStack Nova Cert Service
+          type: notify
+          notify_access: all
+          user: nova
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}nova-cert"
+          config_dirs: /etc/nova
+          config_files: /etc/nova/nova.conf
+          restart: always
+          state: absent
+      nova_cells:
+        ubuntu:
+          name: nova_cells
+          desc: OpenStack Nova Cells Service
+          user: nova
+          cmd: /usr/local/bin/nova_cells
+          config_dirs: /etc/nova
+          state: absent
+        rhel:
+          name: openstack-nova_cells
+          desc: OpenStack Nova Cells Service
+          type: notify
+          notify_access: all
+          user: nova
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}nova_cells"
+          config_dirs: /etc/nova
+          config_files: /etc/nova/nova.conf
+          restart: always
+          state: absent
+      libvirt:
+        ubuntu:
+          name: libvirt-bin
+          desc: Libvirt Service
+        rhel:
+          name: libvirtd
+          desc: Libvrt Service
+  neutron:
+    services:
+      neutron_server:
+        ubuntu:
+          name: neutron-server
+          desc: OpenStack Neutron Server Service
+          user: neutron
+          cmd: /usr/local/bin/neutron-server
+          config_dirs: /etc/neutron
+          config_files: /etc/neutron/neutron.conf,/etc/neutron/plugins/ml2/ml2_plugin.ini
+        rhel:
+          name: neutron-server
+          desc: OpenStack Neutron Server Service
+          type: notify
+          notify_access: all
+          user: neutron
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}neutron-server"
+          config_dirs: /etc/neutron
+          config_files: /etc/neutron/neutron.conf,/etc/neutron/plugins/ml2/ml2_plugin.ini
+          restart: on-failure
+          kill_mode: process
+      neutron_dhcp_agent:
+        ubuntu:
+          name: neutron-dhcp-agent
+          desc: OpenStack Neutron DHCP Agent Service
+          user: neutron
+          cmd: /usr/local/bin/neutron-dhcp-agent
+          config_dirs: /etc/neutron
+          config_files: /etc/neutron/neutron.conf,/etc/neutron/dhcp_agent.ini
+          start_on: starting neutron-linuxbridge-agent
+          stop_on: stopping neutron-linuxbridge-agent
+        rhel:
+          name: neutron-dhcp-agent
+          desc: OpenStack Neutron DHCP Agent Service
+          type: simple
+          user: neutron
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}neutron-dhcp-agent"
+          config_dirs: /etc/neutron
+          config_files: /etc/neutron/neutron.conf,/etc/neutron/dhcp_agent.ini
+          restart: on-failure
+          kill_mode: process
+      neutron_l3_agent:
+        ubuntu:
+          name: neutron-l3-agent
+          desc: OpenStack Neutron L3 Agent Service
+          user: neutron
+          cmd: /usr/local/bin/neutron-l3-agent
+          config_dirs: /etc/neutron
+          config_files: /etc/neutron/neutron.conf,/etc/neutron/l3_agent.ini
+          pidfile: /var/run/neutron-l3-agent.pid
+          start_on: starting neutron-linuxbridge-agent
+          stop_on: stopping neutron-linuxbridge-agent
+        rhel:
+          name: neutron-l3-agent
+          desc: OpenStack Neutron L3 Agent Service
+          type: simple
+          user: neutron
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}neutron-l3-agent"
+          config_dirs: /etc/neutron
+          config_files: /etc/neutron/neutron.conf,/etc/neutron/l3_agent.ini
+          pidfile: /var/run/neutron-l3-agent.pid
+          restart: on-failure
+          kill_mode: process
+      neutron_openvswitch_agent:
+        ubuntu:
+          name: neutron-openvswitch-agent
+          desc: OpenStack Neutron Open VSwitch Service
+          user: neutron
+          cmd: /usr/local/bin/neutron-openvswitch-agent
+          config_dirs: /etc/neutron
+        rhel:
+          name: neutron-openvswitch-agent
+          desc: OpenStack Neutron Open VSwitch Service
+          user: neutron
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}neutron-openvswitch-agent"
+          config_dirs: /etc/neutron
+      neutron_linuxbridge_agent:
+        ubuntu:
+          name: neutron-linuxbridge-agent
+          desc: OpenStack Neutron Linuxbridge Agent Service
+          user: neutron
+          cmd: /usr/local/bin/neutron-linuxbridge-agent
+          config_dirs: /etc/neutron
+          config_files: /etc/neutron/neutron.conf,/etc/neutron/plugins/ml2/ml2_plugin.ini,/etc/neutron/plugins/ml2/ml2_plugin_dataplane.ini
+        rhel:
+          name: neutron-linuxbridge-agent
+          desc: OpenStack Neutron Linuxbridge Agent Service
+          type: simple
+          user: neutron
+          #prestart_script: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/neutron-enable-bridge-firewall.sh', '') }}"
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}neutron-linuxbridge-agent"
+          config_dirs: /etc/neutron
+          config_files: /etc/neutron/neutron.conf,/etc/neutron/plugins/ml2/ml2_plugin.ini,/etc/neutron/plugins/ml2/ml2_plugin_dataplane.ini
+          restart: on-failure
+          kill_mode: process
+      neutron_metadata_agent:
+        ubuntu:
+          name: neutron-metadata-agent
+          desc: OpenStack Neutron Metadata Agent Service
+          user: neutron
+          cmd: /usr/local/bin/neutron-metadata-agent
+          config_dirs: /etc/neutron
+          config_files: /etc/neutron/neutron.conf,/etc/neutron/metadata_agent.ini
+          start_on: starting neutron-linuxbridge-agent
+          stop_on: stopping neutron-linuxbridge-agent
+        rhel:
+          name: neutron-metadata-agent
+          desc: OpenStack Neutron Metadata Agent Service
+          type: simple
+          user: neutron
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}neutron-metadata-agent"
+          config_dirs: /etc/neutron
+          config_files: /etc/neutron/neutron.conf,/etc/neutron/metadata_agent.ini
+          restart: on-failure
+          kill_mode: process
+      neutron_lbaasv2_agent:
+        ubuntu:
+          name: neutron-lbaasv2-agent
+          desc: OpenStack Neutron LBaasv2 Service
+          user: neutron
+          cmd: /usr/local/bin/neutron-lbaasv2-agent
+          config_dirs: /etc/neutron
+          config_files: /etc/neutron/neutron.conf,/etc/neutron/services/loadbalancer/haproxy/lbaas_agent.ini,/etc/neutron/neutron_lbaas.conf
+          start_on: starting neutron-linuxbridge-agent
+          stop_on: stopping neutron-linuxbridge-agent
+        rhel:
+          name: neutron-lbaasv2-agent
+          desc: OpenStack Neutron LBaasv2 Service
+          type: simple
+          user: neutron
+          cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}neutron-lbaasv2-agent"
+          config_dirs: /etc/neutron
+          config_files: /etc/neutron/neutron.conf,/etc/neutron/services/loadbalancer/haproxy/lbaas_agent.ini,/etc/neutron/neutron_lbaas.conf
+          restart: on-failure
+          kill_mode: process

--- a/roles/preflight-checks/tasks/network.yml
+++ b/roles/preflight-checks/tasks/network.yml
@@ -1,5 +1,7 @@
 ---
 - name: checking network {{ item.name }}
+  environment:
+    PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
   os_networks_facts:
     name: "{{ item.name }}"
     auth:
@@ -7,30 +9,31 @@
       project_name: admin
       username: admin
       password: "{{ secrets.admin_password }}"
+    validate_certs: "{{ validate_certs|default(omit) }}"
 
 - block:
   - name: ensure provider physical netowrk
-    assert: 
+    assert:
       that: openstack_networks[0]['provider:physical_network'] == item.provider_physical_network
       msg: "Could not find matching attribute for provider:physical_network."
-  
+
   - name: ensure segmentation ID
-    assert: 
+    assert:
       that: openstack_networks[0]['provider:segmentation_id'] == item.segmentation_id
       msg: "Could not find matching attribute for provider:segmentation_id."
-  
+
   - name: ensure provider network type
-    assert: 
+    assert:
       that: openstack_networks[0]['provider:network_type'] == item.network_type
       msg: "Could not find matching attribute for provider:network_type."
-  
+
   - name: ensure router external
-    assert: 
+    assert:
       that: openstack_networks[0]['router:external'] == item.external
       msg: "Could not find matching attribute for router:external."
-  
-  - name: ensure shared 
-    assert: 
+
+  - name: ensure shared
+    assert:
       that: openstack_networks[0]['shared'] == item.shared
       msg: "Could not find matching attribute for shared."
 

--- a/roles/preflight-checks/tasks/subnet.yml
+++ b/roles/preflight-checks/tasks/subnet.yml
@@ -1,5 +1,7 @@
 ---
 - name: checking neutron subnet {{ item.name }}
+  environment:
+    PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
   os_subnets_facts:
     name: "{{ item.name }}"
     auth:
@@ -7,46 +9,47 @@
       project_name: admin
       username: admin
       password: "{{ secrets.admin_password }}"
+    validate_certs: "{{ validate_certs|default(omit) }}"
 
 - block:
   - name: ensure cidr
-    assert: 
+    assert:
       that: openstack_subnets[0]['cidr'] == item.cidr
       msg: "Could not find matching attribute for cidr."
-  
+
   - name: ensure gateway_ip
     assert:
       that: openstack_subnets[0]['gateway_ip'] == item.gateway_ip
       msg: "Could not find matching attribute for gateway_ip."
-  
+
   - name: ensure ip_version
     assert:
       that: openstack_subnets[0]['ip_version'] == item.ip_version
       msg: "Could not find matching attribute for ip_version."
-  
+
   - name: ensure enable_dhcp
     assert:
       that: openstack_subnets[0]['enable_dhcp'] == {{ item.enable_dhcp | bool }}
       msg: "Could not find matching attribute for enable_dhcp."
-  
+
   - name: ensure ipv6_ra_mode
     assert:
       that: openstack_subnets[0]['ipv6_ra_mode'] == item.ipv6_ra_mode
       msg: "Could not find matching attribute for ipv6_ra_mode."
     when: item.ipv6_ra_mode is defined
-  
+
   - name: ensure pool_start
     assert:
       that: openstack_subnets[0]['allocation_pools'][0]['start'] == item.pool_start
       msg: "Could not find matching attribute for pool_start."
     when: item.pool_start is defined
-  
+
   - name: ensure pool_end
     assert:
       that: openstack_subnets[0]['allocation_pools'][0]['end'] == item.pool_end
       msg: "Could not find matching attribute for pool_end."
     when: item.pool_end is defined
-  
+
   - name: ensure ipv6_address_mode
     assert:
       that: openstack_subnets[0]['ipv6_address_mode'] == item.ipv6_address_mode


### PR DESCRIPTION
Following items are being addressed under this PR.

    abstracting upstart and systemd service definitions in services roles/defaults. This will cut down duplicated code for service setup, service restart, service start, etc by OS. Also, will help managedthe systemd/upstart conf file information in one place.

    generate systemd for centos and rhel (for rhel am making sure it matches up to what rhel rpm writes minus args to rhel specific config fragments)

    avoid some skip tasks by logically grouping tasks under block by OS where it make sense

    ensure services are enabled to autostart on reboot

For now am focusing on, keystone, glance, cinder, nova, neutron