### PR TITLE
Restructure Inspec Defaults to Dictionary

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -649,6 +649,9 @@ serverspec:
 
 inspec:
   enabled: False
+  controls:
+    rhel7:
+      enabled: "{{ ursula_os == 'rhel' }}"
 
 #openstack-ansible-security overrides
 security_enable_chrony: false

--- a/roles/inspec/defaults/main.yml
+++ b/roles/inspec/defaults/main.yml
@@ -5,15 +5,29 @@ inspec:
   interval: 3600
   dependency_install_method: 'tar'
   dependency_path: /etc/inspec/
-  profile_dependencies:
-    - name: inspec-openstack-security
+  profiles:
+    openstack_security:
+      name: inspec-openstack-security
       version: master
       url: https://github.com/chef-partners/inspec-openstack-security/archive/master.tar.gz
-    - name: inspec-stig-rhel7
+    stig_rhel:
+      name: inspec-stig-rhel7
       version: master
       url: https://github.com/inspec-stigs/inspec-stig-rhel7/archive/master.tar.gz
-  openstack:
+  controls:
+    rhel7:
+      enabled: false
+      profile_location: stig_rhel
+      skip_controls: []
+      attributes:
+        RHEL_07_030710_audit_key_name: audit_account_changes-V-38531
+        client_alive_interval: '900'
+        RHEL_07_030523_audit_key_name: actions-V-38578
     horizon:
+      enabled: true
+      profile_location: openstack_security
+      attributes:
+        horizon_config_group: apache
       required_controls:
         - check-dashboard-01
         - check-dashboard-02
@@ -26,9 +40,9 @@ inspec:
         - check-dashboard-09
         - check-dashboard-10
         - check-dashboard-11
-      attributes:
-        horizon_config_group: apache
     cinder:
+      enabled: true
+      profile_location: openstack_security
       required_controls:
         - check-block-01
         - check-block-02
@@ -39,16 +53,22 @@ inspec:
         - check-block-07
         - check-block-08
     glance:
+      enabled: true
+      profile_location: openstack_security
       required_controls:
         - check-image-03
         - check-image-04
     nova:
+      enabled: true
+      profile_location: openstack_security
       required_controls:
         - check-compute-01
         - check-compute-02
         - check-compute-03
         - check-compute-04
     keystone:
+      enabled: true
+      profile_location: openstack_security
       required_controls:
         - check-identity-01
         - check-identity-02
@@ -57,14 +77,10 @@ inspec:
         - check-identity-05
         - check-identity-06
     neutron:
+      enabled: true
+      profile_location: openstack_security
       required_controls:
         - check-neutron-01
         - check-neutron-02
         - check-neutron-03
         - check-neutron-04
-  rhel7:
-    attributes:
-      RHEL_07_030710_audit_key_name: audit_account_changes-V-38531
-      client_alive_interval: '900'
-      RHEL_07_030523_audit_key_name: actions-V-38578
-    skip_controls: []

--- a/roles/inspec/tasks/main.yml
+++ b/roles/inspec/tasks/main.yml
@@ -19,7 +19,6 @@
     dest: '{{ inspec.dependency_path }}/archive/'
     mode: 0766
     state: directory
-  with_items: '{{inspec.profile_dependencies }}'
   when: inspec.dependency_install_method == 'tar'
 
 - name: create current directory for inspec dependencies
@@ -29,29 +28,39 @@
     state: directory
   when: inspec.dependency_install_method == 'tar'
 
+- name: populate dependent profile list
+  set_fact:
+    inspec_dependency_profiles: '{{ inspec_dependency_profiles|default([]) + [ inspec.controls[item].profile_location ] }}'
+  when: "{{ inspec.controls[item].enabled|default('False')|bool }}"
+  with_items: '{{ inspec.controls.keys() }}'
+
+- name: make sure every element in the profile list is unique
+  set_fact:
+    inspec_dependency_profiles: '{{ inspec_dependency_profiles|unique }}'
+
 - name: fetch inspec dependencies when install method is tar
   get_url:
-    url: '{{ item.url }}'
-    dest: '{{ inspec.dependency_path }}/archive/{{ item.name }}-{{ item.version }}'
+    url: '{{ inspec.profiles[item].url }}'
+    dest: '{{ inspec.dependency_path }}/archive/{{ inspec.profiles[item].name}}-{{ inspec.profiles[item].version }}'
     mode: 0644
-  with_items: '{{ inspec.profile_dependencies }}'
+  with_items: inspec_dependency_profiles
   when: inspec.dependency_install_method == 'tar'
 
 - name: untar inspec dependencies
   unarchive:
-    src: '{{ inspec.dependency_path }}/archive/{{ item.name }}-{{ item.version }}'
+    src: '{{ inspec.dependency_path }}/archive/{{ inspec.profiles[item].name }}-{{ inspec.profiles[item].version }}'
     dest: '{{ inspec.dependency_path }}'
     copy: no
-  with_items: '{{inspec.profile_dependencies }}'
+  with_items: inspec_dependency_profiles
   when: inspec.dependency_install_method == 'tar'
 
 - name: create inspec dependency current symlink
   file:
-    src: '{{ inspec.dependency_path }}/{{ item.name }}-{{ item.version }}'
-    dest: '{{ inspec.dependency_path }}/current/{{ item.name }}'
+    src: '{{ inspec.dependency_path }}/{{ inspec.profiles[item].name }}-{{ inspec.profiles[item].version }}'
+    dest: '{{ inspec.dependency_path }}/current/{{ inspec.profiles[item].name }}'
     state: link
     force: true
-  with_items: '{{inspec.profile_dependencies }}'
+  with_items: inspec_dependency_profiles
   when: inspec.dependency_install_method == 'tar'
 
 - name: inspec profile yml
