### PR TITLE
Add initial inspec checks for the OpenStack services

### DIFF
--- a/roles/inspec/defaults/main.yml
+++ b/roles/inspec/defaults/main.yml
@@ -3,3 +3,16 @@ inspec:
   version: ~
   enabled: true
   interval: 3600
+  dependency_install_method: 'tar'
+  dependency_path: /etc/inspec/
+  profile_dependencies:
+    - name: inspec-openstack-security
+      version: master
+      url: https://github.com/chef-partners/inspec-openstack-security/archive/master.tar.gz
+  openstack:
+    horizon:
+      required_controls:
+        - check-dashboard-01
+        - check-dashboard-02
+      attributes:
+        horizon_config_group: apache

--- a/roles/inspec/tasks/main.yml
+++ b/roles/inspec/tasks/main.yml
@@ -10,18 +10,79 @@
     mode: 0755
   with_items:
     - /etc/inspec
-    - /etc/inspec/controls
-    - /etc/inspec/libraries
+    - /etc/inspec/host-controls
+    - /etc/inspec/host-controls/controls
+    - /etc/inspec/host-controls/controls/controller
+    - /etc/inspec/host-controls/libraries
 
-- name: inspec config file
+- name: inspec dependency profile directories
+  file:
+    dest: '{{ inspec.dependency_path }}/archive/'
+    mode: 0766
+    state: directory
+  with_items: '{{inspec.profile_dependencies }}'
+  when: inspec.dependency_install_method == 'tar'
+
+- name: create current directory for inspec dependencies
+  file:
+    dest: '{{ inspec.dependency_path }}/current/'
+    mode: 0766
+    state: directory
+  when: inspec.dependency_install_method == 'tar'
+
+- name: fetch inspec dependencies when install method is tar
+  get_url:
+    url: '{{ item.url }}'
+    dest: '{{ inspec.dependency_path }}/archive/{{ item.name }}-{{ item.version }}'
+    mode: 0644
+  with_items: '{{ inspec.profile_dependencies }}'
+  when: inspec.dependency_install_method == 'tar'
+
+- name: untar inspec dependencies
+  unarchive:
+    src: '{{ inspec.dependency_path }}/archive/{{ item.name }}-{{ item.version }}'
+    dest: '{{ inspec.dependency_path }}'
+    copy: no
+  with_items: '{{inspec.profile_dependencies }}'
+  when: inspec.dependency_install_method == 'tar'
+
+- name: create inspec dependency current symlink
+  file:
+    src: '{{ inspec.dependency_path }}/{{ item.name }}-{{ item.version }}'
+    dest: '{{ inspec.dependency_path }}/current/{{ item.name }}'
+    state: link
+    force: true
+  with_items: '{{inspec.profile_dependencies }}'
+  when: inspec.dependency_install_method == 'tar'
+
+- name: inspec profile yml
   template:
-    src: etc/inspec/inspec.yml
-    dest: /etc/inspec/inspec.yml
+    src: etc/inspec/host-controls/inspec.yml
+    dest: /etc/inspec/host-controls/inspec.yml
+    mode: 0644
+
+- name: inspec controller control files
+  template:
+    src: '{{ item }}'
+    dest: /etc/inspec/host-controls/controls/controller/
+    mode: 0644
+  with_fileglob: ../templates/etc/inspec/host-controls/controls/controller/*
+  when: inventory_hostname in groups['controller']
+
+- name: remove inspec lock file so we can upgrade
+  file:
+    dest: /etc/inspec/host-controls/inspec.lock
+    state: absent
+
+- name: inspec attributes
+  template:
+    src: etc/inspec/host-controls/attributes.yml
+    dest: /etc/inspec/host-controls/attributes.yml
     mode: 0644
 
 - name: inspec sensu hook
   sensu_check: name=inspec-check plugin=check-inspec.rb
-               args='--controls /etc/inspec/controls' use_sudo=true
+               args='/etc/inspec/host-controls --attrs /etc/inspec/host-controls/attributes.yml' use_sudo=true
                interval={{ inspec.interval }}
   notify: restart sensu-client
   when: inspec.enabled|default(True)|bool

--- a/roles/inspec/templates/etc/inspec/host-controls/attributes.yml
+++ b/roles/inspec/templates/etc/inspec/host-controls/attributes.yml
@@ -1,0 +1,3 @@
+{% for name,value in inspec.openstack.horizon.attributes.iteritems() %}
+{{ name }}: {{ value }}
+{% endfor %}

--- a/roles/inspec/templates/etc/inspec/host-controls/controls/controller/openstack-security.rb
+++ b/roles/inspec/templates/etc/inspec/host-controls/controls/controller/openstack-security.rb
@@ -1,0 +1,9 @@
+# encoding: utf-8
+# license: Apache 2.0
+#title 'host-controls'
+
+require_controls 'inspec-openstack-security' do
+{% for control in inspec.openstack.horizon.required_controls %}
+    control '{{ control }}'
+{% endfor %}
+end

--- a/roles/inspec/templates/etc/inspec/host-controls/inspec.yml
+++ b/roles/inspec/templates/etc/inspec/host-controls/inspec.yml
@@ -1,0 +1,13 @@
+name: Ursula
+title: Compliance Audit
+maintainer: Ursula Team
+copyright: IBM
+copyright_email:
+license: Apache 2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+depends:
+{% for profile in inspec.profile_dependencies %}
+- name: {{ profile.name }}
+  path: '{{ inspec.dependency_path }}/current/{{ profile.name }}'
+{% endfor %}

--- a/roles/inspec/templates/etc/inspec/inspec.yml
+++ b/roles/inspec/templates/etc/inspec/inspec.yml
@@ -1,8 +1,0 @@
-name: Ursula
-title: Compliance Audit
-maintainer: Ursula Team
-copyright: IBM
-copyright_email:
-license: All Rights Reserved
-summary: An InSpec Compliance Profile
-version: 0.1.0


### PR DESCRIPTION
This adds the feature to download a tar bar of an inspec profile
dependency. The dependency being pulled down are the inspec
openstack security check. A control file called openstack-security.rb
will contain the list of controls to run for a controller node.