### PR TITLE
rename os to ursula_os

### DIFF
--- a/envs/example/allinone-centos/group_vars/all.yml
+++ b/envs/example/allinone-centos/group_vars/all.yml
@@ -1,6 +1,7 @@
 ---
 stack_env: example_allinone
 floating_ip: 172.16.0.100
+ursula_os: 'rhel'
 xtradb:
   sst_auth_password: asdf
 validate_certs: false

--- a/envs/example/allinone-rhel/group_vars/all.yml
+++ b/envs/example/allinone-rhel/group_vars/all.yml
@@ -1,6 +1,7 @@
 ---
 openstack_install_method: 'distro'
 openstack_distro_type: 'osp'
+ursula_os: 'rhel'
 stack_env: example_allinone
 floating_ip: 172.16.0.100
 xtradb:

--- a/envs/example/allinone/group_vars/all.yml
+++ b/envs/example/allinone/group_vars/all.yml
@@ -1,6 +1,7 @@
 ---
 stack_env: example_allinone
 floating_ip: 172.16.0.100
+ursula_os: 'ubuntu'
 
 xtradb:
   sst_auth_password: asdf

--- a/envs/example/ci-ceph-redhat/group_vars/all.yml
+++ b/envs/example/ci-ceph-redhat/group_vars/all.yml
@@ -2,6 +2,7 @@
 stack_env: ci-ceph-redhat
 openstack_install_method: 'distro'
 openstack_distro_type: 'osp'
+ursula_os: 'rhel'
 undercloud_cidr:
   - cidr: 192.168.0.0/22
 ceph:

--- a/envs/example/ci-ceph_swift/group_vars/all.yml
+++ b/envs/example/ci-ceph_swift/group_vars/all.yml
@@ -1,5 +1,6 @@
 ---
 stack_env: example_ci-ceph_swift
+ursula_os: 'ubuntu'
 
 state_path_base: /opt/stack/data
 

--- a/envs/example/ci-full-centos/group_vars/all.yml
+++ b/envs/example/ci-full-centos/group_vars/all.yml
@@ -1,5 +1,6 @@
 ---
 stack_env: ci-full-centos
+ursula_os: 'rhel'
 undercloud_cidr:
   - cidr: 192.168.0.0/22
 state_path_base: /opt/stack/data

--- a/envs/example/ci-full-rhel/group_vars/all.yml
+++ b/envs/example/ci-full-rhel/group_vars/all.yml
@@ -1,6 +1,7 @@
 ---
 openstack_install_method: 'distro'
 openstack_distro_type: 'osp'
+ursula_os: 'rhel'
 
 stack_env: ci-full-centos
 undercloud_cidr:

--- a/envs/example/ci-full/group_vars/all.yml
+++ b/envs/example/ci-full/group_vars/all.yml
@@ -1,5 +1,6 @@
 ---
 stack_env: example_ci-full
+ursula_os: 'ubuntu'
 
 state_path_base: /opt/stack/data
 

--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -497,7 +497,7 @@ keystone:
     enabled: False
 
 ssl:
-  cafile: "{{ (os == 'rhel' ) | ternary('/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt', '/etc/ssl/certs/ca-certificates.crt') }}"
+  cafile: "{{ (ursula_os == 'rhel' ) | ternary('/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt', '/etc/ssl/certs/ca-certificates.crt') }}"
   crt: |
     -----BEGIN CERTIFICATE-----
     MIIDmzCCAoOgAwIBAgIJAPiU05VLEq08MA0GCSqGSIb3DQEBBQUAMGwxCzAJBgNV

--- a/playbooks/tests/tasks/all.yml
+++ b/playbooks/tests/tasks/all.yml
@@ -4,14 +4,14 @@
   tags: always
   tasks:
   - set_fact:
-      os: 'ubuntu'
+      ursula_os: 'ubuntu'
     when: ansible_distribution == 'Ubuntu'
   - set_fact:
-      os: 'rhel'
+      ursula_os: 'rhel'
     when: ansible_distribution in ['CentOS','RedHat']
   - debug:
       msg: "OS is {{ ansible_distribution }}"
-    failed_when: os is not defined
+    failed_when: ursula_os is not defined
 
 - name: Test basic things on all hosts
   hosts: all
@@ -30,4 +30,4 @@
 
   - name: Running 12.04.4 LTS or greater
     shell: bash -c '. /etc/os-release; echo -e "${VERSION}\n12.04.4" | sort -V | head -1 | egrep "^12.04.4"'
-    when: os == 'ubuntu'
+    when: ursula_os == 'ubuntu'

--- a/playbooks/tests/tasks/controller.yml
+++ b/playbooks/tests/tasks/controller.yml
@@ -8,16 +8,16 @@
 #  - name: horizon is up
 #    shell: curl -sSL -k http://localhost:8080 | grep "Login - OpenStack Dashboard"
 
-  - name: client stackrc has an os cacert env variable
+  - name: client stackrc has an cacert env variable
     shell: grep OS_CACERT /root/stackrc
 
   - name: common timezone is utc
     shell: grep UTC /etc/timezone
-    when: os == 'ubuntu'
+    when: ursula_os == 'ubuntu'
 
   - name: common timezone is utc
     shell: grep UTC /etc/localtime
-    when: os == 'rhel'
+    when: ursula_os == 'rhel'
 
   - name: common date command has utc
     shell: date | grep UTC
@@ -79,11 +79,11 @@
 
   - name: iptables defaults to dropping connections from the internet
     shell: ufw status verbose | egrep '^Default. deny .incoming.'
-    when: os == 'ubuntu'
+    when: ursula_os == 'ubuntu'
 
   - name: iptables lets ssh in from outside
     shell: ufw status verbose | egrep '^22/tcp                     ALLOW IN    Anywhere'
-    when: os == 'ubuntu'
+    when: ursula_os == 'ubuntu'
 
   - name: all backends are up in haproxy
     shell: curl -k -s -u admin:{{ secrets.admin_password }} https://127.0.0.1/haproxy_stats\;csv | awk '/DOWN/ {print;ec=1} END{exit ec}'

--- a/roles/aodh/defaults/main.yml
+++ b/roles/aodh/defaults/main.yml
@@ -3,11 +3,11 @@ project_name: aodh
 aodh:
   debug: False
   services:
-    aodh_api: "{{ openstack_meta.aodh.services.aodh_api[os] }}"
-    aodh_evaluator: "{{ openstack_meta.aodh.services.aodh_evaluator[os] }}"
-    aodh_listener: "{{ openstack_meta.aodh.services.aodh_listener[os] }}"
-    aodh_notifier: "{{ openstack_meta.aodh.services.aodh_notifier[os] }}"
-    aodh_expirer: "{{ openstack_meta.aodh.services.aodh_expirer[os] }}"
+    aodh_api: "{{ openstack_meta.aodh.services.aodh_api[ursula_os] }}"
+    aodh_evaluator: "{{ openstack_meta.aodh.services.aodh_evaluator[ursula_os] }}"
+    aodh_listener: "{{ openstack_meta.aodh.services.aodh_listener[ursula_os] }}"
+    aodh_notifier: "{{ openstack_meta.aodh.services.aodh_notifier[ursula_os] }}"
+    aodh_expirer: "{{ openstack_meta.aodh.services.aodh_expirer[ursula_os] }}"
   distro:
     project_packages:
       - openstack-aodh-api

--- a/roles/aodh/tasks/main.yml
+++ b/roles/aodh/tasks/main.yml
@@ -24,7 +24,7 @@
     - "{{ aodh.services.aodh_evaluator }}"
     - "{{ aodh.services.aodh_listener }}"
     - "{{ aodh.services.aodh_notifier }}"
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - block:
   - name: install aodh services (rhel)
@@ -50,7 +50,7 @@
       state: absent
     with_items:
       - "{{ aodh.services.aodh_expirer }}"
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: aodh config
   template: src={{ item }} dest=/etc/aodh/

--- a/roles/apache/defaults/main.yml
+++ b/roles/apache/defaults/main.yml
@@ -19,12 +19,12 @@ apache:
   listen: []
   logs:
     - paths:
-        - "{{ apache_log_path[os] }}/access.log"
+        - "{{ apache_log_path[ursula_os] }}/access.log"
       fields:
         # type: <custom type defined in receiving Logstash>
         tags: apache_access
     - paths:
-        -  "{{ apache_log_path[os] }}/error.log"
+        -  "{{ apache_log_path[ursula_os] }}/error.log"
       fields:
         # type: <custom type defined in receiving Logstash>
         tags: apache_error

--- a/roles/apache/handlers/main.yml
+++ b/roles/apache/handlers/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: restart apache
-  service: name="{{ apache.service_name[os] }}" state=restarted must_exist=false
+  service: name="{{ apache.service_name[ursula_os] }}" state=restarted must_exist=false
 
 - name: reload apache
-  service: name="{{ apache.service_name[os] }}" state=reloaded must_exist=false
+  service: name="{{ apache.service_name[ursula_os] }}" state=reloaded must_exist=false
 
 - name: stop apache
-  service: name="{{ apache.service_name[os] }}" state=stopped
+  service: name="{{ apache.service_name[ursula_os] }}" state=stopped

--- a/roles/apache/tasks/logging.yml
+++ b/roles/apache/tasks/logging.yml
@@ -2,7 +2,7 @@
 - name: set up log rotation for apache
   logrotate: 
     name: apache2 
-    path: "{{ apache_log_path[os] }}/*.log"
+    path: "{{ apache_log_path[ursula_os] }}/*.log"
   args:
     options:
         - daily

--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: install apache package
-  package: name="{{ openstack_meta.apache[os].package_name }}"
+  package: name="{{ openstack_meta.apache[ursula_os].package_name }}"
   register: result
   until: result|succeeded
   retries: 5
@@ -15,11 +15,11 @@
 
   - name: check selinux for httpd_can_network_connect
     seboolean: name=httpd_can_network_connect state=yes persistent=yes
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: install apache module packages
   package: name={{ item }}
-  with_items: "{{ apache.modules[os] }}"
+  with_items: "{{ apache.modules[ursula_os] }}"
   register: result
   until: result|succeeded
   retries: 5
@@ -55,7 +55,7 @@
 
   - name: remove ports.conf
     file: dest=/etc/apache2/ports.conf state=absent
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - block:
   - name: disable apache status
@@ -81,18 +81,18 @@
       - userdir.conf
       - welcome.conf
     notify: restart apache
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: enable apache server
   service:
-    name: "{{ apache.service_name[os] }}"
+    name: "{{ apache.service_name[ursula_os] }}"
     enabled: true
 
 - name: create horizon config directory
   file: 
     dest: "/etc/openstack-dashboard"
     state: directory 
