### PR TITLE
Explicitly define distro project packages to be installed.

### DIFF
--- a/roles/aodh/defaults/main.yml
+++ b/roles/aodh/defaults/main.yml
@@ -2,6 +2,9 @@
 project_name: aodh
 aodh:
   debug: False
+  distro:
+    project_packages:
+      - openstack-aodh
   source:
     rev: 'stable/newton'
     constrain: True

--- a/roles/aodh/meta/main.yml
+++ b/roles/aodh/meta/main.yml
@@ -20,4 +20,5 @@ dependencies:
     database_name: aodh
   - role: openstack-distro
     project_name: aodh
+    project_packages: "{{ aodh.distro.project_packages }}"
     when: openstack_install_method == 'distro'

--- a/roles/ceilometer-common/defaults/main.yml
+++ b/roles/ceilometer-common/defaults/main.yml
@@ -2,6 +2,9 @@
 project_name: ceilometer
 ceilometer:
   enabled: False
+  distro:
+    project_packages:
+      - openstack-ceilometer
   source:
     rev: 'stable/newton'
     constrain: True

--- a/roles/ceilometer-common/meta/main.yml
+++ b/roles/ceilometer-common/meta/main.yml
@@ -21,4 +21,5 @@ dependencies:
     when: openstack_install_method == 'package'
   - role: openstack-distro
     project_name: ceilometer
+    project_packages: "{{ ceilometer.distro.project_packages }}"
     when: openstack_install_method == 'distro'

--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -54,6 +54,9 @@ cinder:
       - cinder-volume
       - cinder-volume-usage-audit
   heartbeat_timeout_threshold: 30
+  distro:
+    project_packages:
+      - openstack-cinder
   source:
     rev: 'stable/newton'
     constrain: True

--- a/roles/cinder-common/meta/main.yml
+++ b/roles/cinder-common/meta/main.yml
@@ -27,5 +27,6 @@ dependencies:
     when: ceph.enabled|bool
   - role: openstack-distro
     project_name: cinder
+    project_packages: "{{ cinder.distro.project_packages }}"
     rootwrap: True
     when: openstack_install_method == 'distro'

--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -24,6 +24,9 @@ glance:
   store_swift: False
   store_ceph: False
   store_file: False
+  distro:
+    project_packages:
+      - openstack-glance
   source:
     rev: 'stable/newton'
     constrain: True

--- a/roles/glance/meta/main.yml
+++ b/roles/glance/meta/main.yml
@@ -29,4 +29,5 @@ dependencies:
     database_name: glance
   - role: openstack-distro
     project_name: glance
+    project_packages: "{{ glance.distro.project_packages }}"
     when: openstack_install_method == 'distro'

--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -5,13 +5,13 @@ heat:
     heat_api: "{{ openstack_meta.heat.services.heat_api[os] }}"
     heat_api_cfn: "{{ openstack_meta.heat.services.heat_api_cfn[os] }}"
     heat_engine: "{{ openstack_meta.heat.services.heat_engine[os] }}"
-  osp_sys_packages: 
-    - openstack-heat-api
-    - openstack-heat-api-cfn
-    - openstack-heat-engine
-    - openstack-heat-common
   enabled: True
   heartbeat_timeout_threshold: 30
+  distro:
+    project_packages:
+      - openstack-heat-api
+      - openstack-heat-api-cfn
+      - openstack-heat-engine
   source:
     rev: 'stable/newton'
     constrain: True

--- a/roles/heat/meta/main.yml
+++ b/roles/heat/meta/main.yml
@@ -22,9 +22,8 @@ dependencies:
     alternatives: "{{ heat.alternatives }}"
     when: openstack_install_method == 'package'
   - role: openstack-distro
-    dependent_packages: "{{ heat.osp_sys_packages }}" 
     project_name: heat
-    package_name: openstack-heat-common
+    project_packages: "{{ heat.distro.project_packages }}"
     when: openstack_install_method == 'distro'
   - role: openstack-database
     database_name: heat

--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -8,13 +8,14 @@ horizon:
   nextgen_instance_panel: true
   legacy_instance_panel: false
   session_engine: django.contrib.sessions.backends.cache
-  osp_sys_packages:
-    - neutron-lbaas-dashboard
   password_validator:
     enabled: True
     regex: '^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&+=()_]).{8,}$'
     help_text: 'Password is not compliant. Password must contain uppercase, lowercase, special characters !@#$%%^&+=()_, digits, and be at least 8 characters in length.'
   distro:
