### PR TITLE
modifications for skip tag 'precheck'

### DIFF
--- a/roles/preflight-checks/tasks/check_items.yml
+++ b/roles/preflight-checks/tasks/check_items.yml
@@ -1,0 +1,41 @@
+---
+- block:
+  - name: check whether neutron-client is installed
+    command: neutron --version
+    register: result_neutron_installed
+    failed_when: false
+
+  - name: check whether neutron endpoint exists
+    shell: . /root/stackrc; openstack endpoint list | grep neutron
+    failed_when: false
+    register: result_neutron_endpoint
+
+  - include: neutron.yml
+    when:
+      - result_neutron_installed.rc == 0
+      - result_neutron_endpoint.rc == 0
+
+  delegate_to: "{{ groups['controller'][0] }}"
+  run_once: true
+
+- block:
+  - name: check ceph installed
+    command: ceph --version
+    register: result_ceph_installed
+    failed_when: false
+    delegate_to: "{{ groups['ceph_monitors'][0] }}"
+
+  - name: Check whether Cinder endpoint exists
+    shell: . /root/stackrc; openstack endpoint list | grep cinder
+    failed_when: false
+    register: result_cinder_endpoint
+    delegate_to: "{{ groups['controller'][0] }}"
+
+  - include: ceph.yml
+    when:
+      - result_ceph_installed.rc == 0
+      - result_cinder_endpoint.rc == 0
+
+  when: ceph.enabled | default('False') | bool
+  tags: ['precheck_ceph']
+  run_once: true

--- a/roles/preflight-checks/tasks/main.yml
+++ b/roles/preflight-checks/tasks/main.yml
@@ -33,45 +33,5 @@
     ca_bundle: /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
   when: os == 'rhel'
 
-
-
-- block:
-  - name: check whether neutron-client is installed
-    command: neutron --version
-    register: result_neutron_installed
-    failed_when: false
-
-  - name: check whether neutron endpoint exists
-    shell: . /root/stackrc; openstack endpoint list | grep neutron
-    failed_when: false
-    register: result_neutron_endpoint
-
-  - include: neutron.yml
-    when:
-      - result_neutron_installed.rc == 0
-      - result_neutron_endpoint.rc == 0
-
-  delegate_to: "{{ groups['controller'][0] }}"
-  run_once: true
-
-- block:
-  - name: check ceph installed
-    command: ceph --version
-    register: result_ceph_installed
-    failed_when: false
-    delegate_to: "{{ groups['ceph_monitors'][0] }}"
-
-  - name: Check whether Cinder endpoint exists
-    shell: . /root/stackrc; openstack endpoint list | grep cinder
-    failed_when: false
-    register: result_cinder_endpoint
-    delegate_to: "{{ groups['controller'][0] }}"
-
-  - include: ceph.yml
-    when:
-      - result_ceph_installed.rc == 0
-      - result_cinder_endpoint.rc == 0
-
-  when: ceph.enabled | default('False') | bool
-  tags: ['precheck', 'precheck_ceph']
-  run_once: true
+- include: check_items.yml
+  tags: ['precheck']

--- a/site.yml
+++ b/site.yml
@@ -17,7 +17,7 @@
   hosts: all:!vyatta-*
   roles:
     - role: preflight-checks
-      tags: ['always','precheck']
+      tags: ['always']
   environment: "{{ env_vars|default({}) }}"
 
 - name: RedHat Network registration for RedHat hosts


### PR DESCRIPTION
when we use '--skip-tags precheck' before, ursula will skip all registered variables and all items that need to be prechecked, however, registered variables are very useful and cannot skip them.

changes:
1. move checked items to file ' roles/preflight-checks/tasks/check_items.yml' and tag it 'precheck'.
2. keep all registered variables in file 'roles/preflight-checks/tasks/main.yml'.