### PR TITLE
Fix flush token cron job for RHEL

### DIFF
--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -188,7 +188,6 @@
   service: name=shibd state=started enabled=true
   when: keystone.federation.enabled|bool and keystone.federation.sp.saml.enabled|bool
 
-# FIXME adjust template for /us/bin on rhel
 - name: add cron job to clean up expired tokens
   template:
     src: etc/cron.d/drop-expired-keystone-tokens

--- a/roles/keystone/templates/etc/cron.d/drop-expired-keystone-tokens
+++ b/roles/keystone/templates/etc/cron.d/drop-expired-keystone-tokens
@@ -1,4 +1,5 @@
-PATH=/usr/local/bin/
+PATH=/sbin:/usr/sbin:{{ (os == 'rhel' ) | ternary('/usr/bin/', '/usr/local/bin/') }}
+
 
 # Drop the tokens every 5 minutes
-*/5 * * * * root keystone-manage token_flush
+*/5 * * * * root if ip a | grep {{ undercloud_floating_ip | default(floating_ip) }} > /dev/null 2>&1; then keystone-manage token_flush; fi


### PR DESCRIPTION
    The job was not running because the path was wrong. This caused
    the token count to go high. This fixes the path and should
    only run on the machine that the undercloud floating ip is
    assigned to.