+    project_packages:
+      - openstack-dashboard
+      - openstack-neutron-lbaas-ui
     python_post_dependencies: []
   source:
     python_post_dependencies: []

--- a/roles/horizon/meta/main.yml
+++ b/roles/horizon/meta/main.yml
@@ -19,12 +19,11 @@ dependencies:
     when: openstack_install_method == 'source'
   - role: openstack-package
     project_name: horizon
-    when: openstack_install_method == 'package' 
+    when: openstack_install_method == 'package'
   - role: openstack-distro
     project_name: horizon
-    dependent_packages: "{{ horizon.osp_sys_packages }}"
-    package_name: openstack-dashboard
+    project_packages: "{{ horizon.distro.project_packages }}"
     python_post_dependencies: "{{ horizon.distro.python_post_dependencies }}"
-    when: openstack_install_method == 'distro' 
+    when: openstack_install_method == 'distro'
   - role: apache
   - role: keystone-defaults

--- a/roles/ironic-common/defaults/main.yml
+++ b/roles/ironic-common/defaults/main.yml
@@ -17,6 +17,9 @@ ironic:
     - agent_ssh
     - agent_ipmitool
   heartbeat_timeout_threshold: 30
+  distro:
+    project_packages:
+      - openstack-ironic
   source:
     rev: 'stable/newton'
     constrain: True

--- a/roles/ironic-common/meta/main.yml
+++ b/roles/ironic-common/meta/main.yml
@@ -21,4 +21,5 @@ dependencies:
     when: openstack_install_method == 'package'
   - role: openstack-distro
     project_name: ironic
+    project_packages: "{{ ironic.distro.project_packages }}"
     when: openstack_install_method == 'distro'

--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -16,6 +16,8 @@ keystone:
       source: /opt/openstack/current/keystone
       package: /opt/openstack/current/keystone
   distro:
+    project_packages:
+      - openstack-keystone
     python_post_dependencies: []
   # Example for distro/source:
   # python_post_dependencies:

--- a/roles/keystone/meta/main.yml
+++ b/roles/keystone/meta/main.yml
@@ -25,6 +25,7 @@ dependencies:
     when: openstack_install_method == 'package'
   - role: openstack-distro
     project_name: keystone
+    project_packages: "{{ keystone.distro.project_packages }}"
     python_post_dependencies: "{{ keystone.distro.python_post_dependencies }}"
     when: openstack_install_method == 'distro'
   - role: collectd-plugin

--- a/roles/magnum/defaults/main.yml
+++ b/roles/magnum/defaults/main.yml
@@ -3,6 +3,9 @@ magnum:
   port: 9512
   host: 127.0.0.1
   heartbeat_timeout_threshold: 30
+  distro:
+    project_packages:
+      - openstack-magnum
   source:
     rev: 'stable/newton'
     constrain: True

--- a/roles/magnum/meta/main.yml
+++ b/roles/magnum/meta/main.yml
@@ -27,4 +27,5 @@ dependencies:
     database_name: magnum
   - role: openstack-distro
     project_name: magnum
+    project_packages: "{{ magnum.distro.project_packages }}"
     when: openstack_install_method == 'distro'

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -18,8 +18,6 @@ neutron:
   path_mtu: 1550
   global_physnet_mtu: 1550
   max_subnet_host_routes: 20
-  osp_sys_packages:
-    - openstack-neutron-linuxbridge
   vxlan:
     # The multicast prefix to use for broadcast, multicast and unknown frames
     # Consider using a larger prefix (e.g. a /24) on deployments with a
@@ -84,6 +82,12 @@ neutron:
   service:
     envs: []
   distro:
+    project_packages:
+      - openstack-neutron
+      - openstack-neutron-linuxbridge
+    lbaas_v2:
+      project_packages:
+        - openstack-neutron-lbaas
     python_post_dependencies: []
   # Example for distro/source:
   # python_post_dependencies:

--- a/roles/neutron-common/meta/main.yml
+++ b/roles/neutron-common/meta/main.yml
@@ -26,15 +26,14 @@ dependencies:
     when: openstack_install_method == 'package'
   - role: openstack-distro
     project_name: neutron
-    dependent_packages: "{{ neutron.osp_sys_packages }}"
+    project_packages: "{{ neutron.distro.project_packages }}"
     python_post_dependencies: "{{ neutron.distro.python_post_dependencies }}"
     rootwrap: True
     when: openstack_install_method == 'distro'
   - role: openstack-distro
     project_name: neutron-lbaas
