### PR TITLE
Make firewalld changes effective on active config

### DIFF
--- a/roles/cinder-control/tasks/main.yml
+++ b/roles/cinder-control/tasks/main.yml
@@ -61,6 +61,7 @@
   firewalld:
     state: enabled
     permanent: true
+    immediate: true
     port: "{{ endpoints.cinder.port.haproxy_api }}/tcp"
   tags: firewall
   when: os == 'rhel'

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -42,7 +42,7 @@
       permission: r
     - etype: other
       permission: r
-      
+
 #Glance-manage in OSP is creating the api.log with incorrect permissions
 # this prohibits glance-api from starting
 - name: glance fixme acl
@@ -67,6 +67,7 @@
   firewalld:
     state: enabled
     permanent: true
+    immediate: true
     port: "{{ item }}/tcp"
   with_items:
     - "{{ endpoints.glance.port.haproxy_api }}"
@@ -82,7 +83,7 @@
     - glance-api
     - glance-registry
   when: openstack_install_method != 'distro' and os == 'rhel'
-  
+
 - name: install glance services
   upstart_service: name={{ item }}
                    user=glance
@@ -91,7 +92,7 @@
     - glance-api
     - glance-registry
   when: os == 'ubuntu'
-  
+
 - name: glance config
   template: src={{ item }} dest=/etc/glance mode={{ 0644 if 'policy.json' in item else 0640 }}
             owner=glance group=glance
@@ -106,7 +107,7 @@
     - glance-registry
   when: (database_create.changed or force_sync|default('false')|bool) and openstack_install_method != 'distro'
   tags: db-migrate
-  
+
 - name: stop glance services before db sync (rhel osp)
   service: name={{ item }} state=stopped
   with_items:
@@ -152,7 +153,7 @@
     - openstack-glance-api
     - openstack-glance-registry
   when: openstack_install_method == 'distro'
-  
+
 - include: image-sync.yml
   when: glance.sync.enabled
 

--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -25,6 +25,7 @@
   firewalld:
     state: enabled
     permanent: true
+    immediate: true
     port: "{{ item }}/tcp"
   with_items:
     - "{{ endpoints.heat.port.haproxy_api }}"
@@ -177,7 +178,7 @@
     environment:
       OS_IDENTITY_API_VERSION: 3
       PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
-    shell: . /root/stackrc; openstack --os-auth-url "{{ endpoints.keystone.url.internal }}/v3" user delete --domain default heat_domain_admin 
+    shell: . /root/stackrc; openstack --os-auth-url "{{ endpoints.keystone.url.internal }}/v3" user delete --domain default heat_domain_admin
     register: remove_heat_admin
     failed_when: remove_heat_admin|failed and
                  "No user with a name or ID" not in remove_heat_admin.stderr|default('')
@@ -206,7 +207,7 @@
     environment:
       OS_IDENTITY_API_VERSION: 3
       PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
-    shell: . /root/stackrc; openstack --os-auth-url "{{ endpoints.keystone.url.internal }}/v3" role add --domain "{{ heat_domain.domain.id }}" --user "{{ heat_admin_user.user.id }}" admin 
+    shell: . /root/stackrc; openstack --os-auth-url "{{ endpoints.keystone.url.internal }}/v3" role add --domain "{{ heat_domain.domain.id }}" --user "{{ heat_admin_user.user.id }}" admin
     when: heat.enabled|bool and heat_admin_user|changed
   run_once: true
 
@@ -218,7 +219,7 @@
     - heat-api-cfn
     - heat-engine
   tags: db-migrate
-  
+
 - name: stop heat services before db sync (rhel osp)
   service: name={{ item }} state=stopped
   when: (database_create.changed or force_sync|default('false')|bool) and openstack_install_method == 'distro'
@@ -255,7 +256,7 @@
     - heat-api-cfn
     - heat-engine
   when: openstack_install_method != 'distro'
-  
+
 - name: start heat services (rhel osp)
   service: name={{ item }} state=started
   with_items:

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -219,6 +219,7 @@
   firewalld:
     state: enabled
     permanent: true
+    immediate: true
     port: "{{ item }}/tcp"
   with_items:
     - 80

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -39,7 +39,7 @@
   set_fact:
     uwsgi_path: "{{ openstack_package.virtualenv_base }}/keystone/bin/uwsgi"
   when: openstack_install_method == 'package' and os == 'ubuntu'
-  
+
 - name: set uwsgi path (package install rhel)
   set_fact:
     uwsgi_path: "/usr/sbin/uwsgi"
@@ -161,6 +161,7 @@
   firewalld:
     state: enabled
     permanent: true
+    immediate: true
     port: "{{ item }}/tcp"
   with_items:
     - "{{ endpoints.keystone.port.haproxy_api }}"

--- a/roles/magnum/tasks/main.yml
+++ b/roles/magnum/tasks/main.yml
@@ -65,6 +65,7 @@
 - name: Permit access to magnum
   firewalld:
     permanent: true
+    immediate: true
     port: "{{ item }}/tcp"
   with_items:
     - "{{ endpoints.magnum.port.haproxy_api }}"

--- a/roles/neutron-control/tasks/main.yml
+++ b/roles/neutron-control/tasks/main.yml
@@ -31,7 +31,7 @@
     config_files: /etc/neutron/plugins/ml2/ml2_plugin.ini
     #envs: "{{ neutron.service.envs }}"
   when: os == 'rhel' and openstack_install_method == 'distro'
-  
+
 - name: stop neutron service before db sync
   service: name=neutron-server state=stopped
   when: database_create.changed or force_sync|default('false')|bool
@@ -65,10 +65,11 @@
   tags: ufw
   when: os == 'ubuntu'
 
-- name: Permit access to glance
+- name: Permit access to Neutron
   firewalld:
     state: enabled
     permanent: true
+    immediate: true
     port: "{{ item }}/tcp"
   with_items:
     - "{{ endpoints.neutron.port.haproxy_api }}"

--- a/roles/nova-control/tasks/main.yml
+++ b/roles/nova-control/tasks/main.yml
@@ -91,7 +91,7 @@
     - nova-consoleauth
     - nova-scheduler
     - nova-novncproxy
-    
+
 - name: start nova controller services (rhel osp)
   service: name={{ item }} state=started
   when: openstack_install_method == 'distro'
@@ -111,6 +111,7 @@
   firewalld:
     state: enabled
     permanent: true
+    immediate: true
     port: "{{ item }}/tcp"
   with_items:
     - "{{ endpoints.nova.port.haproxy_api }}"


### PR DESCRIPTION
Currently changes are not made to the active config, so firewalld needs to be restarted in order make the firewall changes.  Adding "immediate: true" removes the need for the service restart.  This also fixes the name of the task in the neutron role.