### PR TITLE
using tmpfiles.d create  /run/haproxy and /run/uswgi on reboot.

### DIFF
--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -21,13 +21,24 @@
   template: src=etc/init.d/haproxy dest=/etc/init.d/haproxy mode=0755
   when: os == "ubuntu"
 
-- name: install haproxy rsyslog config
-  template: src=etc/rsyslog.d/haproxy.conf
-            dest=/etc/rsyslog.d/49-haproxy.conf
+- block:
+  - name: configure tmpfiles.d for creation of /run/haproxy on reboot
+    template:
+      src: usr/lib/tmpfiles.d/haproxy.conf
+      dest: /usr/lib/tmpfiles.d/haproxy.conf
+      mode: 0644
+
+  - name: install haproxy rsyslog config
+    template: src=etc/rsyslog.d/haproxy.conf
+              dest=/etc/rsyslog.d/49-haproxy.conf
+    notify: restart rsyslog
+    tags:
+      - ssl
+
+  - name: set selinux policy for haproxy
+    seboolean: name=haproxy_connect_any state=yes persistent=yes
+    tags: selinux
   when: os == 'rhel'
-  notify: restart rsyslog
-  tags:
-    - ssl
 
 - name: install ssl cert+key
   template: src=etc/haproxy/openstack.pem dest=/etc/haproxy/openstack.pem
@@ -42,11 +53,6 @@
   notify: reload haproxy
 
 - meta: flush_handlers
-
-- name: set selinux policy for haproxy
-  seboolean: name=haproxy_connect_any state=yes persistent=yes
-  when: os == 'rhel'
-  tags: selinux
 
 - name: start and enable haproxy
   service: name=haproxy state=started enabled=yes

--- a/roles/haproxy/templates/usr/lib/tmpfiles.d/haproxy.conf
+++ b/roles/haproxy/templates/usr/lib/tmpfiles.d/haproxy.conf
@@ -1,0 +1,1 @@
+d /run/haproxy   755 root root

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -84,6 +84,12 @@
       - "{{ endpoints.keystone_admin.port.haproxy_api }}"
       - "{{ endpoints.keystone_legacy.port.haproxy_api }}"
     tags: firewall
+
+  - name: Configure tmpfiles.d for creation of /run/uwsgi on reboot
+    template:
+      src: usr/lib/tmpfiles.d/openstack-keystone.conf
+      dest: /usr/lib/tmpfiles.d/openstack-keystone.conf
+      mode: 0644
   when: os == 'rhel'
 
 - name: Creates keystone uwsgi and httpd directories

--- a/roles/keystone/templates/usr/lib/tmpfiles.d/openstack-keystone.conf
+++ b/roles/keystone/templates/usr/lib/tmpfiles.d/openstack-keystone.conf
@@ -1,0 +1,1 @@
+d /run/uwsgi   755 keystone keystone


### PR DESCRIPTION
On controller reboot, haproxy and uswgi fails to start due to missing directories in /run. This PR will drop-in haproxy.conf and openstack-keystone.conf in /usr/lib/tmpfiles.d that will ensure these folder are created on service start.

In ubuntu we are doing this via our wrapper start scripts.