### PR TITLE
Re-enable JellyRoll Password Complexity

### DIFF
--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -9,11 +9,11 @@ horizon:
   legacy_instance_panel: false
   session_engine: django.contrib.sessions.backends.cache
   password_validator:
-    enabled: True
+    enabled: false
     regex: '^(?=.*\d)(?=.*[a-z]).{8,}$'
     help_text: 'Password is not compliant. Password must contain lowercase letters, digits, and be at least 8 characters in length.'
   glance:
-    allow_location: False  
+    allow_location: False
   distro:
     project_packages:
       - openstack-dashboard

--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -51,7 +51,9 @@ keystone:
     - keystone-wsgi-public
   jellyroll: False # custom middleware for password compliance
   security_compliance:
-    enabled: true
+    # if enabled then the jellyroll middleware filter:passval
+    # should be removed from keystone-paste.ini
+    enabled: false
     password_regex: '^(?=.*\d)(?=.*[a-z]).{8,}$'
     password_regex_description: 'Password is not compliant. Password must contain lowercase letters, digits, and be at least 8 characters in length.'
   roles:

--- a/roles/keystone/templates/etc/keystone/keystone-paste.ini
+++ b/roles/keystone/templates/etc/keystone/keystone-paste.ini
@@ -49,6 +49,9 @@ use = egg:keystone#url_normalize
 use = egg:oslo.middleware#sizelimit
 
 {% if keystone.jellyroll|bool %}
+[filter:passval]
+paste.filter_factory = jellyroll.keystone.password_validation:KeystonePasswordValidation.factory
+
 [filter:unauthlog]
 paste.filter_factory = jellyroll.keystone.unauthorized_logger:UnauthorizedLogger.factory
 memcache_hosts = {{ endpoints.memcache }}
@@ -75,13 +78,13 @@ use = egg:keystone#service_v3
 use = egg:keystone#admin_service
 
 [pipeline:public_api]
-pipeline = healthcheck cors sizelimit url_normalize http_proxy_to_wsgi request_id build_auth_context token_auth json_body ec2_extension{{ ' unauthlog' if keystone.jellyroll|bool else '' }} public_service
+pipeline = healthcheck cors sizelimit url_normalize http_proxy_to_wsgi request_id build_auth_context token_auth json_body ec2_extension{{ ' passval unauthlog' if keystone.jellyroll|bool else '' }} public_service
 
 [pipeline:admin_api]
-pipeline = healthcheck cors sizelimit url_normalize http_proxy_to_wsgi request_id build_auth_context token_auth json_body ec2_extension s3_extension{{ ' unauthlog' if keystone.jellyroll|bool else '' }} admin_service
+pipeline = healthcheck cors sizelimit url_normalize http_proxy_to_wsgi request_id build_auth_context token_auth json_body ec2_extension s3_extension{{ ' passval unauthlog' if keystone.jellyroll|bool else '' }} admin_service
 
 [pipeline:api_v3]
-pipeline = healthcheck cors sizelimit url_normalize http_proxy_to_wsgi request_id build_auth_context token_auth json_body ec2_extension_v3 s3_extension{{ ' rbac_filter unauthlog' if keystone.jellyroll|bool else '' }}  service_v3
+pipeline = healthcheck cors sizelimit url_normalize http_proxy_to_wsgi request_id build_auth_context token_auth json_body ec2_extension_v3 s3_extension{{ ' rbac_filter passval unauthlog' if keystone.jellyroll|bool else '' }} service_v3
 
 [app:public_version_service]
 use = egg:keystone#public_version_service


### PR DESCRIPTION
    Heat is having issues creating users with passwords requirements. So
    the password complexity feature by Keystone will be disabled to allow
    heat to work again. The JellyRoll password validator will
    be enabled again.