@@ -65,14 +74,16 @@
     src: etc/inspec/host-controls/controls/openstack-security.rb
     dest: /etc/inspec/host-controls/controls/
     mode: 0644
-  when: inventory_hostname in groups['controller'] or  inventory_hostname in groups['compute'] or inventory_hostname in groups['cinder_volume']|default([])
+  when: inventory_hostname in groups['controller'] or
+        inventory_hostname in groups['compute'] or
+        inventory_hostname in groups['cinder_volume']|default([])
 
 - name: rhel control files
   template:
     src: etc/inspec/host-controls/controls/rhel7-stigs.rb
     dest: /etc/inspec/host-controls/controls/
     mode: 0644
-  when: ursula_os == 'rhel'
+  when: inspec.controls.rhel7.enabled|default('False')|bool
 
 - name: remove inspec lock file so we can upgrade
   file:

--- a/roles/inspec/templates/etc/inspec/host-controls/attributes.yml
+++ b/roles/inspec/templates/etc/inspec/host-controls/attributes.yml
@@ -1,3 +1,7 @@
-{% for name,value in inspec.openstack.horizon.attributes.iteritems() %}
+{% for profile_name,profile in inspec.controls.iteritems() %}
+{% if profile.enabled|default('False')|bool and profile.attributes is defined %}
+{% for name,value in profile.attributes.iteritems() %}
 {{ name }}: {{ value }}
+{% endfor %}
+{% endif %}
 {% endfor %}

--- a/roles/inspec/templates/etc/inspec/host-controls/controls/openstack-security.rb
+++ b/roles/inspec/templates/etc/inspec/host-controls/controls/openstack-security.rb
@@ -5,32 +5,42 @@
 require_controls 'inspec-openstack-security' do
 
 {% if inventory_hostname in groups['controller'] %}
-{% for control in inspec.openstack.horizon.required_controls %}
-    control '{{ control }}'
-{% endfor %}
-{% for control in inspec.openstack.glance.required_controls %}
-    control '{{ control }}'
-{% endfor %}
-{% for control in inspec.openstack.keystone.required_controls %}
+{% if inspec.controls.horizon.enabled|default('False')|bool %}
+{% for control in inspec.controls.horizon.required_controls %}
     control '{{ control }}'
 {% endfor %}
 {% endif %}
+{% if inspec.controls.glance.enabled|default('False')|bool %}
+{% for control in inspec.controls.glance.required_controls %}
+    control '{{ control }}'
+{% endfor %}
+{% endif %}
+{% if inspec.controls.keystone.enabled|default('False')|bool %}
+{% for control in inspec.controls.keystone.required_controls %}
+    control '{{ control }}'
+{% endfor %}
+{% endif %}
+{% endif %}
 
 {% if inventory_hostname in groups['controller'] or inventory_hostname in groups['cinder_volume']|default([]) %}
-{% if cinder.enabled|default('False')|bool %}
-{% for control in inspec.openstack.cinder.required_controls %}
+{% if cinder.enabled|default('False')|bool and inspec.controls.cinder.enabled|default('False')|bool %}
+{% for control in inspec.controls.cinder.required_controls %}
     control '{{ control }}'
 {% endfor %}
 {% endif %}
 {% endif %}
 
 {% if inventory_hostname in groups['controller'] or inventory_hostname in groups['compute'] %}
-{% for control in inspec.openstack.nova.required_controls %}
+{% if inspec.controls.nova.enabled|default('False')|bool %}
+{% for control in inspec.controls.nova.required_controls %}
     control '{{ control }}'
 {% endfor %}
-{% for control in inspec.openstack.neutron.required_controls %}
+{% endif %}
+{% if inspec.controls.neutron.enabled|default('False')|bool %}
+{% for control in inspec.controls.neutron.required_controls %}
     control '{{ control }}'
 {% endfor %}
+{% endif %}
 {% endif %}
 
 end

--- a/roles/inspec/templates/etc/inspec/host-controls/controls/rhel7-stigs.rb
+++ b/roles/inspec/templates/etc/inspec/host-controls/controls/rhel7-stigs.rb
@@ -3,7 +3,7 @@
 #title 'host-controls'
 
 include_controls 'inspec-stig-rhel7' do
-{% for control in inspec.rhel7.skip_controls %}
+{% for control in inspec.controls.rhel7.skip_controls %}
     skip_control '{{ control }}'
 {% endfor %}
 end

--- a/roles/inspec/templates/etc/inspec/host-controls/inspec.yml
+++ b/roles/inspec/templates/etc/inspec/host-controls/inspec.yml
@@ -7,7 +7,14 @@ license: Apache 2.0
 summary: An InSpec Compliance Profile
 version: 0.1.0
 depends:
-{% for profile in inspec.profile_dependencies %}
-- name: {{ profile.name }}
-  path: '{{ inspec.dependency_path }}/current/{{ profile.name }}'
+{% for item in inspec_dependency_profiles %}
+{% if not inspec.profiles[item].sub_profiles is defined %}
+- name: {{ inspec.profiles[item].name }}
+  path: '{{ inspec.dependency_path }}/current/{{ inspec.profiles[item].name }}'
+{% else %}
+{% for sub_profile in inspec.profiles[item].sub_profiles %}
+- name: {{ sub_profile.name }}
+  path: '{{ inspec.dependency_path }}/current/{{ inspec.profiles[item].name }}/{{ sub_profile.path }}'
+{% endfor %}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
This restructures the Inspec role default variables for profiles to
be a dictionary instead of a list. We then build a list
of needed dependency profile installations by checking if the
dependent profile is enabled. We only install dependency profiles
if needed.
