### PR TITLE
remove duplicate variables for cafile value.

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -283,7 +283,7 @@ neutron:
       tenant_name: admin
   service:
     envs:
-      - "REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"
+      - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
   tenant_nameservers:
     - 8.8.4.4
     - 8.8.8.8

--- a/roles/aodh/defaults/main.yml
+++ b/roles/aodh/defaults/main.yml
@@ -47,5 +47,5 @@ aodh:
       fields:
         type: openstack
         tags: aodh,aodh-evaluator
-  cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"
+  cafile: "{{ ssl.cafile }}"
   alarm_history_time_to_live: 864000

--- a/roles/ceilometer-common/defaults/main.yml
+++ b/roles/ceilometer-common/defaults/main.yml
@@ -47,7 +47,7 @@ ceilometer:
   logging:
     debug: False
     verbose: True
-  cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"
+  cafile: "{{ ssl.cafile }}"
   monitoring:
     sensu_checks:
       check_ceilometer_api:

--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -91,7 +91,7 @@ cinder:
   logging:
     debug: False
     verbose: True
-  cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"
+  cafile: "{{ ssl.cafile }}"
   monitoring:
     sensu_checks:
       check_cinder_services:

--- a/roles/client/templates/root/stackrc
+++ b/roles/client/templates/root/stackrc
@@ -6,7 +6,7 @@ export OS_PROJECT_NAME=admin
 export OS_TENANT_NAME=admin
 export OS_USER_DOMAIN_NAME=Default
 export OS_PROJECT_DOMAIN_NAME=Default
-export OS_CACERT={{ ca_bundle }}
+export OS_CACERT={{ ssl.cafile }}
 export OS_NO_CACHE=True
 export OS_VOLUME_API_VERSION=2
 # NOTE(mriedem): OS_COMPUTE_API_VERSION is left unspecified. By default the

--- a/roles/common/tasks/ssl.yml
+++ b/roles/common/tasks/ssl.yml
@@ -15,6 +15,16 @@
       src: "{{ item.src | default(omit) }}"
     with_items: "{{ ssl.extracacerts | default([]) }}"
     notify: refresh CAs
+
+  # ugly hack: some python http libs don't honor the system ca-certs, and ship with
+  # their own list, instead.
+  # pre-install these client libs, and force them to use the system cert list.
+  - name: force our ssl cert for python libs (ubuntu)
+    file: src={{ ssl.cafile }} dest={{ item }} owner=root
+          mode=0644 state=link force=yes
+    with_items:
+      - "{{ basevenv_lib_dir }}/requests/cacert.pem"
+    notify: refresh CAs
   when: os == 'ubuntu'
 
 - block:
@@ -34,8 +44,30 @@
       src: "{{ item.src | default(omit) }}"
     with_items: "{{ ssl.extracacerts | default([]) }}"
     notify: refresh rhel CAs
-  when: os == 'rhel'
 
+  # ugly hack: some python http libs don't honor the system ca-certs, and ship with
+  # their own list, instead.
+  # pre-install these client libs, and force them to use the system cert list.
+  - name: force our ssl cert for python libs (centos)
+    file: src={{ ssl.cafile }} dest={{ item }} owner=root
+          mode=0644 state=link force=yes
+    with_items:
+      - "{{ basevenv_lib_dir }}/requests/cacert.pem"
+      - /usr/lib/python2.7/site-packages/requests/cacert.pem
+    notify: refresh rhel CAs
+    when:
+      - openstack_install_method == 'source'
+
+  - name: force our ssl cert for python libs (rhel))
+    file: src={{ ssl.cafile }} dest={{ item }} owner=root
+          mode=0644 state=link force=yes
+    with_items:
+      - "{{ basevenv_lib_dir }}/requests/cacert.pem"
+      - /usr/lib/python2.7/site-packages/requests/cacert.pem
+      - /etc/pki/tls/certs/ca-bundle.crt
+    notify: refresh rhel CAs
+    when: openstack_install_method == 'distro'
+  when: os == 'rhel'
 
 - name: ssl directory
   file: dest=/opt/stack/ssl state=directory
@@ -47,26 +79,6 @@
     mode: 0644
   tags:
     - cert
-
-# ugly hack: some python http libs don't honor the system ca-certs, and ship with
-# their own list, instead.
-# pre-install these client libs, and force them to use the system cert list.
-
-- name: force our ssl cert for python libs on trusty
-  file: src=/etc/ssl/certs/ca-certificates.crt dest={{ item }} owner=root
-        mode=0644 state=link force=yes
-  with_items:
-    - "{{ basevenv_lib_dir }}/requests/cacert.pem"
-  when: os == 'ubuntu'
-
-- name: force our ssl cert for python libs on rhel
-  file: src=/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt dest={{ item }} owner=root
-        mode=0644 state=link force=yes
-  with_items:
-    - "{{ basevenv_lib_dir }}/requests/cacert.pem"
-    - /usr/lib/python2.7/site-packages/requests/cacert.pem
-    - "{{ ca_bundle }}"
-  when: os == 'rhel'
 
 - meta: flush_handlers
 

