### PR TITLE
fix register variables

### DIFF
--- a/roles/ceph-osd/tasks/pool_names.yml
+++ b/roles/ceph-osd/tasks/pool_names.yml
@@ -31,14 +31,14 @@
     ssd_pool: "default"
     hybrid_pool: "rbd_hybrid"
   with_items: "{{ groups['ceph_osds_ssd'] | default([]) }}"
-  when: result_first_osd_host is defined and item | search(result_first_osd_host.stdout)
+  when: result_first_osd_host.stdout is defined and item | search(result_first_osd_host.stdout)
 
 - name: set hybrid_pool=default if hybrid is original backend
   set_fact:
     hybrid_pool: "default"
     ssd_pool: "rbd_ssd"
   with_items: "{{ groups['ceph_osds_hybrid'] | default([]) }}"
-  when: result_first_osd_host is defined and item | search(result_first_osd_host.stdout)
+  when: result_first_osd_host.stdout is defined and item | search(result_first_osd_host.stdout)
 
 # there is potential risk of host name match, do a check here
 - name: pool name should have been defined here if only default pool exists
@@ -46,7 +46,7 @@
     that:
       - ssd_pool is defined
       - hybrid_pool is defined
-  when: result_first_osd_host is defined
+  when: result_first_osd_host.skipped is undefined
 
 # if default pool exists, ssd/hybrid pool exists too
 - name: set pool names if default pool and ssd pool exist
@@ -135,14 +135,14 @@
   set_fact:
     ceph_default_backend: "rbd_hybrid"
     ceph_default_pool: "{{ ceph_pools.rbd_hybrid.pool_name }}"
-  when: result_running_first_osd is defined and result_running_first_osd.rc != 0
+  when: result_running_first_osd.rc is defined and result_running_first_osd.rc != 0
 
 - name: ssd is the original backend
   set_fact:
     ceph_default_backend: "rbd_ssd"
     ceph_default_pool: "{{ ceph_pools.rbd_ssd.pool_name }}"
   with_items: "{{ groups['ceph_osds_ssd'] | default([]) }}"
-  when: result_running_first_osd is defined and result_running_first_osd.rc == 0 and
+  when: result_running_first_osd.rc is defined and result_running_first_osd.rc == 0 and
         item | search(result_running_first_osd.stdout)
 
 - name: hybrid is the original backend
@@ -150,7 +150,7 @@
     ceph_default_backend: "rbd_hybrid"
     ceph_default_pool: "{{ ceph_pools.rbd_hybrid.pool_name }}"
   with_items: "{{ groups['ceph_osds_hybrid'] | default([]) }}"
-  when: result_running_first_osd is defined and result_running_first_osd.rc == 0 and
+  when: result_running_first_osd.rc is defined and result_running_first_osd.rc == 0 and
         item | search(result_running_first_osd.stdout)
 
 # make a check here in case hostname search fail for unknow error


### PR DESCRIPTION
registered variables are always exists even the task is skipped.
So we can't judge if a task is skipped by if registered variable is
defined.

This path is to fix the bug in pool_names.yml