### PR TITLE
adjust /etc/hosts for rhel/centos and ubuntu

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -8,6 +8,9 @@ openstack_install_method: 'source'
 basevenv: "/opt/openstack/base"
 basevenv_lib_dir: "{{ basevenv }}/lib/python2.7/site-packages"
 
+hostname_fqdn: "{{ ansible_fqdn }}"
+hostname_short: "{{ hostname_fqdn.split('.')|first }}"
+
 primary_interface: 'ansible_eth0'
 primary_ip: "{{ hostvars[inventory_hostname][primary_interface]['ipv4']['address'] }}"
 

--- a/roles/common/templates/etc/hosts
+++ b/roles/common/templates/etc/hosts
@@ -1,5 +1,8 @@
+# {{ ansible_managed }}
+
+{% if ansible_os_family == 'Debian' -%}
 127.0.0.1   localhost.localdomain localhost
-127.0.1.1   {{ ansible_fqdn }} {{ ansible_hostname }} {{ ansible_nodename }}
+127.0.1.1   {{ hostname_fqdn }} {{ hostname_short }}
 
 # The following lines are desirable for IPv6 capable hosts
 ::1     ip6-localhost ip6-loopback
@@ -7,6 +10,18 @@ fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
+
+{% elif ansible_os_family == 'RedHat' -%}
+127.0.0.1 {{ hostname_fqdn }} {{ hostname_short }}
+127.0.0.1 localhost.localdomain localhost
+127.0.0.1 localhost4.localdomain4 localhost4
+
+# The following lines are desirable for IPv6 capable hosts
+::1 {{ hostname_fqdn }} {{ hostname_short }}
+::1 localhost.localdomain localhost
+::1 localhost6.localdomain6 localhost6
+
+{% endif %}
 
 {% for entry in etc_hosts|default([]) -%}
 {{ entry.ip }} {{ entry.name }}


### PR DESCRIPTION
Enhance /etc/hosts templates to create entries using hostname_fqdn and hostname_short along with taking difference of operatingsystem into account.