### PR TITLE
Add OS condition to interface log cleanup cron job

### DIFF
--- a/roles/neutron-data/tasks/main.yml
+++ b/roles/neutron-data/tasks/main.yml
@@ -86,11 +86,11 @@
     enabled: True
   when: neutron.plugin == 'ml2'
 
-#FIXME validate cron job on rhel
 - name: cleanup interface logs
   template: src=etc/cron.daily/cleanup-neutron-interfaces
             dest=/etc/cron.daily/cleanup-neutron-interfaces
             mode=0755 owner=root
+  when: os == 'ubuntu'
 
 - include: monitoring.yml
   tags:


### PR DESCRIPTION
Upstart creates a new service log for every tap interface, and this cron job cleans those up.  Since we are running systemd on RHEL we do not need this cron job.