### PR TITLE
Make job names shorter and concise

### DIFF
--- a/test/common
+++ b/test/common
@@ -12,8 +12,8 @@ export ANSIBLE_VAR_DEFAULTS_FILE="${ROOT}/envs/test/defaults-2.0.yml"
 export IMAGE_ID=${IMAGE_ID:=ubuntu-14.04}
 export AVAILABILITY_ZONE=${OS_AVAILABILITY_ZONE:=nova}
 export TEST_ENV=${TEST_ENV:=ci-full}
-if [[ -n ${BUILD_TAG} ]]; then
-  export testenv_instance_prefix=${BUILD_TAG}
+if [[ -n ${ghprbPullId} ]]; then
+  export testenv_instance_prefix="ursula-${BUILD_ID}-pr${ghprbPullId}"
 elif [[ $(git rev-parse --abbrev-ref HEAD) == 'HEAD' ]]; then
   export testenv_instance_prefix=$(git rev-parse --short HEAD)
 else


### PR DESCRIPTION
Job names need to be shorter because it becomes the hostname for ci stack nodes. They also need to have more destinct names so we are making the naming convention usula-build number-pr number.