-    group: "{{ openstack_meta.apache[os].group }}"
+    group: "{{ openstack_meta.apache[ursula_os].group }}"
     mode: 0750
 
 - include: logging.yml

--- a/roles/ceilometer-common/defaults/main.yml
+++ b/roles/ceilometer-common/defaults/main.yml
@@ -2,11 +2,11 @@
 project_name: ceilometer
 ceilometer:
   services:
-    ceilometer_api: "{{ openstack_meta.ceilometer.services.ceilometer_api[os] }}"
-    ceilometer_collector: "{{ openstack_meta.ceilometer.services.ceilometer_collector[os] }}"
-    ceilometer_notification: "{{ openstack_meta.ceilometer.services.ceilometer_notification[os] }}"
-    ceilometer_polling: "{{ openstack_meta.ceilometer.services.ceilometer_polling[os] }}"
-    ceilometer_polling_compute: "{{ openstack_meta.ceilometer.services.ceilometer_polling_compute[os] }}"
+    ceilometer_api: "{{ openstack_meta.ceilometer.services.ceilometer_api[ursula_os] }}"
+    ceilometer_collector: "{{ openstack_meta.ceilometer.services.ceilometer_collector[ursula_os] }}"
+    ceilometer_notification: "{{ openstack_meta.ceilometer.services.ceilometer_notification[ursula_os] }}"
+    ceilometer_polling: "{{ openstack_meta.ceilometer.services.ceilometer_polling[ursula_os] }}"
+    ceilometer_polling_compute: "{{ openstack_meta.ceilometer.services.ceilometer_polling_compute[ursula_os] }}"
   enabled: False
   distro:
     controller:

--- a/roles/ceilometer-common/tasks/main.yml
+++ b/roles/ceilometer-common/tasks/main.yml
@@ -30,7 +30,7 @@
     src: "etc/ceilometer/policy.json"
     dest: "/etc/openstack-dashboard/ceilometer_policy.json"
     owner: "root"
-    group: "{{ openstack_meta.apache[os].group }}"
+    group: "{{ openstack_meta.apache[ursula_os].group }}"
     mode: 0640
   when: inventory_hostname in groups['controller']
 

--- a/roles/ceilometer-control/tasks/main.yml
+++ b/roles/ceilometer-control/tasks/main.yml
@@ -10,7 +10,7 @@
     - "{{ ceilometer.services.ceilometer_polling }}"
     - "{{ ceilometer.services.ceilometer_notification }}"
   notify: restart ceilometer services
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: install ceilometer controller services (rhel)
   systemd_service:
@@ -26,7 +26,7 @@
     - "{{ ceilometer.services.ceilometer_collector }}"
     - "{{ ceilometer.services.ceilometer_notification }}"
     - "{{ ceilometer.services.ceilometer_polling }}"
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: trigger restart on upgrades
   debug:

--- a/roles/ceilometer-data/tasks/main.yml
+++ b/roles/ceilometer-data/tasks/main.yml
@@ -7,7 +7,7 @@
   with_items:
     - "{{ ceilometer.services.ceilometer_polling }}"
   notify: restart ceilometer data services
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: install ceilometer polling agent (rhel)
   systemd_service:
@@ -21,7 +21,7 @@
   with_items:
     - "{{ ceilometer.services.ceilometer_polling }}"
     - "{{ ceilometer.services.ceilometer_polling_compute }}"
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: install libvirt-python in package venv
   command: "{{ 'ceilometer'|ursula_package_path(openstack_package_version) }}/bin/pip install libvirt-python"

--- a/roles/ceph-client/tasks/main.yml
+++ b/roles/ceph-client/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: install ceph client
-  package: name=ceph-common{{ ceph.pkg_version_connector[os] }}{{ ceph.client_version[os] }}
+  package: name=ceph-common{{ ceph.pkg_version_connector[ursula_os] }}{{ ceph.client_version[ursula_os] }}
            state=present
   register: result_cephclient
   until: result_cephclient|succeeded

--- a/roles/ceph-monitor/meta/main.yml
+++ b/roles/ceph-monitor/meta/main.yml
@@ -11,5 +11,5 @@ dependencies:
     repos:
       - repo: 'deb {{ apt_repos.ceph.repo }} {{ ansible_lsb.codename }} main'
         key_url: '{{ apt_repos.ceph.key_url }}'
-    when: os == 'ubuntu'
+    when: ursula_os == 'ubuntu'
 # as redhat already has ceph repo added, we don't need to add it here

--- a/roles/ceph-monitor/tasks/main.yml
+++ b/roles/ceph-monitor/tasks/main.yml
@@ -7,7 +7,7 @@
   retries: 5
 
 - name: install ceph monitor
-  package: name=ceph-mon{{ ceph.pkg_version_connector[os] }}{{ ceph.version[os] }}
+  package: name=ceph-mon{{ ceph.pkg_version_connector[ursula_os] }}{{ ceph.version[ursula_os] }}
            state=present
   register: result
   until: result|succeeded
@@ -73,20 +73,20 @@
   with_items:
     - done
     - upstart
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: ensure ceph-mon service enabled and started(debian)
   service: name=ceph-mon
            state=started
            enabled=yes
            args=id={{ ansible_hostname }}
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: ensure ceph-mon service enabled and started(redhat)
   service: name=ceph-mon@{{ ansible_hostname }}
            state=started
            enabled=yes
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: wait for client.admin key exists
   wait_for: path=/etc/ceph/ceph.client.admin.keyring

--- a/roles/ceph-monitor/tasks/monitoring.yml
+++ b/roles/ceph-monitor/tasks/monitoring.yml
@@ -1,7 +1,7 @@
 ---
 - name: import rados module into base_venv (rhel)
   file:
-    src: "{{ ceph.pylib_dir[os] }}{{ item }}"
+    src: "{{ ceph.pylib_dir[ursula_os] }}{{ item }}"
     dest: "/opt/openstack/base/lib/python2.7/site-packages/{{ item }}"
     state: link
     owner: root
@@ -10,11 +10,11 @@
   with_items:
     - rados.so
     - rbd.so
-  when: os == "rhel"
+  when: ursula_os == "rhel"
 
 - name: import rados module into base_venv (ubuntu)
   file:
-    src: "{{ ceph.pylib_dir[os] }}{{ item }}"
+    src: "{{ ceph.pylib_dir[ursula_os] }}{{ item }}"
     dest: "/opt/openstack/base/lib/python2.7/site-packages/{{ item }}"
     state: link
     owner: root
@@ -23,11 +23,11 @@
   with_items:
     - rados.x86_64-linux-gnu.so
     - rbd.x86_64-linux-gnu.so
-  when: os == "ubuntu"
+  when: ursula_os == "ubuntu"
 
 - name: import other ceph modules into base_venv
   file:
-    src: "{{ ceph.pylib_dir2[os] }}{{ item }}"
+    src: "{{ ceph.pylib_dir2[ursula_os] }}{{ item }}"
     dest: "/opt/openstack/base/lib/python2.7/site-packages/{{ item }}"
     state: link
     owner: root

--- a/roles/ceph-osd/meta/main.yml
+++ b/roles/ceph-osd/meta/main.yml
@@ -11,5 +11,5 @@ dependencies:
     repos:
       - repo: 'deb {{ apt_repos.ceph.repo }} {{ ansible_lsb.codename }} main'
         key_url: '{{ apt_repos.ceph.key_url }}'
-    when: os == 'ubuntu'
+    when: ursula_os == 'ubuntu'
 # as redhat already has ceph repo added, we don't need to add it here

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -24,7 +24,7 @@
   retries: 5
 
 - name: install ceph osd
-  package: name=ceph-osd{{ ceph.pkg_version_connector[os] }}{{ ceph.version[os] }}
+  package: name=ceph-osd{{ ceph.pkg_version_connector[ursula_os] }}{{ ceph.version[ursula_os] }}
            state=present
   register: result
   until: result|succeeded

--- a/roles/ceph-osd/tasks/system_tuning.yml
+++ b/roles/ceph-osd/tasks/system_tuning.yml
@@ -8,7 +8,7 @@
 - block:
   - name: install dependencies
     package: name={{ item }}
-    with_items: "{{ ceph.hugepage_pkgs[os] }}"
+    with_items: "{{ ceph.hugepage_pkgs[ursula_os] }}"
     register: result
     until: result|succeeded
     retries: 5
@@ -25,11 +25,11 @@
   
   - name: update grub config with changes(debian)
     command: update-grub
-    when: os == 'ubuntu'
+    when: ursula_os == 'ubuntu'
   
   - name: update grub config with changes(redhat)
     command: grub2-mkconfig -o /boot/grub2/grub.cfg
-    when: os == 'rhel'
+    when: ursula_os == 'rhel'
   when: ceph.disable_transparent_hugepage
 
 - name: apply operating system tuning

--- a/roles/ceph-update/tasks/main.yml
+++ b/roles/ceph-update/tasks/main.yml
@@ -21,7 +21,7 @@
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
 
 - name: restart ceph mons
-  service: name={{ ceph.mon_service[os] }} state=restarted enabled=yes
+  service: name={{ ceph.mon_service[ursula_os] }} state=restarted enabled=yes
   when: "'ceph_monitors' in group_names"
 
 # tasks of ceph osds
@@ -41,7 +41,7 @@
     delegate_to: "{{ groups['ceph_monitors'][0] }}"
 
   - name: restart ceph osds
-    service: name={{ ceph.osd_service[os] }} state=restarted enabled=yes
+    service: name={{ ceph.osd_service[ursula_os] }} state=restarted enabled=yes
 
   # make sure ceph osd services are up before unset noout
   - name: make sure ceph osds are up

--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -2,10 +2,10 @@
 project_name: cinder
 cinder:
   services:
-    cinder_api: "{{ openstack_meta.cinder.services.cinder_api[os] }}"
-    cinder_scheduler: "{{ openstack_meta.cinder.services.cinder_scheduler[os] }}"
-    cinder_volume: "{{ openstack_meta.cinder.services.cinder_volume[os] }}"
-    cinder_backup: "{{ openstack_meta.cinder.services.cinder_backup[os] }}"
+    cinder_api: "{{ openstack_meta.cinder.services.cinder_api[ursula_os] }}"
+    cinder_scheduler: "{{ openstack_meta.cinder.services.cinder_scheduler[ursula_os] }}"
+    cinder_volume: "{{ openstack_meta.cinder.services.cinder_volume[ursula_os] }}"
+    cinder_backup: "{{ openstack_meta.cinder.services.cinder_backup[ursula_os] }}"
   enabled: True
   enabled_backends: [] # determined automatically by Ceph roles
   default_backend:

--- a/roles/cinder-common/handlers/main.yml
+++ b/roles/cinder-common/handlers/main.yml
@@ -30,4 +30,4 @@
 
 # FIXME variablize by OS
 - name: restart tgt service
-  service: name="{{ cinder.tgt_service[os] }}" state=restarted
+  service: name="{{ cinder.tgt_service[ursula_os] }}" state=restarted

--- a/roles/cinder-common/tasks/ceph_integration.yml
+++ b/roles/cinder-common/tasks/ceph_integration.yml
@@ -1,7 +1,7 @@
 ---
 - name: import rados and rbd modules into cinder
   file:
-    src: "{{ ceph.pylib_dir[os] }}{{ item }}"
+    src: "{{ ceph.pylib_dir[ursula_os] }}{{ item }}"
     dest: /opt/openstack/current/cinder/lib/python2.7/site-packages/{{ item }}
     state: link
     owner: root

--- a/roles/cinder-common/tasks/main.yml
+++ b/roles/cinder-common/tasks/main.yml
@@ -80,7 +80,7 @@
     src: "etc/cinder/policy.json"
     dest: "/etc/openstack-dashboard/cinder_policy.json"
     owner: "root"
-    group: "{{ openstack_meta.apache[os].group }}"
+    group: "{{ openstack_meta.apache[ursula_os].group }}"
     mode: 0640
   when: inventory_hostname in groups['controller']
 

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -20,7 +20,7 @@ rootwrap_config=/etc/cinder/rootwrap.conf
 api_paste_config = /etc/cinder/api-paste.ini
 
 {% if not ceph.enabled|bool -%}
-iscsi_helper={{ cinder.iscsi_helper[os] }}
+iscsi_helper={{ cinder.iscsi_helper[ursula_os] }}
 iscsi_ip_address = {{ primary_ip }}
 volume_group = cinder-volumes
 use_forwarded_for = true

--- a/roles/cinder-control/tasks/main.yml
+++ b/roles/cinder-control/tasks/main.yml
@@ -8,7 +8,7 @@
   with_items:
     - "{{ cinder.services.cinder_api }}"
     - "{{ cinder.services.cinder_scheduler }}"
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: install cinder controller services (rhel)
   systemd_service:
@@ -23,7 +23,7 @@
   with_items:
     - "{{ cinder.services.cinder_api }}"
     - "{{ cinder.services.cinder_scheduler }}"
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: sync cinder database
   command: cinder-manage db sync

--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: install cinder-data required packages
   package: name={{ item }}
-  with_items: "{{ cinder.data_pkgs[os] }}"
+  with_items: "{{ cinder.data_pkgs[ursula_os] }}"
   register: result
   until: result|succeeded
   retries: 5
@@ -21,13 +21,13 @@
   notify: restart tgt service
 
 - name: ensure tgt service is running
-  service: name="{{ cinder.tgt_service[os] }}" state=started
+  service: name="{{ cinder.tgt_service[ursula_os] }}" state=started
 
 - include: volume_group.yml
   when: cinder.create_vg|bool and ( cinder.fixed_key is not defined or (cinder.fixed_key is defined and "compute" not in group_names) )
 
 - name: iscsi start
-  service: name="{{ cinder.iscsi_service[os] }}" state=started
+  service: name="{{ cinder.iscsi_service[ursula_os] }}" state=started
 
 - name: enable cinder encryption
   template: src=etc/cinder/cinder.encryption.conf dest=/etc/cinder/cinder.encryption.conf mode=0640
@@ -60,7 +60,7 @@
     when: swift.enabled|default("false")|bool
     with_items:
       - "{{ cinder.services.cinder_backup }}"
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 
 #When OS is Rhel
@@ -92,7 +92,7 @@
     when: swift.enabled|default("false")|bool
     with_items:
       - "{{ cinder.services.cinder_backup }}"
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: trigger restart on upgrades
   debug:

--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -20,7 +20,7 @@
   register: result
   until: result|succeeded
   retries: 5
-  when: os == 'rhel' and openstack_install_method == 'distro'
+  when: ursula_os == 'rhel' and openstack_install_method == 'distro'
 
 - name: install openstack clients
   pip: name={{ item }}
@@ -30,7 +30,7 @@
   register: result
   until: result|succeeded
   retries: 5
-  when: (os == 'ubuntu') or (os == 'rhel' and openstack_install_method == 'source')
+  when: (ursula_os == 'ubuntu') or (ursula_os == 'rhel' and openstack_install_method == 'source')
 
 - name: fix ssl certs for requests for keystone-client on trusty
   file: src=/etc/ssl/certs/ca-certificates.crt

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -4,11 +4,11 @@
 
 - name: refresh CAs
   command: update-ca-certificates
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: refresh rhel CAs
   command: /bin/update-ca-trust extract
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: apply-sysctl
   shell: "cat /etc/sysctl.d/*.conf /etc/sysctl.conf | sysctl -e -p -"
@@ -32,5 +32,5 @@
   register: result
   until: result|succeeded
   retries: 5
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
   

--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -5,23 +5,23 @@ dependencies:
     repos:
       - repo: 'deb {{ apt_repos.bbg_ubuntu.repo }} {{ ansible_lsb.codename }} main'
         key_url: '{{ apt_repos.bbg_ubuntu.key_url }}'
-    when: ansible_architecture != "ppc64le" and os == 'ubuntu'
+    when: ansible_architecture != "ppc64le" and ursula_os == 'ubuntu'
   - role: apt-repos
     repos:
       - repo: 'deb {{ apt_repos.hwraid.repo }} {{ ansible_lsb.codename }} main'
         key_url: '{{ apt_repos.hwraid.key_url }}'
-    when: common.hwraid.enabled|bool and os == 'ubuntu'
+    when: common.hwraid.enabled|bool and ursula_os == 'ubuntu'
   - role: apt-repos
     repos:
       - repo: 'deb {{ apt_repos.sensu.repo }} {{ apt_repos.sensu.distribution }} {{ apt_repos.sensu.components }}'
         key_url: '{{ apt_repos.sensu.key_url }}'
-    when: monitoring.enabled|default(True)|bool and os == 'ubuntu'
+    when: monitoring.enabled|default(True)|bool and ursula_os == 'ubuntu'
   - role: repos
     repo: sensu
-    when: monitoring.enabled|default(True)|bool and os == 'rhel'
+    when: monitoring.enabled|default(True)|bool and ursula_os == 'rhel'
   - role: repos
     repo: epel
-    when: os == 'rhel'
+    when: ursula_os == 'rhel'
   - role: docker
     when: docker.enabled is defined and docker.enabled|bool
   - role: monitoring-common

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -99,11 +99,11 @@
   with_items: "{{ common.os_tuning_params_clean }}"
 
 - include: ufw.yml
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
   tags: firewall
 
 - include: iptables.yml
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
   tags: firewall
 
 - include: ntp.yml
@@ -112,7 +112,7 @@
 # Include serial console before kernel-tuning to build serial_console_cmdline
 - include: serial-console.yml tty={{ common.serial_console.name }}
                               baud_rate={{ common.serial_console.baud_rate }}
-  when: common.serial_console.enabled | bool and os == 'ubuntu'
+  when: common.serial_console.enabled | bool and ursula_os == 'ubuntu'
   tags: ['prereboot']
 
 - include: ipmi.yml
@@ -121,7 +121,7 @@
 
 - include: kernel-tuning.yml
   tags: ['prereboot']
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - include: disable-swap.yml
 
@@ -157,7 +157,7 @@
     src: etc/update-motd.d/90-ursula-motd
     dest: /etc/update-motd.d/90-ursula-motd 
     mode: 0755
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - block:
   - name: drop an motd with ursula metadata for rhel
@@ -171,7 +171,7 @@
       src: etc/profile.d/ursula-motd.sh
       dest: /etc/profile.d/ursula-motd.sh
       mode: 644
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: drop ursula release file
   template:

--- a/roles/common/tasks/monitoring.yml
+++ b/roles/common/tasks/monitoring.yml
@@ -10,14 +10,14 @@
 
 - name: install perl which module - ubuntu
   package: name=libfile-which-perl
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
   register: result
   until: result|succeeded
   retries: 5
 
 - name: install perl which module - ubuntu
   package: name=perl-File-Which
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
   register: result
   until: result|succeeded
   retries: 5
@@ -77,7 +77,7 @@
     group: root
     mode: 0644
   notify: restart sensu-client
-  when: os == "rhel"
+  when: ursula_os == "rhel"
 
 - name: sensu client config
   template: src=monitoring/config.json dest=/etc/sensu/config.json owner=root
@@ -101,7 +101,7 @@
 
 - name: override sensu-client startup
   shell: update-rc.d sensu-client defaults
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: install sensu plugin pip modules
   pip: name=sensu_plugin version=0.1.0

--- a/roles/common/tasks/networking.yml
+++ b/roles/common/tasks/networking.yml
@@ -2,18 +2,18 @@
 - name: Disable NetworkManager
   service: name=NetworkManager state=stopped enabled=no
   failed_when: false
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - block:
   - name: set network config dir path - ubuntu
     set_fact:
       network_dir_path: /etc/network/interfaces.d
-    when: os == 'ubuntu'
+    when: ursula_os == 'ubuntu'
 
   - name: set network dir path - rhel
     set_fact:
       network_dir_path: /etc/sysconfig/network-scripts
-    when: os == 'rhel'
+    when: ursula_os == 'rhel'
   tags: ['prereboot']
 
 - block:
@@ -26,7 +26,7 @@
       group: root
       mode: 0644
     when:
-      - os == 'ubuntu'
+      - ursula_os == 'ubuntu'
 
   - name: create interfaces.d directory if multiple interface files
     file:
@@ -34,7 +34,7 @@
       path: "{{ network_dir_path }}"
       mode: 0755
     when:
-      - os == 'ubuntu'
+      - ursula_os == 'ubuntu'
 
   - name: remove unnecessary network config
     file:
@@ -71,7 +71,7 @@
 
 - include: ucarp.yml
   when:
-    - os == 'rhel'
+    - ursula_os == 'rhel'
     - network.ucarp.config|length > 0
   tags: ['prereboot']
 
@@ -107,7 +107,7 @@
     with_items: "{{ undercloud_cidr }}"
     changed_when: False
     when: ansible_default_ipv4.network  != ( item.cidr | ipaddr('network'))
-  when: os == 'ubuntu' and (update_routes|default('false')|bool)
+  when: ursula_os == 'ubuntu' and (update_routes|default('false')|bool)
 
 - block:
   - name: Check if route configuration exists
@@ -124,7 +124,7 @@
     with_items: "{{ undercloud_cidr }}"
     changed_when: False
     when: ansible_default_ipv4.network  != ( item.cidr | ipaddr('network'))