-    dependent_packages: "{{ neutron.osp_sys_packages }}"
+    project_packages: "{{ neutron.distro.lbaas_v2.project_packages }}"
     rootwrap: True
-    when: 
-      - os == 'rhel'
+    when:
       - openstack_install_method == 'distro'
       - (neutron.lbaas.enabled == "smart" and groups['controller'][0] not in groups['compute']) or neutron.lbaas.enabled|bool

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -65,6 +65,17 @@ nova:
       rev: 'stable/newton'
       git_mirror: https://github.com/stackforge/nova-docker.git
       dest: /opt/stack/novadocker
+  distro:
+    controller:
+      project_packages:
+        - openstack-nova-api
+        - openstack-nova-conductor
+        - openstack-nova-scheduler
+        - openstack-nova-novncproxy
+        - openstack-nova-console
+    compute:
+      project_packages:
+        - openstack-nova-compute
   source:
     rev: 'stable/newton'
     constrain: True

--- a/roles/nova-common/meta/main.yml
+++ b/roles/nova-common/meta/main.yml
@@ -31,5 +31,15 @@ dependencies:
     when: openstack_install_method == 'package'
   - role: openstack-distro
     project_name: nova
+    project_packages: "{{ nova.distro.controller.project_packages }}"
     rootwrap: True
-    when: openstack_install_method == 'distro'
+    when: 
+      - openstack_install_method == 'distro'
+      - inventory_hostname in groups['controller']
+  - role: openstack-distro
+    project_name: nova
+    project_packages: "{{ nova.distro.compute.project_packages }}"
+    rootwrap: True
+    when:
+      - openstack_install_method == 'distro'
+      - inventory_hostname in groups['compute']

--- a/roles/openstack-distro/defaults/main.yml
+++ b/roles/openstack-distro/defaults/main.yml
@@ -1,4 +1,5 @@
 openstack_distro:
-  osp_package_name: 'openstack-{{ project_name }}'
+  project_packages: "{{ project_packages|default([]) }}"
+  dependent_packages: "{{ dependent_packages|default([]) }}"
   python_post_dependencies: "{{ python_post_dependencies|default([]) }}"
   pip_extra_args: ""

--- a/roles/openstack-distro/tasks/osp.yml
+++ b/roles/openstack-distro/tasks/osp.yml
@@ -1,11 +1,12 @@
 ---
 - name: "install {{ project_name }} package"
   yum:
-    name: "{{ package_name|default(openstack_distro.osp_package_name) }}"
+    name: "{{ item }}"
     state: present
   register: project_package
   until: project_package|succeeded
   retries: 5
+  with_items: "{{ openstack_distro.project_packages }}"
 
 - name: "Install {{ project_name }} dependent packages"
   yum:
@@ -14,8 +15,7 @@
   register: dep_package
   until: dep_package|succeeded
   retries: 5
-  with_items: "{{ dependent_packages }}"
-  when: dependent_packages is defined
+  with_items: "{{ openstack_distro.dependent_packages }}"
 
 - name: set pip args fact
   set_fact:

--- a/roles/swift-common/defaults/main.yml
+++ b/roles/swift-common/defaults/main.yml
@@ -7,6 +7,9 @@ swift:
   disks:
     - disk: sdb
   allow_versions: True
+  distro:
+    project_packages:
+      - openstack-swift
   source:
     rev: 'stable/newton'
     constrain: True
@@ -107,4 +110,3 @@ swift:
         no_auditors: 1
         no_updaters: 1
   venv_dir: '/opt/openstack/current/swift'
-

--- a/roles/swift-common/meta/main.yml
+++ b/roles/swift-common/meta/main.yml
@@ -22,5 +22,5 @@ dependencies:
     when: openstack_install_method == 'package'
   - role: openstack-distro
     project_name: swift
+    project_packages: "{{ swift.distro.project_packages }}"
     when: openstack_install_method == 'distro'
-


### PR DESCRIPTION
Openstack distro packages could bring in un-wanted dependent packages when using openstack-{project_name} as package to be installed. This approach work good with our giftwrap as we bundle required supported features in each project giftwrap.

Example: openstack-nova rhosp package will install all the openstack-nova plgs (cell, cert, placement-api, etc).

This PR, enabled openstack-distro to take list of project_packages that will be installed for a given project. 