### PR TITLE
compliance changes to handle rhel 7 inspec checks

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -647,3 +647,17 @@ security_password_minimum_length: 8
 security_password_minimum_days: 1
 security_password_maximum_days: 90
 security_password_warn_age: 7
+security_audit_DAC_chmod: 'yes'                      # V-38543
+security_audit_DAC_chown: 'yes'                    # V-38545
+security_audit_DAC_lchown: 'yes'                     # V-38558
+security_audit_DAC_fchmod: 'yes'                     # V-38547
+security_audit_DAC_fchmodat: 'yes'                   # V-38550
+security_audit_DAC_fchown: 'yes'                     # V-38552
+security_audit_DAC_fchownat: 'yes'                   # V-38554
+security_audit_DAC_fremovexattr: 'yes'               # V-38556
+security_audit_DAC_lremovexattr: 'yes'               # V-38559
+security_audit_DAC_fsetxattr: 'yes'                  # V-38557
+security_audit_DAC_lsetxattr: 'yes'                  # V-38561
+security_audit_DAC_setxattr: 'yes'                   # V-38565
+security_audit_deletions: 'yes'                      # V-38575
+security_audit_failed_access: 'yes'                  # V-38566

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -172,6 +172,12 @@ common:
     - { name: net.ipv4.tcp_syncookies }
     - { name: net.ipv4.tcp_synack_retries }
 
+  compliance:
+    rmusers:
+      - ftp
+      - games
+      - gopher
+
 # Below is a ucarp config example:
 network:
   ucarp:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -79,6 +79,8 @@
 - include: ssh.yml
   tags: ssh
 
+- include: remove-default-users.yml
+
 - include: networking.yml
 
 - include: password-policy.yml

--- a/roles/common/tasks/password-policy.yml
+++ b/roles/common/tasks/password-policy.yml
@@ -1,20 +1,48 @@
 ---
-- name: remove invalid configuration for pam_unix
-  lineinfile: dest=/etc/pam.d/common-password regexp=(pam_unix.so) state=absent
-              line="password [success=7 default=ignore] pam_unix.so obscure sha512"
+- block:
+  - name: remove invalid configuration for pam_unix
+    lineinfile: dest=/etc/pam.d/common-password regexp=(pam_unix.so) state=absent
+                line="password [success=7 default=ignore] pam_unix.so obscure sha512"
+  
+  - name: remove invalid configuration for pam_cracklib
+    lineinfile: dest=/etc/pam.d/common-password regexp=(pam_cracklib.so) state=absent
+                line="password requisite pam_cracklib.so ucredit=0 lcredit=-1 dcredit=-1 ocredit=0 minlen=8 retry=3"
+  
+  - name: implement password controls for pam.d login
+    lineinfile:
+      dest: "{{ item[0] }}"
+      state: absent
+      line: "{{ item[1] }}"
+    with_nested:
+      - [ /etc/pam.d/login, /etc/pam.d/passwd, /etc/pam.d/sshd, /etc/pam.d/su ]
+      - [ "auth include common-auth", "account include common-account", "password include common-password" ]
+    
+  - name: prevent resuse of passwords
+    lineinfile: dest=/etc/pam.d/common-password regexp=(pam_unix.so) state=present
+                line="password [success=1 default=ignore] pam_unix.so obscure use_authtok sha512 remember=7 shadow"
+                insertafter='^# here are the per-package modules'
+                create=true
+  
+  - name: implement password complexity
+    lineinfile: dest=/etc/pam.d/common-password regexp=(pam_cracklib.so) state=present
+                line="password requisite pam_cracklib.so ucredit=0 lcredit=-1 dcredit=-1 ocredit=0 retry=3 minlen=8 difok=3 reject_username"
+                insertafter='^# here are the per-package modules'
+                create=true
+    
+  when: os == 'ubuntu'
 
