### PR TITLE
Do not hardcode nova cpu_mode

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -12,6 +12,7 @@ nova:
   metadata_api_workers: 5
   cpu_allocation_ratio: 1.0
   ram_allocation_ratio: 1.0
+  libvirt_cpu_mode: host-model
   libvirt_cpu_model: null
   libvirt_type: kvm
   enable_ssh: False

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -142,7 +142,7 @@ cpu_model = {{ nova.libvirt_cpu_model }}
 {% elif (nova.libvirt_cpu_model and ansible_architecture == "ppc64le") or nova.enable_numa %}
 cpu_mode = host-passthrough
 {% else %}
-cpu_mode = host-model
+cpu_mode = {{ nova.libvirt_cpu_mode }}
 {% endif -%}
 live_migration_downtime = 500
 live_migration_downtime_steps = 10


### PR DESCRIPTION
Right now there is no way to allow set libvirt's cpu_mode without side
effects. In order to preserve the current functionality, add host-model
as the nova default, but allow an operator to override if necessary.