-  when: os == 'rhel' and (update_routes|default('false')|bool)
+  when: ursula_os == 'rhel' and (update_routes|default('false')|bool)
 
 - name: hosts file
   template: src=etc/hosts dest=/etc/hosts owner=root group=root mode=0644

--- a/roles/common/tasks/ntp.yml
+++ b/roles/common/tasks/ntp.yml
@@ -1,10 +1,10 @@
 ---
 - set_fact:
     ntpd_service_name: ntp
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 - set_fact:
     ntpd_service_name: ntpd
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: install ntp.conf
   template:

--- a/roles/common/tasks/password-policy.yml
+++ b/roles/common/tasks/password-policy.yml
@@ -29,7 +29,7 @@
                 insertafter='^# here are the per-package modules'
                 create=true
     
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - block:
   - name: set password history to last seven
@@ -42,7 +42,7 @@
   - name: set the password policy for centos/rhel
     template: src=etc/security/pwquality.conf dest=/etc/security/pwquality.conf
   
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: set maximum password age
   lineinfile: dest=/etc/login.defs regexp=^PASS_MAX_DAYS

--- a/roles/common/tasks/python.yml
+++ b/roles/common/tasks/python.yml
@@ -30,7 +30,7 @@
 - name: update pip (ubuntu)
   pip: name=pip version={{ common.pip_version }}
        extra_args="-i {{ openstack.pypi_mirror }}"
-  when: ansible_distribution_version != "12.04" and os == "ubuntu"
+  when: ansible_distribution_version != "12.04" and ursula_os == "ubuntu"
   register: result
   until: result|succeeded
   retries: 5

--- a/roles/common/tasks/ssl.yml
+++ b/roles/common/tasks/ssl.yml
@@ -15,7 +15,7 @@
       src: "{{ item.src | default(omit) }}"
     with_items: "{{ ssl.extracacerts | default([]) }}"
     notify: refresh CAs
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - block:
   - name: custom CA cert directory
@@ -34,7 +34,7 @@
       src: "{{ item.src | default(omit) }}"
     with_items: "{{ ssl.extracacerts | default([]) }}"
     notify: refresh rhel CAs
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 # ugly hack: some python http libs don't honor the system ca-certs, and ship with
 # their own list, instead.
@@ -59,8 +59,8 @@
 
 - name: update ca certificates
   command: update-ca-certificates
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: update ca certificates (rhel)
   command: update-ca-trust
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'

--- a/roles/common/tasks/system-tools.yml
+++ b/roles/common/tasks/system-tools.yml
@@ -19,7 +19,7 @@
   package: name={{ item }}
   with_items:
     - ack-grep
-  when: ansible_architecture != "ppc64le" and os == "ubuntu"
+  when: ansible_architecture != "ppc64le" and ursula_os == "ubuntu"
   register: result
   until: result|succeeded
   retries: 5
@@ -27,7 +27,7 @@
 - name: install selinux tooling
   package:
     name: policycoreutils-python
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
   register: result
   until: result|succeeded
   retries: 5
@@ -35,7 +35,7 @@
 - name: load vlan module
   lineinfile: dest=/etc/modules
               line="8021q"
-  when: os == 'ubuntu' and ansible_distribution_version == "14.04"
+  when: ursula_os == 'ubuntu' and ansible_distribution_version == "14.04"
 
 - name: install mcelog package
   package: name=mcelog

--- a/roles/common/templates/etc/sensu/stackrc
+++ b/roles/common/templates/etc/sensu/stackrc
@@ -2,7 +2,7 @@ export OS_PASSWORD={{ monitoring.openstack.user.password }}
 export OS_AUTH_URL={{ endpoints.auth_uri }}
 export OS_USERNAME={{ monitoring.openstack.user.username }}
 export OS_TENANT_NAME={{ monitoring.openstack.user.tenant }}
-{% if client.self_signed_cert and os == 'ubuntu' -%}
+{% if client.self_signed_cert and ursula_os == 'ubuntu' -%}
 export OS_CACERT=/opt/stack/ssl/openstack.crt
 {% else %}
 export OS_CACERT={{ ssl.cafile }}

--- a/roles/common/templates/etc/sshd_config
+++ b/roles/common/templates/etc/sshd_config
@@ -83,7 +83,7 @@ Banner /etc/issue.net
 # Allow client to pass locale environment variables
 AcceptEnv LANG LC_*
 
-{% if os == 'ubuntu' %}
+{% if ursula_os == 'ubuntu' %}
 Subsystem sftp /usr/lib/openssh/sftp-server
 {% else %}
 Subsystem sftp /usr/libexec/openssh/sftp-server

--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -2,8 +2,8 @@
 project_name: glance
 glance:
   services:
-    glance_api: "{{ openstack_meta.glance.services.glance_api[os] }}"
-    glance_registry: "{{ openstack_meta.glance.services.glance_registry[os] }}"
+    glance_api: "{{ openstack_meta.glance.services.glance_api[ursula_os] }}"
+    glance_registry: "{{ openstack_meta.glance.services.glance_registry[ursula_os] }}"
   api_workers: 5
   rbd_store_chunk_size: 8
   registry_workers: 5

--- a/roles/glance/tasks/ceph_integration.yml
+++ b/roles/glance/tasks/ceph_integration.yml
@@ -3,7 +3,7 @@
 # the name may be not rados.so and rbd.so on ubuntu
 - name: import rados module into glance
   file:
-    src: "{{ ceph.pylib_dir[os] }}{{ item }}"
+    src: "{{ ceph.pylib_dir[ursula_os] }}{{ item }}"
     dest: /opt/openstack/current/glance/lib/python2.7/site-packages/{{ item }}
     state: link
     owner: root

--- a/roles/glance/tasks/image-sync.yml
+++ b/roles/glance/tasks/image-sync.yml
@@ -3,16 +3,16 @@
 # set facts to deal with cross platform
 - set_fact:
     rsync_defaults: /etc/sysconfig/rsyncd
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 - set_fact:
     rsync_defaults: /etc/default/rsync
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 - set_fact:
     rsync_service: rsyncd
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 - set_fact:
     rsync_service: rsync
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 
 - name: stop btsync

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -64,7 +64,7 @@
   with_items:
     - "{{ glance.services.glance_api }}"
     - "{{ glance.services.glance_registry }}"
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: install glance services (rhel)
   systemd_service:
@@ -79,7 +79,7 @@
   with_items:
     - "{{ glance.services.glance_api }}"
     - "{{ glance.services.glance_registry }}"
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: glance config
   template: src={{ item }} dest=/etc/glance mode=0640
@@ -93,7 +93,7 @@
     src: "etc/glance/policy.json"
     dest: "/etc/openstack-dashboard/glance_policy.json"
     owner: "root"
-    group: "{{ openstack_meta.apache[os].group }}"
+    group: "{{ openstack_meta.apache[ursula_os].group }}"
     mode: 0640
   when: inventory_hostname in groups['controller']
 

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -19,7 +19,7 @@
 # WORKAROUND: `service haproxy stop` fails due to incorrect `start-stop-daemon --pid`
 - name: fix haproxy init script
   template: src=etc/init.d/haproxy dest=/etc/init.d/haproxy mode=0755
-  when: os == "ubuntu"
+  when: ursula_os == "ubuntu"
 
 - block:
   - name: configure tmpfiles.d for creation of /run/haproxy on reboot
@@ -38,7 +38,7 @@
   - name: set selinux policy for haproxy
     seboolean: name=haproxy_connect_any state=yes persistent=yes
     tags: selinux
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: install ssl cert+key
   template: src=etc/haproxy/openstack.pem dest=/etc/haproxy/openstack.pem

--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -4,9 +4,9 @@ heat:
   enabled: True
   heartbeat_timeout_threshold: 30
   services:
-    heat_api: "{{ openstack_meta.heat.services.heat_api[os] }}"
-    heat_api_cfn: "{{ openstack_meta.heat.services.heat_api_cfn[os] }}"
-    heat_engine: "{{ openstack_meta.heat.services.heat_engine[os] }}"
+    heat_api: "{{ openstack_meta.heat.services.heat_api[ursula_os] }}"
+    heat_api_cfn: "{{ openstack_meta.heat.services.heat_api_cfn[ursula_os] }}"
+    heat_engine: "{{ openstack_meta.heat.services.heat_engine[ursula_os] }}"
   distro:
     project_packages:
       - openstack-heat-api

--- a/roles/heat/tasks/main.yml
+++ b/roles/heat/tasks/main.yml
@@ -22,7 +22,7 @@
     - "{{ heat.services.heat_api }}"
     - "{{ heat.services.heat_api_cfn }}"
     - "{{ heat.services.heat_engine }}"
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: install heat services (rhel)
   systemd_service:
@@ -38,7 +38,7 @@
     - "{{ heat.services.heat_api }}"
     - "{{ heat.services.heat_api_cfn }}"
     - "{{ heat.services.heat_engine }}"
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: heat config
   template: src=etc/heat/{{ item }} dest=/etc/heat/{{ item }} mode=0640 owner=root group=heat
@@ -55,7 +55,7 @@
     src: "etc/heat/policy.json"
     dest: "/etc/openstack-dashboard/heat_policy.json"
     owner: "root"
-    group: "{{ openstack_meta.apache[os].group }}"
+    group: "{{ openstack_meta.apache[ursula_os].group }}"
     mode: 0640
   when: inventory_hostname in groups['controller']
 

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -41,13 +41,13 @@
     dest: "/etc/openstack-dashboard/local_settings.py"
     mode: 0640
     owner: "root"
-    group: "{{ openstack_meta.apache[os].group }}"
+    group: "{{ openstack_meta.apache[ursula_os].group }}"
   notify:
     - reload apache
 
 - name: create static assets directory (source)
   file: dest="{{ horizon.horizon_lib_dir }}/lib/python2.7/site-packages/openstack_dashboard/{{ item }}"
-        owner="{{ openstack_meta.apache[os].user }}" group="{{ openstack_meta.apache[os].group }}" state=directory
+        owner="{{ openstack_meta.apache[ursula_os].user }}" group="{{ openstack_meta.apache[ursula_os].group }}" state=directory
   with_items:
     - static
     - static/dashboard
@@ -104,7 +104,7 @@
       path: "{{ horizon.horizon_lib_dir }}/lib/python2.7/site-packages/openstack_dashboard/local/enabled/_1481_project_ng_loadbalancersv2_panel.py"
       state: "{{ (neutron.lbaas.enabled | bool) | ternary('link', 'absent') }}"
     notify: reload apache
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 # RHEL OSP horizon config
 - block:
@@ -119,7 +119,7 @@
     command: mv /etc/openstack-dashboard/local_settings.d/_11_rcue_theme.py /etc/openstack-dashboard/local_settings.d/_11_rcue_theme.disabled
     when:
       - horizon.customize|default('False')|bool
