### PR TITLE
Ceph NVMe support

### DIFF
--- a/library/ceph_bcache.py
+++ b/library/ceph_bcache.py
@@ -33,6 +33,7 @@ EXAMPLES = """
 """
 
 import os
+import re
 
 
 def main():
@@ -51,13 +52,15 @@ def main():
 
     # the disks have symlinks to /dev/bcacheX. we need the disks
     # in increasing order by X.
+    # Use regex to determine the bcache index
+
     for subdir, dirs, files in os.walk('/dev/disk/by-uuid/'):
       for uuid in files:
         disk = os.path.join(subdir, uuid)
         path = os.path.realpath(disk)
 
         if 'bcache' in path:
-          bcache_index = int(path[len(path)-1:])
+          bcache_index = int(re.search(r'\d+$', path).group(0))
           uuids_in_order.pop(bcache_index)
           uuids_in_order.insert(bcache_index,uuid)
 
@@ -86,13 +89,19 @@ def main():
 
         os.remove('/var/lib/ceph/osd/ceph-' + osd_id + '/journal')
 
-        cmd = ['chown', 'ceph:ceph', '/dev/' + ssd_device + str(partition_index)]
+        if 'nvme' in ssd_device:
+            cmd = ['chown', 'ceph:ceph', '/dev/' + ssd_device + 'p' + str(partition_index)]
+        else:
+            cmd = ['chown', 'ceph:ceph', '/dev/' + ssd_device + str(partition_index)]
         rc, out, err = module.run_command(cmd, check_rc=True)
 
         cmd = ['sgdisk', '-t', str(partition_index) + ':' + journal_guid, '/dev/' + ssd_device]
         rc, out, err = module.run_command(cmd, check_rc=True)
 
-        cmd = ['ln', '-s', '/dev/' + ssd_device + str(partition_index), '/var/lib/ceph/osd/ceph-' + osd_id + '/journal']
+        if 'nvme' in ssd_device:
+            cmd = ['ln', '-s', '/dev/' + ssd_device + 'p' + str(partition_index), '/var/lib/ceph/osd/ceph-' + osd_id + '/journal']
+        else:
+            cmd = ['ln', '-s', '/dev/' + ssd_device + str(partition_index), '/var/lib/ceph/osd/ceph-' + osd_id + '/journal']
         rc, out, err = module.run_command(cmd, check_rc=True)
 
         cmd = ['ceph-osd', '-i', osd_id, '--mkjournal']

--- a/roles/ceph-osd/tasks/bcache.yml
+++ b/roles/ceph-osd/tasks/bcache.yml
@@ -48,6 +48,15 @@
   when: journal_partitions.rc != 0 and
         bcache_partition.rc != 0
 
+- name: initialize partition_connector flag
+  set_fact:
+    partition_connector: ''
+
+- name: set partition_connector flag for nvme
+  set_fact:
+    partition_connector: 'p'
+  when: ceph.bcache_ssd_device|search('nvme')
+
 - name: mklabel gpt
   command: "parted -s /dev/{{ ceph.bcache_ssd_device }} mklabel gpt"
   when: ok_to_deploy
@@ -64,7 +73,7 @@
   when: ok_to_deploy
 
 - name: make-bcache -C <ssd device>
-  command: make-bcache -C /dev/{{ ceph.bcache_ssd_device }}{{ ceph.disks|length + 1 }}
+  command: make-bcache -C /dev/{{ ceph.bcache_ssd_device }}{{ partition_connector }}{{ ceph.disks|length + 1 }}
   ignore_errors: true
   when: ok_to_deploy
 
@@ -87,14 +96,14 @@
   with_sequence: "start=0 end={{ ceph.disks|length - 1 }}"
   when: ok_to_deploy
 
-- name: determine bcache uuid
-  shell: bcache-super-show /dev/{{ ceph.bcache_ssd_device }}{{ ceph.disks|length + 1 }} |
+- name: determine bcache uuid SSD
+  shell: bcache-super-show /dev/{{ ceph.bcache_ssd_device }}{{ partition_connector }}{{ ceph.disks|length + 1 }} |
          grep cset.uuid | awk '{print $2}'
   changed_when: false
   register: bcache_uuid
   when: ok_to_deploy
 
-- name: attach to bcache devices
+- name: attach to bcache devices SSD
   shell: echo {{ bcache_uuid.stdout }} > /sys/block/bcache{{ item }}/bcache/attach
   with_sequence: "start=0 end={{ ceph.disks|length - 1 }}"
   when: ok_to_deploy


### PR DESCRIPTION
Changes:
1. bcache_index to support values more than 9
2. When a partition is created on nvme device it has an extra character, 'p' in it. This code change is to account for the extra character.

Please DONOT merge this into Master. Will submit a separate PR for master.