### PR TITLE
enable venv path for sensu on rhel

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -3,6 +3,9 @@ ceph:
   pylib_dir:
     rhel: /usr/lib64/python2.7/site-packages/
     ubuntu: /usr/lib/python2.7/dist-packages/
+  pylib_dir2:
+    rhel: /usr/lib/python2.7/site-packages/
+    ubuntu: /usr/lib/python2.7/dist-packages/
   enabled: false
   #disks:
   #  - sdb

--- a/roles/ceph-monitor/tasks/monitoring.yml
+++ b/roles/ceph-monitor/tasks/monitoring.yml
@@ -1,4 +1,42 @@
 ---
+- name: import rados module into base_venv (rhel)
+  file:
+    src: "{{ ceph.pylib_dir[os] }}{{ item }}"
+    dest: "/opt/openstack/base/lib/python2.7/site-packages/{{ item }}"
+    state: link
+    owner: root
+    group: root
+    mode: 0644
+  with_items:
+    - rados.so
+    - rbd.so
+  when: os == "rhel"
+
+- name: import rados module into base_venv (ubuntu)
+  file:
+    src: "{{ ceph.pylib_dir[os] }}{{ item }}"
+    dest: "/opt/openstack/base/lib/python2.7/site-packages/{{ item }}"
+    state: link
+    owner: root
+    group: root
+    mode: 0644
+  with_items:
+    - rados.x86_64-linux-gnu.so
+    - rbd.x86_64-linux-gnu.so
+  when: os == "ubuntu"
+
+- name: import other ceph modules into base_venv
+  file:
+    src: "{{ ceph.pylib_dir2[os] }}{{ item }}"
+    dest: "/opt/openstack/base/lib/python2.7/site-packages/{{ item }}"
+    state: link
+    owner: root
+    group: root
+    mode: 0644
+  with_items:
+    - ceph_argparse.py
+    - ceph_daemon.py
+
 - name: ceph status check
   sensu_check: name=check-ceph-status plugin=check-ceph.rb
                use_sudo=true args='--criticality {{ ceph.monitoring.sensu_checks.check_ceph_status.criticality }} {{ ceph.monitoring.sensu_checks.check_ceph_status.escalate_flags }} -o -f -p'

--- a/roles/common/tasks/monitoring.yml
+++ b/roles/common/tasks/monitoring.yml
@@ -69,6 +69,16 @@
               line=". {{ common.python.base_venv }}/bin/activate"
   notify: restart sensu-client
 
+- name: ensure sensu-client path enabled on redhat
+  template: 
+    dest: /etc/sysconfig/sensu-client
+    src: monitoring/sensu-client-path 
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart sensu-client
+  when: os == "rhel"
+
 - name: sensu client config
   template: src=monitoring/config.json dest=/etc/sensu/config.json owner=root
             group=root

--- a/roles/common/templates/monitoring/sensu-client-path
+++ b/roles/common/templates/monitoring/sensu-client-path
@@ -1,0 +1,1 @@
+export PATH="{{ common.python.base_venv }}/bin:/opt/sensu/embedded/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/etc/sensu/plugins"


### PR DESCRIPTION
on sensu-service start, it execute below  in squence :
1. . /etc/default/sensu
2. . /etc/init.d/functions (only on rhel)
3. ./etc/sysconfig/sensu-client (only on rhel)

. /etc/init.d/functions reset the $PATH, which cause PATH in
/etc/default/sensu not work.
so need to setup path in /etc/sysconfig/sensu-client.