### PR TITLE
enable/disable lbaas ui on horizon as per neutron.lbaas flag

### DIFF
--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -15,7 +15,6 @@ horizon:
   distro:
     project_packages:
       - openstack-dashboard
-      - openstack-neutron-lbaas-ui
     python_post_dependencies: []
   source:
     python_post_dependencies: []

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -1,4 +1,24 @@
 ---
+- block:
+  - name: "Install or remove openstack-neutron-lbaas-ui"
+    yum:
+      name: openstack-neutron-lbaas-ui
+      state: "{{ (neutron.lbaas.enabled | bool) | ternary('present', 'absent') }}"
+    register: yum_package
+    until: yum_package|succeeded
+    retries: 5
+    notify:
+      - restart apache
+
+  - name: remove _1480_project_loadbalancersv2_panel.py
+    file: path=/usr/share/openstack-dashboard/openstack_dashboard/local/enabled/_1480_project_loadbalancersv2_panel.py
+          state=absent
+
+  - name: remove _1480_project_loadbalancersv2_panel.pyc
+    file: path=/usr/share/openstack-dashboard/openstack_dashboard/local/enabled/_1480_project_loadbalancersv2_panel.py
+          state=absent
+  when: openstack_install_method == 'distro'
+  
 - name: lesscpy must be in apache PATH
   pip: name=lesscpy version=0.9j
   register: result


### PR DESCRIPTION
- install / remove lbaas ui rpm as per flag
- remove _1480_project_loadbalancersv2_panel.py to make sure only one lbaas v2 tab on Horizon