### PR TITLE
enable rhn repos in a single cmd.

### DIFF
--- a/roles/rhn-subscription/tasks/main.yml
+++ b/roles/rhn-subscription/tasks/main.yml
@@ -14,5 +14,4 @@
   with_items: "{{ rhn_subscription.repos.disable }}"
 
 - name: enable desire redhat repositories
-  command: subscription-manager repos --enable={{ item }}
-  with_items: "{{ rhn_subscription.repos.enable }}"
+  command: subscription-manager repos --enable={{ rhn_subscription.repos.enable | join(' --enable=') }}


### PR DESCRIPTION
Enabling single repo at a time using with_items si adding up significant additional time to ursula run. This PR will join the repo list into a single cmd and enable all the repos at once. 