### PR TITLE
Metering.sample queues grows in a larger environment.

### DIFF
--- a/roles/ceilometer-common/defaults/main.yml
+++ b/roles/ceilometer-common/defaults/main.yml
@@ -19,6 +19,7 @@ ceilometer:
   mongodb_user: ceilometer
   mongodb_password: "{{ secrets.mongodb_password | default('BADPASS') }}"
   heartbeat_timeout_threshold: 30
+  collector_workers: 4
   logs:
     - paths:
         - /var/log/ceilometer/api.log

--- a/roles/ceilometer-common/templates/etc/ceilometer/ceilometer.conf
+++ b/roles/ceilometer-common/templates/etc/ceilometer/ceilometer.conf
@@ -67,6 +67,9 @@ admin_password = {{ secrets.service_password }}
 identity_uri = {{ endpoints.keystone.url.admin }}
 memcached_servers = {{ hostvars|ursula_memcache_hosts(groups, memcached.port) }}
 
+[collector]
+workers = {{ ceilometer.collector_workers }}
+
 [clients]
 ca_file = {{ ceilometer.cafile }}
 


### PR DESCRIPTION
In a larger cloud topology ceilometer rabbitmq queue at times grows quite a bit. This causes our monitoring alerts to go off. Given we only enable ceilometer on a dedicated controllers we are increasing ceilometer collecter workers to 4 from 1. 