-- name: remove invalid configuration for pam_cracklib
-  lineinfile: dest=/etc/pam.d/common-password regexp=(pam_cracklib.so) state=absent
-              line="password requisite pam_cracklib.so ucredit=0 lcredit=-1 dcredit=-1 ocredit=0 minlen=8 retry=3"
-
-- name: implement password controls for pam.d login
-  lineinfile:
-    dest: "{{ item[0] }}"
-    state: absent
-    line: "{{ item[1] }}"
-  with_nested:
-    - [ /etc/pam.d/login, /etc/pam.d/passwd, /etc/pam.d/sshd, /etc/pam.d/su ]
-    - [ "auth include common-auth", "account include common-account", "password include common-password" ]
+- block:
+  - name: set password history to last seven
+    lineinfile:
+      dest: /etc/pam.d/system-auth
+      line: "password    required      pam_pwhistory remember=7 use_authtok"
+      state: present
+      insertafter: '^password\s+\w+\s+pam_pwquality.so'
+  
+  - name: set the password policy for centos/rhel
+    template: src=etc/security/pwquality.conf dest=/etc/security/pwquality.conf
+  
+  when: os == 'rhel'
 
 - name: set maximum password age
   lineinfile: dest=/etc/login.defs regexp=^PASS_MAX_DAYS
@@ -23,16 +51,4 @@
 - name: set minimum password age
   lineinfile: dest=/etc/login.defs regexp=^PASS_MIN_DAYS
               line="PASS_MIN_DAYS   1" state=present
-
-- name: prevent resuse of passwords
-  lineinfile: dest=/etc/pam.d/common-password regexp=(pam_unix.so) state=present
-              line="password [success=1 default=ignore] pam_unix.so obscure use_authtok sha512 remember=7 shadow"
-              insertafter='^# here are the per-package modules'
-              create=true
-
-- name: implement password complexity
-  lineinfile: dest=/etc/pam.d/common-password regexp=(pam_cracklib.so) state=present
-              line="password requisite pam_cracklib.so ucredit=0 lcredit=-1 dcredit=-1 ocredit=0 retry=3 minlen=8 difok=3 reject_username"
-              insertafter='^# here are the per-package modules'
-              create=true
 

--- a/roles/common/tasks/remove-default-users.yml
+++ b/roles/common/tasks/remove-default-users.yml
@@ -1,0 +1,6 @@
+---
+# Task to perform some of the miscellanious things 
+# not done by openstack-ansible-security
+- name: remove default system accounts as prescribed by stig
+  user: name={{ item }} state=absent
+  with_items: "{{ common.compliance.rmusers }}" 

--- a/roles/common/tasks/ssh.yml
+++ b/roles/common/tasks/ssh.yml
@@ -14,3 +14,14 @@
             group={{ item.group|default("root") }} mode=0600
   with_items: "{{ common.ssh_private_keys }}"
 
+- name: find ssh private  key files
+  find:
+    path: "/etc/ssh"
+    contains: "^-+BEGIN.*PRIVATE.*KEY-+$"
+  register: result
+
+- name: set mode on the ssh private key files
+  file:
+    path: "{{ item.path }}"
+    mode: 0600
+  with_items: "{{ result.files }}"

--- a/roles/common/tasks/system-file-permissions.yml
+++ b/roles/common/tasks/system-file-permissions.yml
@@ -5,6 +5,5 @@
 - name: Set permissions for shadow
   file: path=/etc/shadow state=file mode=600
 
-- name: Set ownership for games directory
-  file: path=/usr/games state=directory recurse=yes owner=games group=games
-
+- name: Remove default games directory
+  file: path=/usr/games state=absent

--- a/roles/common/templates/etc/ntp.conf
+++ b/roles/common/templates/etc/ntp.conf
@@ -22,13 +22,13 @@ server {{ server }} iburst
 # Use servers from the NTP Pool Project. Approved by Ubuntu Technical Board
 # on 2011-02-08 (LP: #104525). See http://www.pool.ntp.org/join.html for
 # more information.
-server 0.ubuntu.pool.ntp.org
-server 1.ubuntu.pool.ntp.org
-server 2.ubuntu.pool.ntp.org
-server 3.ubuntu.pool.ntp.org
+server 0.ubuntu.pool.ntp.org maxpoll 10
+server 1.ubuntu.pool.ntp.org maxpoll 10
+server 2.ubuntu.pool.ntp.org maxpoll 10
+server 3.ubuntu.pool.ntp.org maxpoll 10
 
 # Use Ubuntu's ntp server as a fallback.
-server ntp.ubuntu.com
+server ntp.ubuntu.com maxpoll 10
 {% endif %}
 
 # Access control configuration; see /usr/share/doc/ntp-doc/html/accopt.html for

