### PR TITLE
add cinder endpoint to haproxy when enabled.

### DIFF
--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -56,17 +56,17 @@
       endpoints.neutron.haproxy.prefer_primary_backend,
       endpoints.neutron.haproxy.health_check,
       endpoints.neutron.haproxy.balance
-    ],
-    [
-      'cinder',
-      endpoints.cinder.port.backend_api,
-      endpoints.cinder.port.haproxy_api,
-      endpoints.cinder.haproxy.prefer_primary_backend,
-      endpoints.cinder.haproxy.health_check,
-      endpoints.cinder.haproxy.balance
     ]
   ]
 -%}
+{% if cinder.enabled|default('True')|bool -%}
+{% set _ = haproxy_services.append(['cinder',
+                                    endpoints.cinder.port.backend_api,
+                                    endpoints.cinder.port.haproxy_api,
+                                    endpoints.cinder.haproxy.prefer_primary_backend,
+                                    endpoints.cinder.haproxy.health_check,
+                                    endpoints.cinder.haproxy.balance ]) %}
+{% endif -%}
 {% if ceilometer.enabled|default('False')|bool -%}
     {% set _ = haproxy_services.append(['ceilometer',
                                         endpoints.ceilometer.port.backend_api,


### PR DESCRIPTION
We always added cinder endpoint to haproxy even when cinder is disabled. This PR check on cinder.enabled to add the cinder endpoint in haproxy config.