-      - os == 'rhel'
+      - ursula_os == 'rhel'
       - rcue.stat.exists == True
     notify: restart apache
 
@@ -129,13 +129,13 @@
     register: rcued
     when:
       - not horizon.customize|default('False')|bool
-      - os == 'rhel'
+      - ursula_os == 'rhel'
 
   - name: Enable OSP custom dashboard (rhel osp)
     command: mv /etc/openstack-dashboard/local_settings.d/_11_rcue_theme.disabled /etc/openstack-dashboard/local_settings.d/_11_rcue_theme.py
     when:
       - not horizon.customize|default('False')|bool
-      - os == 'rhel'
+      - ursula_os == 'rhel'
       - rcued.stat.exists == True
     notify: restart apache
 
@@ -149,7 +149,7 @@
     file: src=/etc/openstack-dashboard/local_settings.py
           dest=/usr/share/openstack-dashboard/openstack_dashboard/local/local_settings.py
           owner=root
-          group="{{ openstack_meta.apache[os].user }}"
+          group="{{ openstack_meta.apache[ursula_os].user }}"
           mode=0644
           state=link
   when: openstack_install_method == 'distro'
@@ -158,7 +158,7 @@
   template: src=etc/apache2/sites-available/openstack_dashboard.conf
             dest=/etc/httpd/conf.d/openstack_dashboard.conf
   when:
-    - os == 'rhel'
+    - ursula_os == 'rhel'
     - openstack_install_method == 'source'
   notify:
     - reload apache
@@ -169,7 +169,7 @@
     file: src=/etc/openstack-dashboard/local_settings.py
           dest=/opt/openstack/current/horizon/lib/python2.7/site-packages/openstack_dashboard/local/local_settings.py
           owner=root
-          group="{{ openstack_meta.apache[os].user }}"
+          group="{{ openstack_meta.apache[ursula_os].user }}"
           mode=0644
           state=link
 
@@ -201,13 +201,13 @@
 - meta: flush_handlers
 
 - name: ensure apache started
-  service: name="{{ apache.service_name[os] }}" state=started
-  when: os == 'ubuntu'
+  service: name="{{ apache.service_name[ursula_os] }}" state=started
+  when: ursula_os == 'ubuntu'
 
 - meta: flush_handlers
 
 - name: ensure apache is enabled
-  service: name="{{ apache.service_name[os] }}" state=started enabled=true
+  service: name="{{ apache.service_name[ursula_os] }}" state=started enabled=true
 
 - include: monitoring.yml
   tags:

--- a/roles/horizon/tasks/monitoring.yml
+++ b/roles/horizon/tasks/monitoring.yml
@@ -1,7 +1,7 @@
 ---
 - name: apache2 process check
   sensu_process_check: 
-    service: "{{ ( os == 'ubuntu' )| ternary('apache2', 'httpd') }}"
+    service: "{{ ( ursula_os == 'ubuntu' )| ternary('apache2', 'httpd') }}"
   notify: restart sensu-client
 
 - name: dashboard port check

--- a/roles/inspec/meta/main.yml
+++ b/roles/inspec/meta/main.yml
@@ -4,7 +4,7 @@ dependencies:
     repos:
       - repo: 'deb {{ apt_repos.chef.repo }} trusty main'
         key_url: '{{ apt_repos.chef.key_url }}'
-    when: os == 'ubuntu'
+    when: ursula_os == 'ubuntu'
   - role: repos
     repo: chef
-    when: os == 'rhel'
+    when: ursula_os == 'rhel'

--- a/roles/inspec/tasks/main.yml
+++ b/roles/inspec/tasks/main.yml
@@ -72,7 +72,7 @@
     src: etc/inspec/host-controls/controls/rhel7-stigs.rb
     dest: /etc/inspec/host-controls/controls/
     mode: 0644
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: remove inspec lock file so we can upgrade
   file:

--- a/roles/keystone-setup/handlers/main.yml
+++ b/roles/keystone-setup/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: restart keystone services
   service:
-    name: "{{ openstack_meta.keystone.services.keystone_api[os].name }}"
+    name: "{{ openstack_meta.keystone.services.keystone_api[ursula_os].name }}"
     state: restarted
     must_exist: false
   when: restart|default('True')

--- a/roles/keystone/handlers/main.yml
+++ b/roles/keystone/handlers/main.yml
@@ -2,7 +2,7 @@
 # Restart serially as to not take keystone completely offline
 - name: restart keystone services
   service:
-    name: "{{ openstack_meta.keystone.services.keystone_api[os].name }}"
+    name: "{{ openstack_meta.keystone.services.keystone_api[ursula_os].name }}"
     state: restarted
     must_exist: false
   run_once: True

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -38,7 +38,7 @@
 - name: set uwsgi path (package install ubuntu)
   set_fact:
     uwsgi_path: "{{ openstack_package.virtualenv_base }}/keystone/bin/uwsgi"
-  when: openstack_install_method == 'package' and os == 'ubuntu'
+  when: openstack_install_method == 'package' and ursula_os == 'ubuntu'
 
 - name: set uwsgi path (package install rhel)
   set_fact:
@@ -48,7 +48,7 @@
 - name: install keystone uwsgi service (ubuntu)
   template: src=etc/init/keystone.conf
             dest=/etc/init/keystone.conf mode=0644
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - block:
   - name: install keystone uwsgi service (rhel)
@@ -63,14 +63,14 @@
       restart: "{{ item.restart }}"
       kill_signal: "SIGQUIT"
     with_items:
-      - "{{ openstack_meta.keystone.services.keystone_api[os] }}"
+      - "{{ openstack_meta.keystone.services.keystone_api[ursula_os] }}"
 
   - name: Configure tmpfiles.d for creation of /run/uwsgi on reboot
     template:
       src: usr/lib/tmpfiles.d/openstack-keystone.conf
       dest: /usr/lib/tmpfiles.d/openstack-keystone.conf
       mode: 0644
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: Creates keystone uwsgi and httpd directories
   file: path={{ item }} state=directory
@@ -109,7 +109,7 @@
 - name: keystone apache vhost (ubuntu)
   template: src=etc/apache2/sites-available/keystone.conf
             dest=/etc/apache2/sites-available/keystone.conf
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
   notify:
     - reload apache
   tags: keystone-federation
@@ -117,7 +117,7 @@
 - name: keystone apache vhost (rhel)
   template: src=etc/apache2/sites-available/keystone.conf
             dest=/etc/httpd/conf.d/keystone.conf
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
   notify:
     - reload apache
   tags: keystone-federation
@@ -145,7 +145,7 @@
     dest: "/etc/openstack-dashboard/keystone_policy.json"
     mode: 0640
     owner: "root"
-    group: "{{ openstack_meta.apache[os].group }}"
+    group: "{{ openstack_meta.apache[ursula_os].group }}"
 
 - include: k2k-idp.yml
   when: keystone.federation.enabled|bool and keystone.federation.idp.k2k.enabled|bool
@@ -171,7 +171,7 @@
   apache2_site: name=keystone state=present
   notify:
     - reload apache
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - include: ldap.yml
   when: keystone.ldap_domain.enabled|default('False')|bool
@@ -180,7 +180,7 @@
 
 - name: start keystone
   service:
-    name: "{{ openstack_meta.keystone.services.keystone_api[os].name }}"
+    name: "{{ openstack_meta.keystone.services.keystone_api[ursula_os].name }}"
     state: started
     enabled: true
 

--- a/roles/keystone/templates/etc/apache2/sites-available/keystone.conf
+++ b/roles/keystone/templates/etc/apache2/sites-available/keystone.conf
@@ -122,7 +122,7 @@ ServerName https://{{ fqdn }}
         SetEnv proxy-nokeepalive 1
 {% endif %}
     </Location>
-    ErrorLog {{ apache_log_path[os] }}/error.log
+    ErrorLog {{ apache_log_path[ursula_os] }}/error.log
     LogLevel error
 </VirtualHost>
 
@@ -147,7 +147,7 @@ ServerName https://{{ fqdn }}
     {{ setup_shibboleth() }}
 {% endif -%}
 
-    ErrorLog {{ apache_log_path[os] }}/error.log
+    ErrorLog {{ apache_log_path[ursula_os] }}/error.log
     LogLevel error
 
 </VirtualHost>

--- a/roles/keystone/templates/etc/cron.d/drop-expired-keystone-tokens
+++ b/roles/keystone/templates/etc/cron.d/drop-expired-keystone-tokens
@@ -1,4 +1,4 @@
-PATH=/sbin:/usr/sbin:{{ (os == 'rhel' ) | ternary('/usr/bin/', '/usr/local/bin/') }}
+PATH=/sbin:/usr/sbin:{{ (ursula_os == 'rhel' ) | ternary('/usr/bin/', '/usr/local/bin/') }}
 
 
 # Drop the tokens every 5 minutes

--- a/roles/logging/defaults/main.yml
+++ b/roles/logging/defaults/main.yml
@@ -13,7 +13,7 @@ logging:
       cluster_name: "unknown"
     logs:
       - paths:
-          - "{{ ( os == 'ubuntu' )| ternary('/var/log/syslog', '/var/log/messages') }}"
+          - "{{ ( ursula_os == 'ubuntu' )| ternary('/var/log/syslog', '/var/log/messages') }}"
         fields:
           type: syslog
   syslog_forwarding:

--- a/roles/logging/handlers/main.yml
+++ b/roles/logging/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: refresh cert auths
   command: update-ca-certificates
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: restart logstash-forwarder
   service: name=logstash-forwarder state=restarted must_exist=false

--- a/roles/logging/meta/main.yml
+++ b/roles/logging/meta/main.yml
@@ -4,8 +4,8 @@ dependencies:
     repos:
       - repo: 'deb {{ apt_repos.elastic.repo }} stable main'
         key_url: '{{ apt_repos.elastic.key_url }}'
-    when: os == 'ubuntu'
+    when: ursula_os == 'ubuntu'
   - role: sensu-check
   - role: repos
     repo: elastic
-    when: os == 'rhel'
+    when: ursula_os == 'rhel'

--- a/roles/logging/tasks/filebeat.yml
+++ b/roles/logging/tasks/filebeat.yml
@@ -7,7 +7,7 @@
   retries: 3
   delay: 10
   notify: restart filebeat
-  when: os == "ubuntu"
+  when: ursula_os == "ubuntu"
 
 - name: install filebeat yum
   yum:
@@ -17,7 +17,7 @@
   retries: 3
   delay: 10
   notify: restart filebeat
-  when: os == "rhel"
+  when: ursula_os == "rhel"
 
 - name: filebeat config directory
   file:

--- a/roles/logging/tasks/logstash.yml
+++ b/roles/logging/tasks/logstash.yml
@@ -17,7 +17,7 @@
 - name: download logstash apt
   get_url: url={{ logging.download.ubuntu.url }}
            dest=/tmp/logstash-forwarder_{{ logging.version }}_amd64.deb
-  when: os == 'ubuntu' and logging.install_method == 'file'
+  when: ursula_os == 'ubuntu' and logging.install_method == 'file'
   register: result
   until: result|succeeded
   retries: 5
@@ -25,36 +25,36 @@
 - name: download logstash yum
   get_url: url={{ logging.download.rhel.url }}
            dest=/tmp/logstash-forwarder_{{ logging.version }}.rpm
-  when: os == 'rhel' and logging.install_method == 'file'
+  when: ursula_os == 'rhel' and logging.install_method == 'file'
   register: result
   until: result|succeeded
   retries: 5
 
 - name: install logstash apt
   apt: deb=/tmp/logstash-forwarder_{{ logging.version }}_amd64.deb
-  when: os == 'ubuntu' and logging.install_method == 'file'
+  when: ursula_os == 'ubuntu' and logging.install_method == 'file'
   register: install_lsf
   until: install_lsf|succeeded
   retries: 5
 
 - name: install logstash yum
   yum: name=/tmp/logstash-forwarder_{{ logging.version }}.rpm
-  when: os == 'rhel' and logging.install_method == 'file'
+  when: ursula_os == 'rhel' and logging.install_method == 'file'
   register: install_lsf
   until: install_lsf|succeeded
   retries: 5
 
 - name: stop logstash-forwarder service
   service: name=logstash-forwarder state=stopped enabled=yes must_exist=false
-  when: os == 'ubuntu' and install_lsf|changed
+  when: ursula_os == 'ubuntu' and install_lsf|changed
 
 - name: install logstash-forwarder service
   template: src=etc/init/logstash-forwarder.conf dest=/etc/init/logstash-forwarder.conf mode=0644
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: remove logstash-forwarder init.d
   file: dest=/etc/init.d/logstash-forwarder state=absent
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: custom cert auth directory
   file: dest=/usr/local/share/ca-certificates state=directory mode=0755

--- a/roles/memcached/tasks/main.yml
+++ b/roles/memcached/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: install memcached packages
   package:
     name=libsasl2-dev
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
   register: result
   until: result|succeeded
   retries: 5
@@ -16,7 +16,7 @@
 - name: install memcached packages
   package:
     name=cyrus-sasl-devel
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
   register: result
   until: result|succeeded
   retries: 5
@@ -25,7 +25,7 @@
 - name: install memcached packages
   package:
     name=python-memcache
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
   register: result
   until: result|succeeded
   retries: 5
@@ -33,7 +33,7 @@
 - name: install memcached packages
   package:
     name=python-memcached
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
   register: result
   until: result|succeeded
   retries: 5

--- a/roles/mongodb-common/tasks/main.yml
+++ b/roles/mongodb-common/tasks/main.yml
@@ -7,7 +7,7 @@
   register: result
   until: result|succeeded
   retries: 5
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: install mongodb packages (centos)
   yum: pkg={{ item }} state=installed
@@ -18,7 +18,7 @@
   until: result|succeeded
   retries: 5
   when:
-    - os == 'rhel'
+    - ursula_os == 'rhel'
     - openstack_install_method == 'source'
 
 - name: install mongodb packages (rhel osp)
@@ -30,7 +30,7 @@
   until: result|succeeded
   retries: 5
   when:
-    - os == 'rhel'
+    - ursula_os == 'rhel'
     - openstack_install_method == 'distro'
 
 - name: install mongodb config files

--- a/roles/mongodb-common/templates/etc/mongodb/mongod.conf
+++ b/roles/mongodb-common/templates/etc/mongodb/mongod.conf
@@ -10,7 +10,7 @@ dbpath=/var/lib/mongodb
 logpath=/var/log/mongodb/mongod.log
 logappend=true
 
-{% if os == 'ubuntu' -%}
+{% if ursula_os == 'ubuntu' -%}
 pidfilepath = /var/run/mongodb.pid
 fork = false
 {% else -%}
@@ -29,7 +29,7 @@ port = {{ mongodb.port }}
   nojournal = false
 {% endif -%}
 
-{% if os == 'ubuntu' -%}
+{% if ursula_os == 'ubuntu' -%}
 smallfiles = true
 {% endif -%}
 

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -2,13 +2,13 @@
 project_name: neutron
 neutron:
   services:
-    neutron_server: "{{ openstack_meta.neutron.services.neutron_server[os] }}"
-    neutron_dhcp_agent: "{{ openstack_meta.neutron.services.neutron_dhcp_agent[os] }}"
-    neutron_l3_agent: "{{ openstack_meta.neutron.services.neutron_l3_agent[os] }}"
-    neutron_openvswitch_agent: "{{ openstack_meta.neutron.services.neutron_openvswitch_agent[os] }}"
-    neutron_linuxbridge_agent: "{{ openstack_meta.neutron.services.neutron_linuxbridge_agent[os] }}"
-    neutron_metadata_agent: "{{ openstack_meta.neutron.services.neutron_metadata_agent[os] }}"
-    neutron_lbaasv2_agent: "{{ openstack_meta.neutron.services.neutron_lbaasv2_agent[os] }}"
+    neutron_server: "{{ openstack_meta.neutron.services.neutron_server[ursula_os] }}"
+    neutron_dhcp_agent: "{{ openstack_meta.neutron.services.neutron_dhcp_agent[ursula_os] }}"
+    neutron_l3_agent: "{{ openstack_meta.neutron.services.neutron_l3_agent[ursula_os] }}"
+    neutron_openvswitch_agent: "{{ openstack_meta.neutron.services.neutron_openvswitch_agent[ursula_os] }}"
+    neutron_linuxbridge_agent: "{{ openstack_meta.neutron.services.neutron_linuxbridge_agent[ursula_os] }}"
+    neutron_metadata_agent: "{{ openstack_meta.neutron.services.neutron_metadata_agent[ursula_os] }}"
+    neutron_lbaasv2_agent: "{{ openstack_meta.neutron.services.neutron_lbaasv2_agent[ursula_os] }}"
   jellyroll: False
   enable_fatal_deprecations: True
   l2_population: False

--- a/roles/neutron-common/tasks/main.yml
+++ b/roles/neutron-common/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: install common neutron packages
   package: name=vlan
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
   register: result
   until: result|succeeded
   retries: 5
@@ -91,7 +91,7 @@
     src: "etc/neutron/policy.json"
     dest: "/etc/openstack-dashboard/neutron_policy.json"
     owner: "root"
-    group: "{{ openstack_meta.apache[os].group }}"
+    group: "{{ openstack_meta.apache[ursula_os].group }}"
     mode: 0640
   when: inventory_hostname in groups['controller']
 

--- a/roles/neutron-control/tasks/main.yml
+++ b/roles/neutron-control/tasks/main.yml
@@ -13,7 +13,7 @@
       envs: "{{ neutron.service.envs }}"
     with_items:
       - "{{ neutron.services.neutron_server }}"
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - block:
   - name: install neutron-server service (rhel)
@@ -31,7 +31,7 @@
       kill_mode: "{{ item.kill_mode }}"
     with_items:
       - "{{ neutron.services.neutron_server }}"
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: stop neutron service before db sync
   service:

--- a/roles/neutron-data-network/tasks/dnsmasq.yml
+++ b/roles/neutron-data-network/tasks/dnsmasq.yml
@@ -6,7 +6,7 @@
 
   - name: delete localhost dnsmask nameserver
     command: resolvconf -d lo.dnsmasq
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: neutron dnsmasq config
   template: src=etc/dnsmasq.conf dest=/etc/dnsmasq.conf mode=0644

--- a/roles/neutron-data-network/tasks/ipchanged.yml
+++ b/roles/neutron-data-network/tasks/ipchanged.yml
@@ -11,7 +11,7 @@
 
 - name: install ipchanged configuraion
   template: src=etc/init/ipchanged.conf dest=/etc/init/ipchanged.conf mode=0644
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: ipchanged systemd service
   systemd_service:
@@ -19,7 +19,7 @@
     type: simple
     cmd: /usr/local/sbin/ipchanged
     wanted_by: multi-user.target
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: ipchanged dirs - undercloud
   file: dest=/etc/ipchanged/{{ item }} state=directory

--- a/roles/neutron-data-network/tasks/main.yml
+++ b/roles/neutron-data-network/tasks/main.yml
@@ -26,7 +26,7 @@
 - include: dnsmasq.yml
 
 - include: igmp-router.yml
-  when: os == 'ubuntu' and (
+  when: ursula_os == 'ubuntu' and (
         neutron.plugin == 'ml2' and
         'vxlan' in neutron.tunnel_types
         and not neutron.l2_population )
@@ -76,7 +76,7 @@
            neutron.lbaas.enabled|bool)
     with_items:
       - "{{ neutron.services.neutron_lbaasv2_agent }}"
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - block:
   - name: install neutron-data-network services (rhel)
@@ -115,7 +115,7 @@
            neutron.lbaas.enabled|bool)
     with_items:
       - "{{ neutron.services.neutron_lbaasv2_agent }}"
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: create lbaas templates folder
   file:

--- a/roles/neutron-data-network/tasks/monitoring.yml
+++ b/roles/neutron-data-network/tasks/monitoring.yml
@@ -20,7 +20,7 @@
 - name: ucarp failover alert
   sensu_check: name=check-ucarp-failover plugin=check-log.rb use_sudo=true
                auto_resolve=false interval=20 occurrences=1
-               args="-f {{ ( os == 'ubuntu' )| ternary('/var/log/syslog', '/var/log/messages') }} -q 'ucarp.+[Ss]witching to state' --silent"
+               args="-f {{ ( ursula_os == 'ubuntu' )| ternary('/var/log/syslog', '/var/log/messages') }} -q 'ucarp.+[Ss]witching to state' --silent"
   notify: restart sensu-client
 
 - name: ucarp processes check

--- a/roles/neutron-data-network/templates/etc/neutron/services/loadbalancer/haproxy/lbaas_agent.ini
+++ b/roles/neutron-data-network/templates/etc/neutron/services/loadbalancer/haproxy/lbaas_agent.ini
@@ -1,7 +1,7 @@
 [DEFAULT]
 interface_driver = {{ neutron.lbaas.interface_driver }}
 
-{% if os == 'rhel' %}
+{% if ursula_os == 'rhel' %}
 user_group = nobody
 {% endif %}
 

