### PR TITLE
fix glance bbchttp plugin on rhel

### DIFF
--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -27,6 +27,7 @@ glance:
   distro:
     project_packages:
       - openstack-glance
+    python_post_dependencies: []
   source:
     rev: 'stable/newton'
     constrain: True
@@ -35,6 +36,7 @@ glance:
       - { name: PyMySQL }
       - { name: python-swiftclient }
       - { name: "git+https://github.com/blueboxgroup/bbc-openstack-plugins.git#egg=bbc_openstack_plugins" }
+    python_post_dependencies: []
     system_dependencies:
         ubuntu:
         - libxml2-dev

--- a/roles/glance/meta/main.yml
+++ b/roles/glance/meta/main.yml
@@ -14,6 +14,7 @@ dependencies:
     alternatives: "{{ glance.alternatives }}"
     system_dependencies: "{{ glance.source.system_dependencies }}"
     python_dependencies: "{{ glance.source.python_dependencies }}"
+    python_post_dependencies: "{{ glance.source.python_post_dependencies }}"
     constrain: "{{ glance.source.constrain }}"
     upper_constraints: "{{ glance.source.upper_constraints }}"
     when: openstack_install_method == 'source'
@@ -30,6 +31,7 @@ dependencies:
   - role: openstack-distro
     project_name: glance
     project_packages: "{{ glance.distro.project_packages }}"
+    python_post_dependencies: "{{ glance.distro.python_post_dependencies }}"
     when: openstack_install_method == 'distro'
   - role: openstack-firewall
     rule_name: glance

--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -12,6 +12,8 @@ horizon:
     enabled: True
     regex: '^(?=.*\d)(?=.*[a-z]).{8,}$'
     help_text: 'Password is not compliant. Password must contain lowercase letters, digits, and be at least 8 characters in length.'
+  glance:
+    allow_location: False  
   distro:
     project_packages:
       - openstack-dashboard

--- a/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
+++ b/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
@@ -363,7 +363,7 @@ OPENSTACK_HEAT_STACK = {
 }
 
 # Enables upload from remote location
-IMAGES_ALLOW_LOCATION = True
+IMAGES_ALLOW_LOCATION = "{{ horizon.glance.allow_location }}"
 HORIZON_IMAGES_UPLOAD_MODE = 'legacy'
 
 # The OPENSTACK_IMAGE_BACKEND settings can be used to customize features


### PR DESCRIPTION
Newton broke remote downloading of images via Horizon, and the required plugin is not being installed on rhel.

This installs the bbchttp plugin on rhel, and re-enables remote downloading of images in Horizon.