### PR TITLE
Split rally cases for different envs

### DIFF
--- a/playbooks/tests/tasks/rally.yml
+++ b/playbooks/tests/tasks/rally.yml
@@ -2,11 +2,15 @@
 - name: Running Rally against test cloud
   hosts: controller[0]
   tasks:
-    - name: copy Rally test profile template into place
+    - name: copy basic Rally test profile template into place
       copy: src=rally/bbc-cloud-validate.yml dest=./bbc-cloud-validate.yml mode=0444
 
+    - name: copy ceph Rally test profile template into place
+      copy: src=rally/bbc-cloud-validate-ceph.yml dest=./bbc-cloud-validate-ceph.yml mode=0444
+      when: cinder.enabled|bool
+
     - name: run Rally script
-      script: ./rally/run.sh {{ build_tag }}
+      script: ./rally/run.sh -e "{{ cinder.enabled }}" -t "{{ build_tag }}"
       become: yes
       become_user: root
 

--- a/playbooks/tests/tasks/rally/bbc-cloud-validate-ceph.yml
+++ b/playbooks/tests/tasks/rally/bbc-cloud-validate-ceph.yml
@@ -1,0 +1,96 @@
+---
+  Authenticate.validate_cinder:
+    -
+      args:
+        repetitions: 2
+      runner:
+        type: "constant"
+        times: 6
+        concurrency: 2
+      context:
+        users:
+          tenants: 3
+          users_per_tenant: 5
+      sla:
+        failure_rate:
+          max: 1
+
+  CinderVolumes.create_and_delete_volume:
+    -
+      args:
+        size: 1
+      runner:
+        type: "constant"
+        times: 6
+        concurrency: 2
+      context:
+        users:
+          tenants: 3
+          users_per_tenant: 2
+        quotas:
+          cinder:
+            volumes: -1
+      sla:
+        failure_rate:
+          max: 1
+
+  CinderVolumes.create_from_volume_and_delete_volume:
+    -
+      args:
+        size: 1
+      runner:
+        type: "constant"
+        times: 6
+        concurrency: 2
+      context:
+        users:
+          tenants: 3
+          users_per_tenant: 2
+        volumes:
+          size: 1
+      sla:
+        failure_rate:
+          max: 1
+
+  CinderVolumes.create_and_delete_snapshot:
+    -
+      args:
+          force: false
+      runner:
+        type: "constant"
+        times: 6
+        concurrency: 2
+      context:
+        users:
+          tenants: 3
+          users_per_tenant: 2
+        volumes:
+          size: 1
+      sla:
+        failure_rate:
+          max: 1
+
+  NovaServers.boot_server_from_volume_and_delete:
+    -
+      args:
+        flavor:
+            name: "m1.tiny"
+        image:
+            name: {{image_name}}
+        volume_size: 10
+        force_delete: false
+        nics:
+          - { "net-id": "{{net_id}}" }
+      runner:
+        type: "constant"
+        times: 10
+        concurrency: 1
+      context:
+        users:
+          tenants: 3
+        quotas:
+          cinder:
+            volumes: -1
+      sla:
+        failure_rate:
+          max: 10

--- a/playbooks/tests/tasks/rally/bbc-cloud-validate.yml
+++ b/playbooks/tests/tasks/rally/bbc-cloud-validate.yml
@@ -21,22 +21,6 @@
         failure_rate:
           max: 1
 
-  Authenticate.validate_cinder:
-    -
-      args:
-        repetitions: 2
-      runner:
-        type: "constant"
-        times: 6
-        concurrency: 2
-      context:
-        users:
-          tenants: 3
-          users_per_tenant: 5
-      sla:
-        failure_rate:
-          max: 1
-
   Authenticate.validate_glance:
     -
       args:
@@ -167,61 +151,6 @@
         failure_rate:
           max: 1
 
-  CinderVolumes.create_and_delete_volume:
-    -
-      args:
-        size: 1
-      runner:
-        type: "constant"
-        times: 6
-        concurrency: 2
-      context:
-        users:
-          tenants: 3
-          users_per_tenant: 2
-        quotas:
-          cinder:
-            volumes: -1
-      sla:
-        failure_rate:
-          max: 1
-
-  CinderVolumes.create_and_delete_snapshot:
-    -
-      args:
-          force: false
-      runner:
-        type: "constant"
-        times: 6
-        concurrency: 2
-      context:
-        users:
-          tenants: 3
-          users_per_tenant: 2
-        volumes:
-          size: 1
-      sla:
-        failure_rate:
-          max: 1
-
-  CinderVolumes.create_from_volume_and_delete_volume:
-    -
-      args:
-        size: 1
-      runner:
-        type: "constant"
-        times: 6
-        concurrency: 2
-      context:
-        users:
-          tenants: 3
-          users_per_tenant: 2
-        volumes:
-          size: 1
-      sla:
-        failure_rate:
-          max: 1
-
   NovaServers.boot_and_delete_server:
     -
       args:
@@ -248,31 +177,6 @@
       sla:
         failure_rate:
           max: 1
-
-  NovaServers.boot_server_from_volume_and_delete:
-    -
-      args:
-        flavor:
-            name: "m1.tiny"
-        image:
-            name: {{image_name}}
-        volume_size: 10
-        force_delete: false
-        nics:
-          - { "net-id": "{{net_id}}" }
-      runner:
-        type: "constant"
-        times: 10
-        concurrency: 1
-      context:
-        users:
-          tenants: 3
-        quotas:
-          cinder:
-            volumes: -1
-      sla:
-        failure_rate:
-          max: 10
 
   NovaServers.suspend_and_resume_server:
     -


### PR DESCRIPTION
Some envs have no ceph nodes so that ceph-related rally cases cannot be run successfully.