--- a/roles/common/templates/etc/security/pwquality.conf
+++ b/roles/common/templates/etc/security/pwquality.conf
@@ -1,0 +1,51 @@
+# Configuration for systemwide password quality limits
+# Defaults:
+#
+# Number of characters in the new password that must not be present in the
+# old password.
+# difok = 5
+#
+# Minimum acceptable size for the new password (plus one if
+# credits are not disabled which is the default). (See pam_cracklib manual.)
+# Cannot be set to lower value than 6.
+minlen = 8
+#
+# The maximum credit for having digits in the new password. If less than 0
+# it is the minimum number of digits in the new password.
+dcredit = -1
+#
+# The maximum credit for having uppercase characters in the new password.
+# If less than 0 it is the minimum number of uppercase characters in the new
+# password.
+ucredit = -1
+#
+# The maximum credit for having lowercase characters in the new password.
+# If less than 0 it is the minimum number of lowercase characters in the new
+# password.
+lcredit = -1
+#
+# The maximum credit for having other characters in the new password.
+# If less than 0 it is the minimum number of other characters in the new
+# password.
+ocredit = -1
+#
+# The minimum number of required classes of characters for the new
+# password (digits, uppercase, lowercase, others).
+# minclass = 0
+#
+# The maximum number of allowed consecutive same characters in the new password.
+# The check is disabled if the value is 0.
+# maxrepeat = 0
+#
+# The maximum number of allowed consecutive characters of the same class in the
+# new password.
+# The check is disabled if the value is 0.
+# maxclassrepeat = 0
+#
+# Whether to check for the words from the passwd entry GECOS string of the user.
+# The check is enabled if the value is not 0.
+gecoscheck = 1
+#
+# Path to the cracklib dictionaries. Default is to use the cracklib default.
+# dictpath =
+

--- a/roles/common/templates/etc/sshd_config
+++ b/roles/common/templates/etc/sshd_config
@@ -3,15 +3,19 @@
 
 # What ports, IPs and protocols we listen for
 Port 22
+
 # Use these options to restrict which interfaces/protocols sshd will bind to
 #ListenAddress ::
 #ListenAddress 0.0.0.0
+
 Protocol 2
+
 # HostKeys for protocol version 2
 HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_dsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
+
 #Privilege Separation is turned on for security
 UsePrivilegeSeparation yes
 
@@ -25,11 +29,7 @@ LogLevel INFO
 
 # Authentication:
 LoginGraceTime 120
-{% if common.ssh.disable_root|bool %}
 PermitRootLogin no
-{% else %}
-PermitRootLogin without-password
-{% endif %}
 StrictModes yes
 
 RSAAuthentication yes
@@ -43,7 +43,7 @@ RhostsRSAAuthentication no
 # similar for protocol version 2
 HostbasedAuthentication no
 # Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
-#IgnoreUserKnownHosts yes
+IgnoreUserKnownHosts yes
 
 # To enable empty passwords, change to yes (NOT RECOMMENDED)
 PermitEmptyPasswords no
@@ -56,7 +56,7 @@ ChallengeResponseAuthentication no
 PasswordAuthentication no
 
 # Kerberos options
-#KerberosAuthentication no
+KerberosAuthentication no
 #KerberosGetAFSToken no
 #KerberosOrLocalPasswd yes
 #KerberosTicketCleanup yes
@@ -77,7 +77,8 @@ MaxStartups {{ common.ssh.max_startups }}
 {% else %}
 MaxStartups 100
 {% endif %}
-#Banner /etc/issue.net
+
+Banner /etc/issue.net
 
 # Allow client to pass locale environment variables
 AcceptEnv LANG LC_*
@@ -89,7 +90,7 @@ Subsystem sftp /usr/libexec/openssh/sftp-server
 {% endif %}
 
 Ciphers aes128-ctr,aes192-ctr,aes256-ctr
-MACs hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-ripemd160
+MACs hmac-sha2-256,hmac-sha2-512
 
 # Set this to 'yes' to enable PAM authentication, account processing,
 # and session processing. If this is enabled, PAM authentication will
@@ -113,3 +114,7 @@ GatewayPorts no
 {% if common.ssh.disable_dns|bool %}
 UseDNS no
 {% endif %}
+
+ClientAliveInterval 1800
+ClientAliveCountMax 0
+Compression delayed


### PR DESCRIPTION
Some of the os settings on the RHEL are different than ubuntu. This PR takes those changes into account. In addition it also add some of the security settings that RHEL7 stig requires. Also adds additional default overrides for openstack-ansible-security for stig requirements.