### PR TITLE
haproxy default tunning for timeout connect

### DIFF
--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -8,7 +8,7 @@ haproxy:
     timeout_http_request: 30s
     timeout_http_keep_alive: 60s
     timeout_queue: 1m
-    timeout_connect: 10s
+    timeout_connect: 5s
     timeout_client: 300s
     timeout_server: 300s
     timeout_check: 10s


### PR DESCRIPTION
We moved the haproxy global/defaults tuning to the haproxy role defaults. This PR is to set timeout connect to 5s in role defaults