### PR TITLE
remove logging-config dep on logging role

### DIFF
--- a/roles/logging-config/meta/main.yml
+++ b/roles/logging-config/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - role: logging

--- a/roles/logging-config/tasks/main.yml
+++ b/roles/logging-config/tasks/main.yml
@@ -1,5 +1,6 @@
 - include: logstash.yml
-  when: logging.forward_type != 'filebeat'
+  when: logging.forward_type|default('filebeat') != 'filebeat'
 
 - include: filebeat.yml
-  when: logging.forward_type  == 'filebeat'
+  when: logging.forward_type|default('filebeat')  == 'filebeat'
+

--- a/site.yml
+++ b/site.yml
@@ -33,6 +33,9 @@
   hosts: all:!vyatta-*
   any_errors_fatal: true
   roles:
+    - role: logging
+      tags: ['common', 'logging']
+      when: logging.enabled|default("True")|bool
     - role: common
       tags: ['common','common-base']
     - role: manage-disks
@@ -44,9 +47,6 @@
     - role: inspec
       tags: ['common', 'inspec']
       when: inspec.enabled|default("False")|bool
-    - role: logging
-      tags: ['common', 'logging']
-      when: logging.enabled|default("True")|bool
     - role: audit
       tags: ['common', 'logging', 'audit']
       when: audit.enabled|default('False')|bool
@@ -62,15 +62,6 @@
     - role: security_errata
       tags: ['common', 'security', 'errata']
       when: ansible_distribution == 'Ubuntu'
-  environment: "{{ env_vars|default({}) }}"
-
-- name: install logging and dependencies
-  hosts: all:!vyatta-*
-  any_errors_fatal: true
-  roles:
-    - role: logging
-      tags: ['common', 'logging']
-      when: logging.enabled|default('True')|bool
   environment: "{{ env_vars|default({}) }}"
 
 - name: setup IPv6 router advertisements


### PR DESCRIPTION
Currently the logging role runs twice per run in site.yml and every time a service role is run (nova,keystone,rabbit,etc). This role only needs to be run once. The logging config role puts each service's filebeat/logstash template in the appropriate directory. This assumes that you have run the logging role once prior to running other roles (it's run before any services in site.yml) You can override the logging.forward_type from envs if you want to use logstash (which is now deprecated). Removing this dep should shorten the ursula run time. 