### PR TITLE
add retires for rhn subscription and disable arp_responder.

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -227,6 +227,7 @@ neutron:
   bridge_mappings: ''
   network_vlan_ranges: ''
   tenant_network_type: vxlan
+  arp_responder: false
   tunnel_types:
     - vxlan
   lbaas:

--- a/roles/rhn-subscription/tasks/main.yml
+++ b/roles/rhn-subscription/tasks/main.yml
@@ -12,8 +12,10 @@
     password: "{{ rhn_subscription.password }}"
     pool: "{{ rhn_subscription.pool_names_regex }}"
     autosubscribe: False
-  register: subscription
   when: not osp_rhn.stdout | search("Current")
+  register: subscription
+  until: subscription|succeeded
+  retries: 3
 
 - block:
   - name: disable all redhat repositories


### PR DESCRIPTION
In our CI runs we seeing random rhn subscription errors so adding retires logic to it. Also, setting arp_responder: false as this will be default in production as well.