### PR TITLE
Provide Forwarding LocalHost For All Logging Enabled Envs

### DIFF
--- a/envs/example/allinone-centos/group_vars/all.yml
+++ b/envs/example/allinone-centos/group_vars/all.yml
@@ -55,6 +55,9 @@ logging:
           - /var/log/messages
         fields:
           type: syslog
+  forward:
+    host: 127.0.0.1
+    port: 4560
 
 serverspec:
   enabled: false
@@ -70,7 +73,7 @@ haproxy:
 keystone:
   ldap_domain:
     enabled: True
-    domain: users  
+    domain: users
   uwsgi:
     method: port
 

--- a/envs/example/allinone-rhel/group_vars/all.yml
+++ b/envs/example/allinone-rhel/group_vars/all.yml
@@ -62,6 +62,9 @@ logging:
           - /var/log/messages
         fields:
           type: syslog
+  forward:
+    host: 127.0.0.1
+    port: 4560
 
 serverspec:
   enabled: false
@@ -77,7 +80,7 @@ haproxy:
 keystone:
   ldap_domain:
     enabled: True
-    domain: users  
+    domain: users
   uwsgi:
     method: port
 

--- a/envs/example/ci-ceph-redhat/group_vars/all.yml
+++ b/envs/example/ci-ceph-redhat/group_vars/all.yml
@@ -44,6 +44,9 @@ logging:
           - /var/log/messages
         fields:
           type: syslog
+  forward:
+    host: 127.0.0.1
+    port: 4560
 
 serverspec:
   enabled: false

--- a/envs/example/ci-full-centos/group_vars/all.yml
+++ b/envs/example/ci-full-centos/group_vars/all.yml
@@ -35,6 +35,9 @@ logging:
           - /var/log/messages
         fields:
           type: syslog
+  forward:
+    host: 127.0.0.1
+    port: 4560
 
 serverspec:
   enabled: false
@@ -55,4 +58,3 @@ ironic:
 
 cinder:
   enabled: False
-

--- a/envs/example/ci-full-rhel/group_vars/all.yml
+++ b/envs/example/ci-full-rhel/group_vars/all.yml
@@ -10,7 +10,7 @@ state_path_base: /opt/stack/data
 validate_certs: false
 
 rhn_subscription:
-  username: "{{ rhn_user }}" 
+  username: "{{ rhn_user }}"
   password: "{{ rhn_pass }}"
 
 etc_hosts:
@@ -38,6 +38,9 @@ logging:
           - /var/log/messages
         fields:
           type: syslog
+  forward:
+    host: 127.0.0.1
+    port: 4560
 
 serverspec:
   enabled: false


### PR DESCRIPTION
Logging is defaulted to False in `envs/example/defaults-2.0.yml`, but I noticed that certain envs had logging enabled in their respective all.yml. Without specifying a `logging.forward.host` value as well in the all.yml, it defaults to `null` which was causing errors starting the service as the template (`roles/logging/templates/etc/filebeat/filebeat.yml`) wasn't being filled in properly.
Three possible solutions here:
1. Disable logging again in all.yml
2. (Current PR) - Set Forward Host to LocalHost (127.0.0.1) in all.yml's to allow service start with only connection refused and test the templating path
3. Implement the `logging.forward.enabled` feature that is currently being unused (maybe only run the filebeat.yml tasks when forward is enabled?)