### PR TITLE
Add network troubleshoot tools

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -76,6 +76,10 @@ common:
         - curl
         - dstat
         - ethtool
+        - net-tools
+        - bind-utils
+        - traceroute
+        - tcpdump
         - git
         - iotop
         - ltrace


### PR DESCRIPTION
Adding the following network tools to help developers troubleshoot:
- tcpdump
- traceroute
- net-tools: arp, hostname, ifconfig, ipmaddr, iptunnel, mii-tool, nameif, netstat, plipconfig, rarp, route, slattach
- bind-utils: dig, host, nslookup
