### PR TITLE
Mask unwanted neutron services for compute hosts

### DIFF
--- a/roles/neutron-data/tasks/main.yml
+++ b/roles/neutron-data/tasks/main.yml
@@ -49,6 +49,17 @@
     - ursula_os == 'rhel'
     - neutron.plugin == 'ml2'
 
+- name: mask unwanted neutron services on compute (rhel)
+  command: systemctl mask {{ item.name }}
+  with_items:
+    - "{{ neutron.services.neutron_server }}"
+    - "{{ neutron.services.neutron_dhcp_agent }}"
+    - "{{ neutron.services.neutron_l3_agent }}"
+    - "{{ neutron.services.neutron_metadata_agent }}"
+  when:
+    - ursula_os == 'rhel'
+    - not inventory_hostname in groups['network']
+
 - name: ml2 dataplane config
   template: src=etc/neutron/plugins/ml2/ml2_plugin_dataplane.ini
             dest=/etc/neutron/plugins/ml2/ml2_plugin_dataplane.ini


### PR DESCRIPTION
Only neutron-linuxbridge-agent service is needed on compute hosts however, all neutron services are installed. When running `neutron-reset` on compute hosts, these unwanted services will get started.