### PR TITLE
enable heat ucd plugin post_python_dependencies hook.

### DIFF
--- a/envs/example/ci-ceph-redhat/group_vars/all.yml
+++ b/envs/example/ci-ceph-redhat/group_vars/all.yml
@@ -68,6 +68,9 @@ nova:
 
 heat:
   enabled: True
+  plugin_dirs:
+    - '/usr/lib/heat'
+    - '/usr/lib64/heat'
 
 ironic:
   enabled: False

--- a/envs/example/ci-full-rhel/group_vars/all.yml
+++ b/envs/example/ci-full-rhel/group_vars/all.yml
@@ -57,6 +57,9 @@ keystone:
 
 heat:
   enabled: True
+  plugin_dirs:
+    - '/usr/lib/heat'
+    - '/usr/lib64/heat'
 
 ironic:
   enabled: False

--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -596,6 +596,8 @@ common:
 
 heat:
   enabled: True
+  plugin_dirs:
+    - '/opt/openstack/current/heat/lib/heat/ibm_sw_orch/heat/'
   logging:
     debug: True
     verbose: True

--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -1,23 +1,30 @@
 ---
 project_name: heat
 heat:
+  enabled: True
+  heartbeat_timeout_threshold: 30
   services:
     heat_api: "{{ openstack_meta.heat.services.heat_api[os] }}"
     heat_api_cfn: "{{ openstack_meta.heat.services.heat_api_cfn[os] }}"
     heat_engine: "{{ openstack_meta.heat.services.heat_engine[os] }}"
-  enabled: True
-  heartbeat_timeout_threshold: 30
   distro:
     project_packages:
       - openstack-heat-api
       - openstack-heat-api-cfn
       - openstack-heat-engine
+    # Example for distro/source:
+    # python_post_dependencies:
+    #   - name: ibm-sw-orch
+    #     version: 6.2.3.dev135
+    #     pip_extra_args: '--extra-index-url https://pypi-mirror.openstack.blueboxgrid.com/root/pypi...'
+    python_post_dependencies: []
   source:
     rev: 'stable/newton'
     constrain: True
     upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt'
     python_dependencies:
       - { name: PyMySQL }
+    python_post_dependencies: []
     system_dependencies:
       ubuntu: []
       rhel: []

--- a/roles/heat/meta/main.yml
+++ b/roles/heat/meta/main.yml
@@ -14,6 +14,7 @@ dependencies:
     alternatives: "{{ heat.alternatives }}"
     system_dependencies: "{{ heat.source.system_dependencies }}"
     python_dependencies: "{{ heat.source.python_dependencies }}"
+    python_post_dependencies: "{{ heat.source.python_post_dependencies }}"
     constrain: "{{ heat.source.constrain }}"
     upper_constraints: "{{ heat.source.upper_constraints }}"
     when: openstack_install_method == 'source'
@@ -24,6 +25,7 @@ dependencies:
   - role: openstack-distro
     project_name: heat
     project_packages: "{{ heat.distro.project_packages }}"
+    python_post_dependencies: "{{ heat.distro.python_post_dependencies }}"
     when: openstack_install_method == 'distro'
   - role: openstack-database
     database_name: heat


### PR DESCRIPTION
Enables heat role for post python dependencies hook which will allow deployment of heat plugin extension for distro and source install types.