### PR TITLE
Add defaults to cinder_volume host check

### DIFF
--- a/roles/inspec/tasks/main.yml
+++ b/roles/inspec/tasks/main.yml
@@ -65,10 +65,10 @@
     src: etc/inspec/host-controls/controls/openstack-security.rb
     dest: /etc/inspec/host-controls/controls/
     mode: 0644
-  when: inventory_hostname in groups['controller'] or  inventory_hostname in groups['compute'] or inventory_hostname in groups['cinder_volume']
+  when: inventory_hostname in groups['controller'] or  inventory_hostname in groups['compute'] or inventory_hostname in groups['cinder_volume']|default([])
 
 - name: rhel control files
-  template: 
+  template:
     src: etc/inspec/host-controls/controls/rhel7-stigs.rb
     dest: /etc/inspec/host-controls/controls/
     mode: 0644

--- a/roles/inspec/templates/etc/inspec/host-controls/controls/openstack-security.rb
+++ b/roles/inspec/templates/etc/inspec/host-controls/controls/openstack-security.rb
@@ -16,10 +16,12 @@ require_controls 'inspec-openstack-security' do
 {% endfor %}
 {% endif %}
 
-{% if inventory_hostname in groups['controller'] or inventory_hostname in groups['cinder_volume'] %}
+{% if inventory_hostname in groups['controller'] or inventory_hostname in groups['cinder_volume']|default([]) %}
+{% if cinder.enabled|default('False')|bool %}
 {% for control in inspec.openstack.cinder.required_controls %}
     control '{{ control }}'
 {% endfor %}
+{% endif %}
 {% endif %}
 
 {% if inventory_hostname in groups['controller'] or inventory_hostname in groups['compute'] %}


### PR DESCRIPTION
This adds defaults while checking if the host belongs
to the cinder_volume group. This check is failing for inspecs
when cinder_volume is not defined.