### PR TITLE
avoid removing swifttool outside of venv for rhosp.

### DIFF
--- a/roles/swift-common/defaults/main.yml
+++ b/roles/swift-common/defaults/main.yml
@@ -40,7 +40,10 @@ swift:
       - { name: keystonemiddleware }
       - { name: python-swiftclient }
     system_dependencies:
-      - liberasurecode-dev
+      ubuntu:
+        - liberasurecode-dev
+      rhel:
+        - liberasurecode-devel
   alternatives:
     - swift-account-audit
     - swift-account-auditor
@@ -132,4 +135,3 @@ swift:
         no_auditors: 1
         no_updaters: 1
   venv_dir: '/opt/openstack/current/swift'
-

--- a/roles/swift-common/handlers/main.yml
+++ b/roles/swift-common/handlers/main.yml
@@ -14,6 +14,7 @@
 
 - name: pip clean swifttool outside venv
   pip: name=swifttool state=absent
+  when: openstack_distro_type != 'osp'
   register: result
   until: result|succeeded
   retries: 5
@@ -22,6 +23,7 @@
   alternatives: name=swifttool
                 path={{ swift.venv_dir }}/bin/swifttool
                 link=/usr/local/bin/swifttool
+  when: openstack_distro_type != 'osp'
 
 - name: update ca-certs
   command: update-ca-certificates


### PR DESCRIPTION
On RHOSP, swifttool is installed at sysytem level as it has dependencies on swift pkgs. This PR add's the condition to no uninstall swifttool ourside of venv when running on rhosp.