### PR TITLE
make haproxy healthcheck inter tuneable with default to 2s.

### DIFF
--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -12,6 +12,7 @@ haproxy:
     timeout_client: 300s
     timeout_server: 300s
     timeout_check: 10s
+    check_interval: 2s
     stats_refresh: 10s
   mysql:
     maxconn: 4096

--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -173,12 +173,12 @@ backend {{ name }}
   {% if not prefer_primary_backend or hostvars[host][primary_interface]['ipv4']['address'] == primary_ip -%}
     {% if  name == "keystone" -%}
     cookie {{ endpoints.keystone.haproxy.oidc_cookie }}
-    server {{ host }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ clear_port }} check maxconn 40 cookie {{ host }}
+    server {{ host }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ clear_port }} check maxconn 40 cookie {{ host }} inter {{ haproxy.defaults.check_interval }}
     {% else -%}
-    server {{ host }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ clear_port }} check maxconn 40
+    server {{ host }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ clear_port }} check maxconn 40 inter {{ haproxy.defaults.check_interval }}
     {% endif -%}
   {% else -%}
-    server {{ host }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ clear_port }} backup check maxconn 40
+    server {{ host }} {{ hostvars[host][primary_interface]['ipv4']['address'] }}:{{ clear_port }} backup check maxconn 40 inter {{ haproxy.defaults.check_interval }}
   {% endif -%}
   {% endfor %}
 


### PR DESCRIPTION
Our current haproxy setting does not set check interval and rely on haproxy default of 2s. This PR make check interval a tuneable property with default of 2s.

We tested with 5s and we are see'ing more longer disruptions (~6-8 secs) in api calls as service is stopped on other controller. With 2sec disruption is very short and at time no disruption (i.e no 503).