### PR TITLE
Enable SELinux to run in enforcing mode part 1

### DIFF
--- a/roles/ceilometer-common/defaults/main.yml
+++ b/roles/ceilometer-common/defaults/main.yml
@@ -11,12 +11,14 @@ ceilometer:
   distro:
     controller:
       project_packages:
+        - openstack-selinux
         - openstack-ceilometer-api
         - openstack-ceilometer-collector
         - openstack-ceilometer-notification
         - openstack-ceilometer-polling
     compute:
       project_packages:
+        - openstack-selinux
         - openstack-ceilometer-polling
         - openstack-ceilometer-compute
   source:

--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -56,6 +56,7 @@ cinder:
   heartbeat_timeout_threshold: 30
   distro:
     project_packages:
+      - openstack-selinux
       - openstack-cinder
   source:
     rev: 'stable/newton'

--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -26,6 +26,7 @@ glance:
   store_file: False
   distro:
     project_packages:
+      - openstack-selinux
       - openstack-glance
     python_post_dependencies: []
   source:

--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -10,6 +10,7 @@ heat:
     heat_engine: "{{ openstack_meta.heat.services.heat_engine[ursula_os] }}"
   distro:
     project_packages:
+      - openstack-selinux
       - openstack-heat-api
       - openstack-heat-api-cfn
       - openstack-heat-engine

--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -17,6 +17,7 @@ keystone:
       package: /opt/openstack/current/keystone
   distro:
     project_packages:
+      - openstack-selinux
       - openstack-keystone
     python_post_dependencies: []
   # Example for distro/source:

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -69,6 +69,7 @@ nova:
   distro:
     controller:
       project_packages:
+        - openstack-selinux
         - openstack-nova-api
         - openstack-nova-conductor
         - openstack-nova-scheduler
@@ -76,6 +77,7 @@ nova:
         - openstack-nova-console
     compute:
       project_packages:
+        - openstack-selinux
         - openstack-nova-compute
   source:
     rev: 'stable/newton'

--- a/roles/swift-common/defaults/main.yml
+++ b/roles/swift-common/defaults/main.yml
@@ -9,6 +9,7 @@ swift:
   allow_versions: True
   distro:
     project_packages:
+      - openstack-selinux
       - openstack-swift
   source:
     rev: 'stable/newton'


### PR DESCRIPTION
We will deploy the openstack-selinux package on the nodes.
We will still be running in PERMISSIVE mode but this will
reduce the 'denies' that we will be seeing in the logs. Will
allow for easier debugging of the other denies