### PR TITLE
ensure PyYAML is installed on all nodes for MOTD.

### DIFF
--- a/roles/ceph-monitor/tasks/monitoring.yml
+++ b/roles/ceph-monitor/tasks/monitoring.yml
@@ -2,7 +2,7 @@
 - name: import rados module into base_venv (rhel)
   file:
     src: "{{ ceph.pylib_dir[ursula_os] }}{{ item }}"
-    dest: "/opt/openstack/base/lib/python2.7/site-packages/{{ item }}"
+    dest: "{{ basevenv_lib_dir }}/{{ item }}"
     state: link
     owner: root
     group: root
@@ -15,7 +15,7 @@
 - name: import rados module into base_venv (ubuntu)
   file:
     src: "{{ ceph.pylib_dir[ursula_os] }}{{ item }}"
-    dest: "/opt/openstack/base/lib/python2.7/site-packages/{{ item }}"
+    dest: "{{ basevenv_lib_dir }}/{{ item }}"
     state: link
     owner: root
     group: root
@@ -28,7 +28,7 @@
 - name: import other ceph modules into base_venv
   file:
     src: "{{ ceph.pylib_dir2[ursula_os] }}{{ item }}"
-    dest: "/opt/openstack/base/lib/python2.7/site-packages/{{ item }}"
+    dest: "{{ basevenv_lib_dir }}/{{ item }}"
     state: link
     owner: root
     group: root

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -106,7 +106,7 @@ common:
         - tree
         - vim
   python:
-    base_venv: "/opt/openstack/base"
+    base_venv: "{{ basevenv | default('/opt/openstack/base') }}"
     ubuntu:
       system_packages:
         - python-pip
@@ -138,6 +138,7 @@ common:
         - python-virtualenv
         - MySQL-python
         - python-jinja2
+        - PyYAML
         - cryptsetup
         - libffi-devel
         - openssl-libs


### PR DESCRIPTION
MOTD requires PyYAML to parse the ursula release config. This PR is adding PyYAML to python system dependencies list in common role.

In addition, removing hard coded references to basevenv and pointing to one common variable we already have defined.