### PR TITLE
use tcp-check for ceilometer and aodh api healthcheck.

### DIFF
--- a/roles/endpoints/defaults/main.yml
+++ b/roles/endpoints/defaults/main.yml
@@ -188,7 +188,7 @@ endpoints:
       backend_api: 9777
       haproxy_api: 8777
     haproxy:
-      health_check: 'httpchk GET /healthcheck'
+      health_check: 'tcp-check /'
       balance: 'source'
       prefer_primary_backend: False
   ironic:
@@ -240,6 +240,6 @@ endpoints:
       backend_api: 8043
       haproxy_api: 8042
     haproxy:
-      health_check: 'httpchk GET /healthcheck'
+      health_check: 'tcp-check /'
       balance: 'source'
       prefer_primary_backend: False

--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -135,6 +135,7 @@ defaults
   timeout client {{ haproxy.defaults.timeout_client }}
   timeout server {{ haproxy.defaults.timeout_server }}
   timeout connect {{ haproxy.defaults.timeout_connect }}
+  timeout check {{ haproxy.defaults.timeout_check }}
   timeout http-keep-alive {{ haproxy.defaults.timeout_http_keep_alive }}
   timeout http-request {{ haproxy.defaults.timeout_http_request }}
 


### PR DESCRIPTION
Haproxy healthcheck calls for ceilometer and aodh api causes socket connect reset errors in service journalctl logs. This error is occurring as haproxy health check closes the connection as soon as it fetches the header and on other end ceilometer-api / aodh-api python is trying to write the body and get's the exceptions.

 We are switching haproxy healthcheck for ceilometer and aodh to tcp-check for time being.