### PR TITLE
fix novnc for rhel and centos.

### DIFF
--- a/roles/nova-control/tasks/main.yml
+++ b/roles/nova-control/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - include: novnc.yml
+  when: openstack_install_method != 'distro'
   tags: novnc
 
 - block:


### PR DESCRIPTION
For centos and rhel openstack packages provides the novnc files in /usr/share. This PR will leverage that instead of laying down bbc novnc tarball.