--- a/roles/common/templates/etc/sensu/stackrc
+++ b/roles/common/templates/etc/sensu/stackrc
@@ -5,7 +5,7 @@ export OS_TENANT_NAME={{ monitoring.openstack.user.tenant }}
 {% if client.self_signed_cert and os == 'ubuntu' -%}
 export OS_CACERT=/opt/stack/ssl/openstack.crt
 {% else %}
-export OS_CACERT={{ ca_bundle }}
+export OS_CACERT={{ ssl.cafile }}
 {% endif -%}
 export OS_NO_CACHE=True
 export NOVACLIENT_UUID_CACHE_DIR=/tmp/sensu

--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -70,7 +70,7 @@ glance:
   logging:
     debug: False
     verbose: True
-  cafile: "{{ ssl.cafile|default(ca_bundle) }}"
+  cafile: "{{ ssl.cafile }}"
   monitoring:
     sensu_checks:
       check_glance_api:

--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -54,7 +54,7 @@ heat:
   logging:
     debug: False
     verbose: True
-  cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"
+  cafile: "{{ ssl.cafile }}"
   plugin_dirs: []
   engine_workers: 4
   api_workers: 5

--- a/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
+++ b/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
@@ -247,7 +247,7 @@ K2K_CHOICES = (
 OPENSTACK_SSL_NO_VERIFY = {{ insecure | default('false') | bool }}
 
 # The CA certificate to use to verify SSL connections
-OPENSTACK_SSL_CACERT = '{{ ca_bundle }}'
+OPENSTACK_SSL_CACERT = '{{ ssl.cafile }}'
 
 # The OPENSTACK_KEYSTONE_BACKEND settings can be used to identify the
 # capabilities of the auth backend for Keystone.

--- a/roles/ironic-common/defaults/main.yml
+++ b/roles/ironic-common/defaults/main.yml
@@ -47,4 +47,4 @@ ironic:
   logging:
     debug: False
     verbose: True
-  cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"
+  cafile: "{{ ssl.cafile }}"

--- a/roles/magnum/defaults/main.yml
+++ b/roles/magnum/defaults/main.yml
@@ -15,7 +15,7 @@ magnum:
       - { name: PyMySQL }
     system_dependencies: []
   package: ~
-  cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"
+  cafile: "{{ ssl.cafile }}"
   logs:
     - paths:
       - /var/log/magnum/magnum-api.log

--- a/roles/mongodb-common/defaults/main.yml
+++ b/roles/mongodb-common/defaults/main.yml
@@ -8,6 +8,6 @@ mongodb:
   logging:
     debug: False
     verbose: True
-  cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"
+  cafile: "{{ ssl.cafile }}"
   endpoint_addr: "{{ hostvars[groups['mongo_db'][0]][primary_interface]['ipv4']['address'] }}"
   

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -157,7 +157,7 @@ neutron:
   logging:
     debug: False
     verbose: True
-  cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"
+  cafile: "{{ ssl.cafile }}"
   enable_external_interface: False
   monitoring:
     sensu_checks:

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -150,7 +150,7 @@ nova:
   logging:
     debug: False
     verbose: True
-  cafile: "{{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}"
+  cafile: "{{ ssl.cafile }}"
   monitoring:
     sensu_checks:
       check_nova_api:

--- a/roles/preflight-checks/tasks/check_items.yml
+++ b/roles/preflight-checks/tasks/check_items.yml
@@ -1,4 +1,9 @@
 ---
+- name: ensure ssl.cafile is defined
+  assert:
+    that: "ssl.cafile is defined"
+    msg: "ssl.cafile must be defined based on the operating system {{ os }}"
+
 - block:
   - name: check whether neutron-client is installed
     command: neutron --version

--- a/roles/preflight-checks/tasks/main.yml
+++ b/roles/preflight-checks/tasks/main.yml
@@ -23,15 +23,5 @@
     ssh_service: sshd
   when: os == 'rhel'
 
-- name: set ca_bundle fact for ubuntu
-  set_fact:
-    ca_bundle: /etc/ssl/certs/ca-certificates.crt
-  when: os == 'ubuntu'
-
-- name: set ca_bundle fact for rhel
-  set_fact:
-    ca_bundle: /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
-  when: os == 'rhel'
-
 - include: check_items.yml
   tags: ['precheck']

--- a/roles/swift-proxy/templates/etc/swift/proxy-server.conf
+++ b/roles/swift-proxy/templates/etc/swift/proxy-server.conf
@@ -100,4 +100,4 @@ admin_user = swift
 cache = swift.cache
 include_service_catalog = False
 delay_auth_decision = true
-cafile = {{ ssl.cafile|default('/etc/ssl/certs/ca-certificates.crt') }}
+cafile = {{ ssl.cafile }}


### PR DESCRIPTION
This PR remove duplicate variables (ca_bundle and ssl.cafile) and uses one common variable ssl.cafile that is required to be defined in defaults-2.0.yml. 

Preflight has assertion to ensure ssl.cafile is defined.

This will fix up all our self signed ssl issues.