### PR TITLE
write override systemd service files to /etc/systemd/system.

### DIFF
--- a/library/systemd_service.py
+++ b/library/systemd_service.py
@@ -114,7 +114,7 @@ def main():
         changed = False
         service_path = None
         if not module.params['path']:
-            service_path = '/usr/lib/systemd/system/%s.service' % module.params['name']
+            service_path = '/etc/systemd/system/%s.service' % module.params['name']
         else:
             service_path = module.params['path']
 


### PR DESCRIPTION
To ensure openstack services points to ursula config dirs we are writing override systemd files. Currently these were written to /usr/lib/systemd/system. This PR enforces the systemd override guidelines to write override systemd files to /etc/systemd/system