--- a/roles/neutron-data/tasks/main.yml
+++ b/roles/neutron-data/tasks/main.yml
@@ -27,7 +27,7 @@
     with_items:
       - "{{ neutron.services.neutron_linuxbridge_agent }}"
     when: neutron.plugin == 'ml2'
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: install neutron-linuxbridge-agent service (rhel package)
   systemd_service:
@@ -46,7 +46,7 @@
   with_items:
     - "{{ neutron.services.neutron_linuxbridge_agent }}"
   when:
-    - os == 'rhel'
+    - ursula_os == 'rhel'
     - neutron.plugin == 'ml2'
 
 - name: ml2 dataplane config
@@ -78,7 +78,7 @@
   template: src=etc/cron.daily/cleanup-neutron-interfaces
             dest=/etc/cron.daily/cleanup-neutron-interfaces
             mode=0755 owner=root
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - include: monitoring.yml
   tags:

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -2,15 +2,15 @@
 project_name: nova
 nova:
   services:
-    nova_api: "{{ openstack_meta.nova.services.nova_api[os] }}"
-    nova_conductor: "{{ openstack_meta.nova.services.nova_conductor[os] }}"
-    nova_compute: "{{ openstack_meta.nova.services.nova_compute[os] }}"
-    nova_consoleauth: "{{ openstack_meta.nova.services.nova_consoleauth[os] }}"
-    nova_novncproxy: "{{ openstack_meta.nova.services.nova_novncproxy[os] }}"
-    nova_scheduler: "{{ openstack_meta.nova.services.nova_scheduler[os] }}"
-    nova_cert: "{{ openstack_meta.nova.services.nova_cert[os] }}"
-    nova_cells: "{{ openstack_meta.nova.services.nova_cells[os] }}"
-    libvirt: "{{ openstack_meta.nova.services.libvirt[os] }}"
+    nova_api: "{{ openstack_meta.nova.services.nova_api[ursula_os] }}"
+    nova_conductor: "{{ openstack_meta.nova.services.nova_conductor[ursula_os] }}"
+    nova_compute: "{{ openstack_meta.nova.services.nova_compute[ursula_os] }}"
+    nova_consoleauth: "{{ openstack_meta.nova.services.nova_consoleauth[ursula_os] }}"
+    nova_novncproxy: "{{ openstack_meta.nova.services.nova_novncproxy[ursula_os] }}"
+    nova_scheduler: "{{ openstack_meta.nova.services.nova_scheduler[ursula_os] }}"
+    nova_cert: "{{ openstack_meta.nova.services.nova_cert[ursula_os] }}"
+    nova_cells: "{{ openstack_meta.nova.services.nova_cells[ursula_os] }}"
+    libvirt: "{{ openstack_meta.nova.services.libvirt[ursula_os] }}"
   libvirt:
     ubuntu:
       config_file: libvirtd.conf
@@ -47,7 +47,7 @@ nova:
   python_libvirt_version: 1.3.1-1ubuntu1~cloud0
   qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.30
   # librdb1 version should match the ceph client version
-  librdb1_version: "{{ ceph.client_version[os] }}"
+  librdb1_version: "{{ ceph.client_version[ursula_os] }}"
   qemu_system_package: qemu-system-x86
   glance_endpoint: http://{{ endpoints.main }}:9393
   reserved_host_disk_mb: 51200

--- a/roles/nova-common/meta/main.yml
+++ b/roles/nova-common/meta/main.yml
@@ -8,7 +8,7 @@ dependencies:
     repos:
       - repo: 'deb {{ apt_repos.cloud_archive.repo }} {{ ansible_distribution_release }}-updates/mitaka main'
         key_package: ubuntu-cloud-keyring
-    when: os == 'ubuntu'
+    when: ursula_os == 'ubuntu'
   - role: sensu-check
   - role: monitoring-common
     when: monitoring.enabled|default(True)|bool

--- a/roles/nova-common/tasks/main.yml
+++ b/roles/nova-common/tasks/main.yml
@@ -8,7 +8,7 @@
   command: mv /etc/httpd/conf.d/00-nova-placement-api.conf /etc/httpd/conf.d/00-nova-placement-api.disabled
   when:
     - np.stat.exists == True
-    - os == 'rhel'
+    - ursula_os == 'rhel'
     - openstack_install_method == 'distro'
 
 - name: nova user
@@ -78,7 +78,7 @@
     src: "etc/nova/policy.json"
     dest: "/etc/openstack-dashboard/nova_policy.json"
     owner: "root"
-    group: "{{ openstack_meta.apache[os].group }}"
+    group: "{{ openstack_meta.apache[ursula_os].group }}"
     mode: 0640
   when: inventory_hostname in groups['controller']
 

--- a/roles/nova-control/tasks/main.yml
+++ b/roles/nova-control/tasks/main.yml
@@ -26,7 +26,7 @@
       - "{{ nova.services.nova_consoleauth }}"
       - "{{ nova.services.nova_scheduler }}"
       - "{{ nova.services.nova_novncproxy }}"
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - block:
   - name: remove retired nova controller services
@@ -55,7 +55,7 @@
       - "{{ nova.services.nova_consoleauth }}"
       - "{{ nova.services.nova_scheduler }}"
       - "{{ nova.services.nova_novncproxy }}"
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 #FIXME do we need this on rhosp?
 - name: install nova-quota-sync script

--- a/roles/nova-data/tasks/libvirt.yml
+++ b/roles/nova-data/tasks/libvirt.yml
@@ -21,7 +21,7 @@
     - genisoimage
     - util-linux
   notify: restart nova services
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
   register: result
   until: result|succeeded
   retries: 5
@@ -45,7 +45,7 @@
   notify:
     - restart nova services
     - restart libvirt-bin
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
   register: result
   until: result|succeeded
   retries: 5
@@ -61,7 +61,7 @@
   register: lvpout
   changed_when: lvpout.stdout|search("Successfully installed")
   notify: restart nova services
-  when: openstack_install_method == 'package' and os == 'ubuntu'
+  when: openstack_install_method == 'package' and ursula_os == 'ubuntu'
 
 - name: install libvirt-python in source venv
   command: "{{ openstack_source.virtualenv_base }}/nova/bin/pip install libvirt-python"
@@ -72,7 +72,7 @@
 
 - name: delete lines in libvirtd.conf
   lineinfile:
-    dest: "/etc/libvirt/{{ nova.libvirt[os].config_file }}"
+    dest: "/etc/libvirt/{{ nova.libvirt[ursula_os].config_file }}"
     regexp: "{{ item.value.regexp }}"
     line: "{{ item.value.line }}"
     state: absent
@@ -87,7 +87,7 @@
 
 - name: add/update various lines in libvirtd.conf
   lineinfile:
-    dest: "/etc/libvirt/{{ nova.libvirt[os].config_file }}"
+    dest: "/etc/libvirt/{{ nova.libvirt[ursula_os].config_file }}"
     regexp: "{{ item.value.regexp }}"
     line: "{{ item.value.line }}"
   with_dict:
@@ -98,7 +98,7 @@
 
 - name: remove libvirtd defaults
   lineinfile:
-    dest: "{{ nova.libvirt[os].defaults }}"
+    dest: "{{ nova.libvirt[ursula_os].defaults }}"
     regexp: '^libvirtd_opts\s*='
     line: 'libvirtd_opts=\"-d -l\"'
     state: absent
@@ -115,14 +115,14 @@
   command: kvm-ok
   when:
     - nova.libvirt_type == 'kvm'
-    - os == 'ubuntu'
+    - ursula_os == 'ubuntu'
   changed_when: False
 
 - name: ensure kvm is supported by cpu and enabled in bios (rhel)
   command: egrep '(vmx|svm)' /proc/cpuinfo
   when:
     - nova.libvirt_type == 'kvm'
-    - os == 'rhel'
+    - ursula_os == 'rhel'
   changed_when: False
 
 - name: generate really unique uuid
@@ -159,5 +159,5 @@
 - name: disable libvirt default network autostart
   file: dest=/etc/libvirt/qemu/networks/autostart/default.xml state=absent
 
-- name: add nova to the {{ nova.libvirt[os].group }} group
-  user: name=nova groups={{ nova.libvirt[os].group }} append=true system=yes createhome=no
+- name: add nova to the {{ nova.libvirt[ursula_os].group }} group
+  user: name=nova groups={{ nova.libvirt[ursula_os].group }} append=true system=yes createhome=no

--- a/roles/nova-data/tasks/main.yml
+++ b/roles/nova-data/tasks/main.yml
@@ -25,7 +25,7 @@
     dest: "{{ nova.state_path }}"
     state: directory
     owner: nova
-    group: "{{ (os == 'rhel' ) | ternary('qemu', 'nova') }}"
+    group: "{{ (ursula_os == 'rhel' ) | ternary('qemu', 'nova') }}"
     mode: 0755
 
 - name: nova instances directory
@@ -33,23 +33,23 @@
     dest: "{{ nova.state_path }}/instances"
     state: directory
     owner: nova
-    group: "{{ (os == 'rhel' ) | ternary('qemu', 'nova') }}"
+    group: "{{ (ursula_os == 'rhel' ) | ternary('qemu', 'nova') }}"
     mode: 0755
 
 - block:
   - name: nbd module - ubuntu
     lineinfile: dest=/etc/modules line="nbd"
-    when: os == 'ubuntu'
+    when: ursula_os == 'ubuntu'
 
   - name: probe nbd - ubuntu
     modprobe: name=nbd state=present
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 #FIXME do we need this on rhosp?
 - name: install nbd package - rhel
   package:
     name: nbd
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - block:
   - name: check if SMT is enabled
@@ -85,7 +85,7 @@
     config_dirs: "{{ item.config_dirs }}"
   with_items:
     - "{{ nova.services.nova_compute }}"
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: install nova-compute service (rhel)
   systemd_service:
@@ -102,7 +102,7 @@
     restart: "{{ item.restart }}"
   with_items:
     - "{{ nova.services.nova_compute }}"
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: trigger restart on upgrades
   debug:

--- a/roles/nova-data/tasks/ssh.yml
+++ b/roles/nova-data/tasks/ssh.yml
@@ -67,4 +67,4 @@
   command: "{{ nova.state_path }}/bin/verify-ssh"
   become: yes
   become_user: nova
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'

--- a/roles/openstack-firewall/tasks/main.yml
+++ b/roles/openstack-firewall/tasks/main.yml
@@ -4,7 +4,7 @@
     ufw: rule=allow to_port={{ item.port }} proto={{ item.protocol }}
     with_items: "{{ rules_type_input | default([]) }}"
     tags: firewall
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - block:
   - name: Persist Permit access to {{ rule_name }}
@@ -34,4 +34,4 @@
       - "{{ rules_type_input | default([]) }}"
       - "{{ iptables_changed.results }}"
     tags: firewall
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'

