### PR TITLE
Settle on common tag firewall instead of ufw and firewalld.

### DIFF
--- a/roles/aodh/tasks/main.yml
+++ b/roles/aodh/tasks/main.yml
@@ -12,10 +12,10 @@
 - name: create aodh cache dir
   file: dest=/var/cache/aodh state=directory mode=0700
         owner=aodh group=aodh
-        
+
 - name: permit access to aodh
   ufw: rule=allow to_port={{ endpoints.aodh.port.haproxy_api }} proto=tcp
-  tags: ufw
+  tags: firewall
 
 - name: install aodh services
   upstart_service: name={{ item }}
@@ -27,7 +27,7 @@
     - aodh-evaluator
     - aodh-listener
     - aodh-notifier
-    
+
 - name: aodh config
   template: src={{ item }} dest=/etc/aodh/
             mode={{ 0644 if 'policy.json' in item else 0640 }}
@@ -35,7 +35,7 @@
   with_fileglob: ../templates/etc/aodh/*
   notify:
     - restart aodh services
-    
+
 - name: stop aodh services before db sync
   service: name={{ item }} state=stopped
   when: database_create.changed or force_sync|default('false')|bool
@@ -65,7 +65,7 @@
         upgrade | default('False') | bool
 
 - meta: flush_handlers
-    
+
 - name: start aodh services
   service: name={{ item }} state=started
   with_items:

--- a/roles/ceilometer-control/tasks/main.yml
+++ b/roles/ceilometer-control/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: permit access to ceilometer
   ufw: rule=allow to_port={{ endpoints.ceilometer.port.haproxy_api }} proto=tcp
-  tags: ufw
+  tags: firewall
 
 - name: install ceilometer controller services
   upstart_service: name={{ item }}

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -95,11 +95,11 @@
 
 - include: ufw.yml
   when: os == 'ubuntu'
-  tags: ufw
+  tags: firewall
 
 - include: firewalld.yml
   when: os == 'rhel'
-  tags: firewalld
+  tags: firewall
 
 - include: ntp.yml
   tags: ntp

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -59,7 +59,7 @@
 - block:
   - name: permit access to glance (ubuntu)
     ufw: rule=allow to_port={{ item }} proto=tcp
-    tags: ufw
+    tags: firewall
     with_items:
       - "{{ endpoints.glance.port.haproxy_api }}"
       - "{{ endpoints.glance.port.backend_api }}"

--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: permit access to heat
   ufw: rule=allow to_port={{ item }} proto=tcp
-  tags: ufw
+  tags: firewall
   with_items:
     - "{{ endpoints.heat.port.haproxy_api }}"
     - "{{ endpoints.heat_cfn.port.haproxy_api }}"

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -241,7 +241,7 @@
 
 - name: Permit HTTP and HTTPS
   ufw: rule=allow to_port={{ item }} proto=tcp
-  tags: ufw
+  tags: firewall
   with_items:
   - 80
   - 443

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -52,12 +52,11 @@
 
   - name: permit access to keystone (ubuntu)
     ufw: rule=allow to_port={{ item }} proto=tcp
-    tags: ufw
+    tags: firewall
     with_items:
       - "{{ endpoints.keystone.port.haproxy_api }}"
       - "{{ endpoints.keystone_admin.port.haproxy_api }}"
       - "{{ endpoints.keystone_legacy.port.haproxy_api }}"
-    tags: firewall
   when: os == 'ubuntu'
 
 - block:

--- a/roles/magnum/tasks/main.yml
+++ b/roles/magnum/tasks/main.yml
@@ -57,7 +57,7 @@
 
 - name: permit access to magnum
   ufw: rule=allow to_port={{ item }} proto=tcp
-  tags: ufw
+  tags: firewall
   with_items:
     - "{{ endpoints.magnum.port.haproxy_api }}"
 

--- a/roles/nova-control/tasks/novnc.yml
+++ b/roles/nova-control/tasks/novnc.yml
@@ -33,7 +33,7 @@
 - name: Permit access to NoVNC (ubuntu)
   ufw: rule=allow to_port={{ endpoints.novnc.port.haproxy_api }} proto=tcp
   when: os == 'ubuntu'
-  tags: firewalld
+  tags: firewall
 
 - name: permit access to NoVNC (rhel)
   firewalld:

--- a/roles/swift-proxy/tasks/main.yml
+++ b/roles/swift-proxy/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: permit swift proxy from anywhere
   ufw: rule=allow to_port=8090 proto=tcp
-  tags: ufw
+  tags: firewall
 
 - name: swift-proxy service script
   upstart_service: name=swift-proxy
@@ -18,7 +18,7 @@
 - stat: path=/etc/swift/account.ring.gz
   register: account_ring
 
-- set_fact: start_proxy={{ container_ring.stat.exists }} and 
+- set_fact: start_proxy={{ container_ring.stat.exists }} and
                         {{ object_ring.stat.exists }} and
                         {{ account_ring.stat.exists }}
 


### PR DESCRIPTION
Merged tags `ufw`,`firewall`,`firewalld` into a universal `firewall`.

Cleaning up extra whitespace is just a side-effect perk of Atom.