### PR TITLE
Add failed_when for restarting ceilometer services

### DIFF
--- a/roles/ceilometer-common/handlers/main.yml
+++ b/roles/ceilometer-common/handlers/main.yml
@@ -2,6 +2,7 @@
 - name: restart ceilometer services
   service: name={{ item.name }} state=restarted must_exist=false
   when: restart|default('True')
+  failed_when: false
   with_items:
     - "{{ ceilometer.services.ceilometer_api }}"
     - "{{ ceilometer.services.ceilometer_collector }}"
@@ -11,6 +12,7 @@
 - name: restart ceilometer data services
   service: name={{ item.name }} state=restarted must_exist=false
   when: restart|default('True')
+  failed_when: false
   with_items:
     - "{{ ceilometer.services.ceilometer_polling }}"
     - "{{ ceilometer.services.ceilometer_polling_compute }}"


### PR DESCRIPTION
Restarting the ceilometer services on the compute node fails
because some of the services are not present. This ignores that.