### PR TITLE
Add jellyroll infra for rhel nightly build

### DIFF
--- a/envs/example/ci-full-rhel/group_vars/all.yml
+++ b/envs/example/ci-full-rhel/group_vars/all.yml
@@ -21,6 +21,13 @@ neutron:
   enable_external_interface: True
   lbaas:
     enabled: False
+  jellyroll: true
+  distro:
+    python_post_dependencies:
+      - name: python-memcached
+      - name: jellyroll
+        version: 0.0.9.dev19
+        pip_extra_args: ~
 
 common:
   hwraid:
@@ -56,6 +63,13 @@ haproxy:
 keystone:
   uwsgi:
     method: port
+  jellyroll: true
+  distro:
+    python_post_dependencies:
+      - name: python-memcached
+      - name: jellyroll
+        version: 0.0.9.dev19
+        pip_extra_args: ~
 
 heat:
   enabled: True


### PR DESCRIPTION
We'll be running jellyroll on rhel nightly builds so we are putting this vars in as infrastructure to enable it. pip_extra_vars gets overriden by jenkins to the needed value.