### PR TITLE
metrics scheme was getting set with .'s on rhel

### DIFF
--- a/roles/monitoring-common/defaults/main.yml
+++ b/roles/monitoring-common/defaults/main.yml
@@ -32,7 +32,7 @@ monitoring:
     criticality: 'critical'
   graphite:
     cluster_prefix: "stats.bbc.{{ stack_env }}.openstack"
-    host_prefix: "stats.bbc.{{ stack_env }}.{{ ansible_nodename|regex_replace('\\\\.*$', '') }}"
+    host_prefix: "stats.bbc.{{ stack_env }}.{{ hostname_short|default(ansible_nodename|regex_replace('\\\\.*$', '')) }}"
   rabbit:
     host: 172.16.0.103
     port: 5671


### PR DESCRIPTION
this screwed up our dashboards etc,  graphite treats .'s as seperators
and effort is made to ensure host metrics ship without .'s in the scheme.

unfortunately under rhel the FQDN was being used,  this fixes it to use the
newer `hostname_short` variable and if that doesn't exist defaults back to
using `ansible_nodename`.