### PR TITLE
filebeats configs were not setting extra fields from log definitions.

### DIFF
--- a/roles/logging-config/templates/etc/filebeat/filebeat.d/template.yml
+++ b/roles/logging-config/templates/etc/filebeat/filebeat.d/template.yml
@@ -1,12 +1,13 @@
 # {{ ansible_managed }}
-{% for item in logdata %}
-{%   if item.fields and logging.follow.global_fields %}
-{%     set _dummy = item.fields.update(logging.follow.global_fields) %}
-{%   elif logging.follow.global_fields %}
-{%     set _dummy = item.setdefault('fields', logging.follow.global_fields) %}
-{%   endif %}
-{% endfor -%}
 ---
 filebeat:
+{% if logdata | length > 0 %}
   prospectors:
-    {{ logdata | to_yaml( indent=2, default_flow_style=False ) | indent ( width=4 ) }}
+{% for log in logdata %}
+    - fields_under_root: true
+      paths: {{ log.paths | to_yaml }}
+{%- if log.fields is defined %}{% set _dummy = log.fields.update(logging.follow.global_fields) %}{% endif %}
+      fields: {{ log.fields | default(logging.follow.global_fields) | to_yaml  }}
+{% endfor %}
+{% endif %}
+

--- a/roles/logging/templates/etc/filebeat/filebeat.yml
+++ b/roles/logging/templates/etc/filebeat/filebeat.yml
@@ -14,5 +14,11 @@ filebeat:
   config_dir: "{{ logging.forward.config_dir }}"
 {% if logging.follow.logs | length > 0 %}
   prospectors:
-    {{ logging.follow.logs | to_yaml( indent=2, default_flow_style=False ) | indent ( width=4 ) }}
+{% for log in logging.follow.logs %}
+    - fields_under_root: true
+      paths: {{ log.paths | to_yaml }}
+{%- if log.fields is defined %}{% set _dummy = log.fields.update(logging.follow.global_fields) %}{% endif %}
+      fields: {{ log.fields | default(logging.follow.global_fields) | to_yaml  }}
+{% endfor %}
 {% endif %}
+

--- a/roles/preflight-checks/tasks/check_items.yml
+++ b/roles/preflight-checks/tasks/check_items.yml
@@ -9,10 +9,12 @@
     command: neutron --version
     register: result_neutron_installed
     failed_when: false
+    changed_when: false
 
   - name: check whether neutron endpoint exists
     shell: . /root/stackrc; openstack endpoint list | grep neutron
     failed_when: false
+    changed_when: false
     register: result_neutron_endpoint
 
   - include: neutron.yml


### PR DESCRIPTION
* updated filebeats config templates to handle the global_fields
* set flag to ensure fields are in root namespace in logs

also fixed a couple of preflight checks so they don't show as changed tasks.