### PR TITLE
Hide image create url method from horizon.

### DIFF
--- a/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
+++ b/roles/horizon/templates/etc/openstack-dashboard/local_settings.py
@@ -363,7 +363,7 @@ OPENSTACK_HEAT_STACK = {
 }
 
 # Enables upload from remote location
-IMAGES_ALLOW_LOCATION = "{{ horizon.glance.allow_location }}"
+IMAGES_ALLOW_LOCATION = {{ horizon.glance.allow_location }}
 HORIZON_IMAGES_UPLOAD_MODE = 'legacy'
 
 # The OPENSTACK_IMAGE_BACKEND settings can be used to customize features


### PR DESCRIPTION
The url method fro image creation does not provide an option to get image copied from remote location at image creation time. This PR will hide this option from horizon.