### PR TITLE
unbreak source install due to setuptools version bump.

### DIFF
--- a/roles/openstack-source/tasks/main.yml
+++ b/roles/openstack-source/tasks/main.yml
@@ -25,7 +25,7 @@
     pip_extra_args: "{{ pip_extra_args }} -i {{ openstack.pypi_mirror }}"
   when: openstack.pypi_mirror is defined
 
-- name: update things in virtualenv
+- name: update pip in virtualenv
   pip:
     name: "{{ item }}"
     state: latest
@@ -33,7 +33,6 @@
     extra_args: "{{ pip_extra_args }}"
   with_items:
     - pip
-    - setuptools
   register: result
   until: result|succeeded
   retries: 5
@@ -58,6 +57,18 @@
       pip_extra_args: "{{ pip_extra_args }} -c /opt/stack/constraints.txt"
 
   when: constrain | bool
+
+- name: update setuptools in virtualenv
+  pip:
+    name: "{{ item }}"
+    state: latest
+    virtualenv: "{{ openstack_source.virtualenv_base }}/{{ project_name }}"
+    extra_args: "{{ pip_extra_args }}"
+  with_items:
+    - setuptools
+  register: result
+  until: result|succeeded
+  retries: 5
 
 - name: set code has changed fact
   set_fact:


### PR DESCRIPTION
Setup tools version got bumped which moves pyparsing to 2.2.0. This is breaking neutron/lbaas when install from source. 

This PR breaks the venv setup by updating pip to latest, setting up upper contraint facts and then install setuptool latest pointing to contrain file. This will ensure setuptools upgrade will not move up the pyparsing version to 2.2.0 and stick with what is mentioned in contrain file i.e 2.1.10.