--- a/roles/openstack-network/tasks/main.yml
+++ b/roles/openstack-network/tasks/main.yml
@@ -27,7 +27,7 @@
               owner=root group=root mode=0644
     when: not neutron_external_ifcfg.stat.exists
     notify: ifup neutron external interface
-  when: os == 'ubuntu' and result.id is defined
+  when: ursula_os == 'ubuntu' and result.id is defined
 
 - block:
   - name: set neutron interface fact
@@ -47,4 +47,4 @@
       - enable ip forwarding
       - enable ipv4 masquerade
       - persist enable ipv4 masquerade
-  when: os == 'rhel' and result.id is defined
+  when: ursula_os == 'rhel' and result.id is defined

--- a/roles/openstack-package/meta/main.yml
+++ b/roles/openstack-package/meta/main.yml
@@ -4,4 +4,4 @@ dependencies:
     repos:
       - repo: 'deb {{ apt_repos.blueboxcloud_giftwrap.repo }} {{ ansible_distribution_release }} main'
         key_url: '{{ apt_repos.blueboxcloud_giftwrap.key_url }}'
-    when: os == 'ubuntu'
+    when: ursula_os == 'ubuntu'

--- a/roles/openstack-source/tasks/main.yml
+++ b/roles/openstack-source/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: install project system dependencies
   package: name={{ item }}
-  with_items: "{{ openstack_source.system_dependencies[os] }}"
+  with_items: "{{ openstack_source.system_dependencies[ursula_os] }}"
   register: result
   until: result|succeeded
   retries: 5

--- a/roles/percona-arbiter/tasks/main.yml
+++ b/roles/percona-arbiter/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: try to stop old garbd service
   service: name="{{ garbd_service }}" state=stopped enabled=false pattern=/usr/bin/garbd
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
   failed_when: False
 
 - name: try to stop old garbd service
   service: name="{{ garbd_service }}" state=stopped enabled=false
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
   failed_when: False
 
 - name: make garbd log
@@ -21,30 +21,30 @@
 # the arbiter node only needs the garbd daemon
 - name: install percona garbd package
   package: pkg=percona-xtradb-cluster-garbd-3.x state=installed
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
   register: result
   until: result|succeeded
   retries: 5
 
 - name: install percona garbd package
   package: pkg=Percona-XtraDB-Cluster-garbd-3 state=installed
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
   register: result
   until: result|succeeded
   retries: 5
 
 - name: install garbd config
   template: src=etc/default/garbd dest=/etc/default/garbd mode=0644
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: install garbd config
   template: src=etc/default/garbd dest=/etc/sysconfig/garb mode=0644
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: ensure garbd running
   service: name="{{ garbd_service }}" state=started enabled=yes pattern=/usr/bin/garbd
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: ensure garbd running
   service: name="{{ garbd_service }}" state=started enabled=yes
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'

--- a/roles/percona-common/tasks/main.yml
+++ b/roles/percona-common/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - set_fact:
     garbd_service: garbd
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 - set_fact:
     garbd_service: garb
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 
 - name: create mysql user
@@ -28,4 +28,4 @@
   selinux_permissive:
     name: mysqld_t
     permissive: true
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'

--- a/roles/percona-server/tasks/main.yml
+++ b/roles/percona-server/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 - name: python-mysqldb package
   apt: pkg=python-mysqldb
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
   register: result
   until: result|succeeded
   retries: 5
 
 - name: python-mysqldb package
   package: name=MySQL-python
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
   register: result
   until: result|succeeded
   retries: 5
@@ -23,15 +23,15 @@
 
 - name: configure my.cnf
   template: src=etc/my.cnf dest=/etc/my.cnf mode=0644
-  when: os == 'rhel' or
-        (os == 'ubuntu' and
+  when: ursula_os == 'rhel' or
+        (ursula_os == 'ubuntu' and
         ansible_distribution_version == "12.04")
   notify:
     - restart mysql server
 
 - name: configure my.cnf
   template: src=etc/my.cnf dest=/etc/mysql/my.cnf mode=0644
-  when: os == 'ubuntu' and
+  when: ursula_os == 'ubuntu' and
         ansible_distribution_version != "12.04"
   notify:
     - restart mysql server
@@ -60,7 +60,7 @@
   - percona-xtradb-cluster-client-{{ xtradb.client_version }}
   - percona-xtradb-cluster-server-{{ xtradb.server_version }}
   - percona-xtrabackup
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
   register: result
   until: result|succeeded
   retries: 5
@@ -68,7 +68,7 @@
 - name: install percona xtradb packages
   package:
     name: "Percona-XtraDB-Cluster-server-{{ xtradb.server_version }}"
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
   register: result
   until: result|succeeded
   retries: 5
@@ -149,8 +149,8 @@
 
 - name: start mysql server
   service: name=mysql state=started enabled=true
-  when: os == 'ubuntu' or
-        ( os == 'rhel' and result.rc != 0 )
+  when: ursula_os == 'ubuntu' or
+        ( ursula_os == 'rhel' and result.rc != 0 )
 
 - name: set mysql root password
   mysql_user: name=root password={{ mysql.root_password }}
@@ -214,13 +214,13 @@
 
   - name: bootstrap the primary node
     command: /etc/init.d/mysql bootstrap-pxc
-    when: os == 'ubuntu' and
+    when: ursula_os == 'ubuntu' and
           ( should_bootstrap_as_primary and not
             already_bootstrapped.rc == 0 )
 
   - name: bootstrap the primary node
     command: systemctl start mysql@bootstrap.service
-    when: os == 'rhel' and
+    when: ursula_os == 'rhel' and
           ( should_bootstrap_as_primary and not
             already_bootstrapped.rc == 0 )
 

--- a/roles/percona-server/templates/etc/mysql/conf.d/replication.cnf
+++ b/roles/percona-server/templates/etc/mysql/conf.d/replication.cnf
@@ -1,6 +1,6 @@
 [mysqld]
 
-{% if os == 'ubuntu' %}
+{% if ursula_os == 'ubuntu' %}
 wsrep_provider = /usr/lib/libgalera_smm.so
 {% else %}
 wsrep_provider = /usr/lib64/libgalera_smm.so

--- a/roles/preflight-checks/tasks/check_items.yml
+++ b/roles/preflight-checks/tasks/check_items.yml
@@ -2,7 +2,7 @@
 - name: ensure ssl.cafile is defined
   assert:
     that: "ssl.cafile is defined"
-    msg: "ssl.cafile must be defined based on the operating system {{ os }}"
+    msg: "ssl.cafile must be defined based on the operating system {{ ursula_os }}"
 
 - block:
   - name: check whether neutron-client is installed

--- a/roles/preflight-checks/tasks/main.yml
+++ b/roles/preflight-checks/tasks/main.yml
@@ -1,27 +1,24 @@
 ---
-- name: set os fact for rhel operating system
+- name: set ursula_os if undefined 
   set_fact:
-    os: rhel
-  when: ansible_distribution in ['CentOS', 'RedHat']
+    ursula_os: "{{ ansible_distribution | regex_replace('RedHat|CentOS', 'rhel')|lower }}"
+  when: ( ursula_os is undefined ) and
+        ( ansible_distribution in ['CentOS', 'RedHat'] or ansible_distribution == 'Ubuntu')
 
-- name: set os fact for rhel operating system
-  set_fact:
-    os: ubuntu
-  when: ansible_distribution in ['Ubuntu']
-
-- name: make sure os is defined
-  fail: msg="We don't support {{ ansible_distribution }} yet. OS should be CentOS, RedHat or Ubuntu."
-  when: os is undefined
+- name: validate ursula_os is a supported operating system and matches host system 
+  fail: msg="ursula_os does not match host operating system or {{ ursula_os }} is not a supported operating system (must be rhel or ubuntu)"
+  when: (ursula_os is defined) and ( ursula_os not in ['rhel', 'ubuntu'] or
+                                     ursula_os != "{{ ansible_distribution | regex_replace('RedHat|CentOS', 'rhel')|lower }}")
 
 - name: set ssh_service fact for ubuntu
   set_fact:
     ssh_service: ssh
-  when: os == 'ubuntu'
+  when: ursula_os == 'ubuntu'
 
 - name: set ssh_service fact for rhel
   set_fact:
     ssh_service: sshd
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - include: check_items.yml
   tags: ['precheck']

--- a/roles/rabbitmq/meta/main.yml
+++ b/roles/rabbitmq/meta/main.yml
@@ -6,7 +6,7 @@ dependencies:
         key_url: '{{ apt_repos.erlang.key_url }}'
       - repo: 'deb {{ apt_repos.rabbitmq.repo }} testing main'
         key_url: '{{ apt_repos.rabbitmq.key_url }}'
-    when: os == 'ubuntu'
+    when: ursula_os == 'ubuntu'
   - role: monitoring-common
     when: monitoring.enabled|default(True)|bool
   - role: logging-config

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -45,7 +45,7 @@
   file:
     dest: /etc/systemd/system/rabbitmq-server.service.d
     state: directory
-  when: os == 'rhel' 
+  when: ursula_os == 'rhel' 
 
 - name: set systemd overrides
   copy:
@@ -53,11 +53,11 @@
     content: "{{ rabbitmq.systemd.custom }}"
     force: yes
   register: override
-  when: os == 'rhel'
+  when: ursula_os == 'rhel'
 
 - name: restart systemd
   command: systemctl daemon-reload
-  when: override.changed and os == 'rhel'
+  when: override.changed and ursula_os == 'rhel'
   notify: 
     - restart rabbitmq
 

--- a/roles/rabbitmq/tasks/monitoring.yml
+++ b/roles/rabbitmq/tasks/monitoring.yml
@@ -7,7 +7,7 @@
 
 - name: rabbit server process check
   sensu_process_check:
-    service: "{{ ( os == 'ubuntu' )| ternary('rabbitmq-server', 'beam.smp') }}"
+    service: "{{ ( ursula_os == 'ubuntu' )| ternary('rabbitmq-server', 'beam.smp') }}"
   notify: restart sensu-client
 
 - name: rabbit cluster check

--- a/roles/repos/tasks/main.yml
+++ b/roles/repos/tasks/main.yml
@@ -1,6 +1,6 @@
 - include: apt.yml
-  when: os == "ubuntu"
+  when: ursula_os == "ubuntu"
 
 - include: yum.yml
-  when: os == "rhel"
+  when: ursula_os == "rhel"
 


### PR DESCRIPTION
Allow the ability to set ursula_os from envs. Added check to make sure what is defined in envs matches the running operating system. Currently centos is defined as rhel. To differentiate between centos and rhel would require logic changes and should be done in a follow up PR. If ursula_os is not set from envs it will be set based on ansible_distribution. 