### PR TITLE
Add playbooks for ci-full-rhel

### DIFF
--- a/playbooks/ci-full-rhel/tasks/pre-deploy.yml
+++ b/playbooks/ci-full-rhel/tasks/pre-deploy.yml
@@ -1,0 +1,31 @@
+---
+- name: controller 0 hosts file
+  hosts: controller[0]
+  tasks:
+    - name: add controller node to /etc/hosts
+      lineinfile: dest=/etc/hosts regexp={{ testenv_instance_prefix }}-controller-0
+                  insertafter=EOF
+                  line="127.0.1.1 {{ testenv_instance_prefix }}-controller-0"
+
+- name: controller 1 hosts file
+  hosts: controller[1]
+  tasks:
+    - name: add controller node to /etc/hosts
+      lineinfile: dest=/etc/hosts regexp={{ testenv_instance_prefix }}-controller-1
+                  insertafter=EOF
+                  line="127.0.1.1 {{ testenv_instance_prefix }}-controller-1"
+
+- name: compute 0 hosts file
+  hosts: compute[0]
+  tasks:
+    - name: add compute node to /etc/hosts
+      lineinfile: dest=/etc/hosts regexp={{ testenv_instance_prefix }}-compute-0
+                  insertafter=EOF
+                  line="127.0.1.1 {{ testenv_instance_prefix }}-compute-0"
+
+- name: tasks for all
+  hosts: all
+  serial: 10
+  tasks:
+  - name: Generate en_US locale
+    command: localedef -c -f UTF-8 -i en_US en_US.UTF-8

--- a/test/setup
+++ b/test/setup
@@ -38,16 +38,16 @@ eof
 echo "deleting heat stack to destroy resources including VMs: ${VMS}"
 ${ROOT}/test/cleanup
 
-echo "creating heat template for test env ..."
-if [[ ! -e ${ROOT}/envs/test/heat_stack.yml ]]; then
-  ursula --ursula-debug "envs/test" ${ROOT}/playbooks/${TEST_ENV}/tasks/create_heat_template.yml --extra-vars="use_private_ips=${USE_PRIVATE_IPS}"
-fi
-
 echo "building config"
 rm -rf ${ROOT}/envs/test/group_vars/
 rm -f ${ROOT}/envs/test/hosts
+rm -f ${ROOT}/envs/test/heat_stack.yml
 mkdir -p ${ROOT}/envs/test/group_vars
 cp -r ${ROOT}/envs/example/${TEST_ENV}/* ${ROOT}/envs/test
+echo "creating heat template for test env if no heat_stack.yml in envs/test/..."
+if [[ ! -e ${ROOT}/envs/test/heat_stack.yml ]]; then
+  ursula --ursula-debug "envs/test" ${ROOT}/playbooks/${TEST_ENV}/tasks/create_heat_template.yml --extra-vars="use_private_ips=${USE_PRIVATE_IPS}"
+fi
 echo "testenv_instance_prefix: ${testenv_instance_prefix}" >> ${ROOT}/envs/test/group_vars/all.yml
 
 #echo "generating ssl cert for openstack.example.com"


### PR DESCRIPTION
When running Ursula with ci-full-rhel started from ursula/test/setup, and found that we missed the playbook of ci-full-rhel so that setup is failed. So here I added the playbook of ci-full-rhel referred to ci-full-centos playbook.
Also I modified test/common to fit ci-full-rhel running.
