### PR TITLE
Relax password requirements

### DIFF
--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -10,8 +10,8 @@ horizon:
   session_engine: django.contrib.sessions.backends.cache
   password_validator:
     enabled: True
-    regex: '^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&+=()_]).{8,}$'
-    help_text: 'Password is not compliant. Password must contain uppercase, lowercase, special characters !@#$%%^&+=()_, digits, and be at least 8 characters in length.'
+    regex: '^(?=.*\d)(?=.*[a-z]).{8,}$'
+    help_text: 'Password is not compliant. Password must contain lowercase letters, digits, and be at least 8 characters in length.'
   distro:
     project_packages:
       - openstack-dashboard

--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -52,8 +52,8 @@ keystone:
   jellyroll: False # custom middleware for password compliance
   security_compliance:
     enabled: true
-    password_regex: '^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&+=()_]).{8,}$'
-    password_regex_description: 'Password is not compliant. Password must contain uppercase, lowercase, special characters !@#$%%^&+=()_, digits, and be at least 8 characters in length.'
+    password_regex: '^(?=.*\d)(?=.*[a-z]).{8,}$'
+    password_regex_description: 'Password is not compliant. Password must contain lowercase letters, digits, and be at least 8 characters in length.'
   roles:
     - project_admin
     - cloud_admin


### PR DESCRIPTION
Heat currently does not support satisfying specify password requirements. We
will relax the requirements for now to only require letters, digits
and be a length of atleast 8.