### PR TITLE
add sigquit keystone systemd service

### DIFF
--- a/library/systemd_service.py
+++ b/library/systemd_service.py
@@ -67,6 +67,9 @@ ExecStartPre={{ prestart_script }}
 {% if kill_mode -%}
 KillMode={{ kill_mode }}
 {% endif %}
+{% if kill_signal -%}
+KillSignal={{ kill_signal }}
+{% endif %}
 #ExecStop=
 #ExecStopPost=
 #ExecReload=
@@ -99,6 +102,7 @@ def main():
             notify_access=dict(default=None, choices=['none', 'main', 'all']),
             config_dirs=dict(default=None),
             config_files=dict(default=None),
+            kill_signal=dict(default=None),
             state=dict(default='present', choices=['present', 'absent']),
             prestart_script=dict(default=None),
             timeout_start_secs=dict(default='120'),

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -61,6 +61,7 @@
       type: "{{ item.type }}"
       notify_access: "{{ item.notify_access }}"
       restart: "{{ item.restart }}"
+      kill_signal: "SIGQUIT"
     with_items:
       - "{{ openstack_meta.keystone.services.keystone_api[os] }}"
 


### PR DESCRIPTION
The default systemd kill signal is SIGTERM, which will reload uwsgi workers. Uwsgi requires a SIGQUIT be sent to immediately kill the entire uWSGI stack. 