### PR TITLE
disable convergence engine

### DIFF
--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -3,6 +3,7 @@ project_name: heat
 heat:
   enabled: True
   heartbeat_timeout_threshold: 30
+  convergence_engine: False
   services:
     heat_api: "{{ openstack_meta.heat.services.heat_api[os] }}"
     heat_api_cfn: "{{ openstack_meta.heat.services.heat_api_cfn[os] }}"

--- a/roles/heat/templates/etc/heat/heat.conf
+++ b/roles/heat/templates/etc/heat/heat.conf
@@ -11,6 +11,8 @@ notification_driver = log
 log_dir = /var/log/heat
 use_stderr = false
 
+convergence_engine = {{ heat.convergence_engine }}
+
 deferred_auth_method=trusts
 trusts_delegated_roles=heat_stack_owner
 


### PR DESCRIPTION
Convergence engine has many problems, and we'd disable convergence engine by default in Newton.

1) convergence engine won't support ucd plugin. This is confirmed by heat team cores and ucd dev. 
2) bugs to software deployment deletion and load balancers with two listeners.