### PR TITLE
Add more inspec checks from openstack security

### DIFF
--- a/roles/inspec/defaults/main.yml
+++ b/roles/inspec/defaults/main.yml
@@ -16,3 +16,21 @@ inspec:
         - check-dashboard-02
       attributes:
         horizon_config_group: apache
+    cinder:
+      required_controls:
+        - check-block-01
+        - check-block-02
+    glance:
+      required_controls: []
+    nova:
+      required_controls:
+        - check-compute-01
+        - check-compute-02
+    keystone:
+      required_controls:
+        - check-identity-01
+        - check-identity-02
+    neutron:
+      required_controls:
+        - check-neutron-01
+        - check-neutron-02

--- a/roles/inspec/tasks/main.yml
+++ b/roles/inspec/tasks/main.yml
@@ -12,7 +12,6 @@
     - /etc/inspec
     - /etc/inspec/host-controls
     - /etc/inspec/host-controls/controls
-    - /etc/inspec/host-controls/controls/controller
     - /etc/inspec/host-controls/libraries
 
 - name: inspec dependency profile directories
@@ -61,13 +60,12 @@
     dest: /etc/inspec/host-controls/inspec.yml
     mode: 0644
 
-- name: inspec controller control files
+- name: inspec openstack control files
   template:
-    src: '{{ item }}'
-    dest: /etc/inspec/host-controls/controls/controller/
+    src: etc/inspec/host-controls/controls/openstack-security.rb
+    dest: /etc/inspec/host-controls/controls/
     mode: 0644
-  with_fileglob: ../templates/etc/inspec/host-controls/controls/controller/*
-  when: inventory_hostname in groups['controller']
+  when: inventory_hostname in groups['controller'] or  inventory_hostname in groups['compute'] or inventory_hostname in groups['cinder_volume']
 
 - name: remove inspec lock file so we can upgrade
   file:
@@ -82,7 +80,7 @@
 
 - name: inspec sensu hook
   sensu_check: name=inspec-check plugin=check-inspec.rb
-               args='/etc/inspec/host-controls --attrs /etc/inspec/host-controls/attributes.yml' use_sudo=true
+               args='--controls /etc/inspec/host-controls --attrs /etc/inspec/host-controls/attributes.yml' use_sudo=true
                interval={{ inspec.interval }}
   notify: restart sensu-client
   when: inspec.enabled|default(True)|bool

--- a/roles/inspec/templates/etc/inspec/host-controls/controls/controller/openstack-security.rb
+++ b/roles/inspec/templates/etc/inspec/host-controls/controls/controller/openstack-security.rb
@@ -1,9 +1,0 @@
-# encoding: utf-8
-# license: Apache 2.0
-#title 'host-controls'
-
-require_controls 'inspec-openstack-security' do
-{% for control in inspec.openstack.horizon.required_controls %}
-    control '{{ control }}'
-{% endfor %}
-end

--- a/roles/inspec/templates/etc/inspec/host-controls/controls/openstack-security.rb
+++ b/roles/inspec/templates/etc/inspec/host-controls/controls/openstack-security.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+# license: Apache 2.0
+#title 'host-controls'
+
+require_controls 'inspec-openstack-security' do
+
+{% if inventory_hostname in groups['controller'] %}
+{% for control in inspec.openstack.horizon.required_controls %}
+    control '{{ control }}'
+{% endfor %}
+{% for control in inspec.openstack.glance.required_controls %}
+    control '{{ control }}'
+{% endfor %}
+{% for control in inspec.openstack.keystone.required_controls %}
+    control '{{ control }}'
+{% endfor %}
+{% endif %}
+
+{% if inventory_hostname in groups['controller'] or inventory_hostname in groups['cinder_volume'] %}
+{% for control in inspec.openstack.cinder.required_controls %}
+    control '{{ control }}'
+{% endfor %}
+{% endif %}
+
+{% if inventory_hostname in groups['controller'] or inventory_hostname in groups['compute'] %}
+{% for control in inspec.openstack.nova.required_controls %}
+    control '{{ control }}'
+{% endfor %}
+{% for control in inspec.openstack.neutron.required_controls %}
+    control '{{ control }}'
+{% endfor %}
+{% endif %}
+
+end


### PR DESCRIPTION
This adds checks for the ownership and modes for the config files of
Apache and the openstack services: cinder, nova, keystone, and neutron.
More checks, including glance, will be added later.