### PR TITLE
add precheck of ceph version if current version is less than Jewel.

### DIFF
--- a/roles/preflight-checks/defaults/main.yml
+++ b/roles/preflight-checks/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+preflight_checks:
+  ceph_minimum_version: 10

--- a/roles/preflight-checks/tasks/ceph.yml
+++ b/roles/preflight-checks/tasks/ceph.yml
@@ -35,3 +35,12 @@
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
   delegate_facts: yes
   when: result_osdhosts.stdout|int < groups['ceph_osds']|length
+
+- name: fail if current ceph version is less than Jewel
+  shell: test $(ceph --version |grep -oP "\d+\.\d+\.?\d{0,3}") \>
+         "{{ preflight_checks.ceph_minimum_version }}"
+  delegate_to: "{{ item }}" 
+  with_items: 
+    - "{{ groups['ceph_monitors']|default([]) }}"
+    - "{{ groups['ceph_osds_ssd']|default([]) }}"
+

--- a/site.yml
+++ b/site.yml
@@ -15,6 +15,7 @@
 
 - name: preflight checks
   hosts: all:!vyatta-*
+  any_errors_fatal: true
   roles:
     - role: preflight-checks
       tags: ['always']


### PR DESCRIPTION
To upgrade ceph, we must make sure the current version is at least Jewel.
