### PR TITLE
fix neutron-rbac when using self-signed certs.

### DIFF
--- a/roles/neutron-control/tasks/main.yml
+++ b/roles/neutron-control/tasks/main.yml
@@ -23,7 +23,7 @@
       type: "{{ item.type }}"
       notify_access: "{{ item.notify_access|default(omit) }}"
       user: "{{ item.user }}"
-      #envs: "{{ neutron.service.envs }}"
+      environment: "{{ neutron.service.envs }}"
       cmd: "{{ item.cmd }}"
       config_dirs: "{{ item.config_dirs }}"
       config_files: "{{ item.config_files }}"

--- a/roles/neutron-data-network/tasks/main.yml
+++ b/roles/neutron-data-network/tasks/main.yml
@@ -85,7 +85,7 @@
       description: "{{ item.desc }}"
       type: "{{ item.type }}"
       user: "{{ item.user }}"
-      #envs: "{{ neutron.service.envs }}"
+      environment: "{{ neutron.service.envs }}"
       cmd: "{{ item.cmd }}"
       config_dirs: "{{ item.config_dirs }}"
       config_files: "{{ item.config_files }}"
@@ -103,7 +103,7 @@
       description: "{{ item.desc }}"
       type: "{{ item.type }}"
       user: "{{ item.user }}"
-      #envs: "{{ neutron.service.envs }}"
+      environment: "{{ neutron.service.envs }}"
       cmd: "{{ item.cmd }}"
       config_dirs: "{{ item.config_dirs }}"
       config_files: "{{ item.config_files }}"
@@ -165,7 +165,7 @@
     - haproxy.loadbalancer.j2
     - haproxy_proxies.j2
   notify: restart neutron lbaas agent
-  when: 
+  when:
     - openstack_install_method == 'distro'
     - (neutron.lbaas.enabled == "smart" and groups['controller'][0] not in groups['compute']) or neutron.lbaas.enabled|bool
 

--- a/roles/neutron-data/tasks/main.yml
+++ b/roles/neutron-data/tasks/main.yml
@@ -35,7 +35,7 @@
     description: "{{ item.desc }}"
     type: "{{ item.type }}"
     user: "{{ item.user }}"
-    #envs: "{{ neutron.service.envs }}"
+    environment: "{{ neutron.service.envs }}"
     #FIXME added prestart to match up osp systemd
     #prestart_script: "{{ item.prestart_script }}"
     cmd: "{{ item.cmd }}"


### PR DESCRIPTION
The neutron-rbac jellyroll calls were failing with ssl cert errors on test environment where we are using self-signed certs. This PR set's the environment in neutron systemd with certs path. It matches up what is already being done for ubuntu stacks.