### PR TITLE
Add condition for test task - router ping internet

### DIFF
--- a/playbooks/tests/tasks/network.yml
+++ b/playbooks/tests/tasks/network.yml
@@ -54,6 +54,7 @@
   - name: neutron router can ping internet
     shell: ROUTER_NS=$( ip netns show | grep qrouter- | awk '{print $1}' );
            ip netns exec ${ROUTER_NS} ping -c 5 8.8.8.8
+    when: neutron.l3ha.enabled is defined and neutron.l3ha.enabled|bool
     register: result
     until: result|success
     retries: 30


### PR DESCRIPTION
Met this issue several times in test TASK [neutron router can ping internet] - 
"FAILED - RETRYING: TASK: neutron router can ping internet (1 retries left).
fatal: [controller-0]: FAILED! => {"changed": true, "cmd": "ROUTER_NS=$( ip netns show | grep qrouter- | awk '{print $1}' ); ip netns exec ${ROUTER_NS} ping -c 5 8.8.8.8", "delta": "0:00:00.005319", "end": "2017-02-26 03:10:05.496612", "failed": true, "rc": 1, "start": "2017-02-26 03:10:05.491293", "stderr": "Cannot open network namespace \"ping\": No such file or directory", "stdout": "", "stdout_lines": [], "warnings": []}"

Tested locally, and found that qrouter-*** cannot be found in controller-0 but controller-1, that's because neutron has no this variable "l3ha: enabled: True".

Not sure which test_env will enable this variable, so I just add a condition in test task to check if this task will be run.
