### PR TITLE
remove --config_dirs from cinder systemd.

### DIFF
--- a/roles/cinder-control/tasks/main.yml
+++ b/roles/cinder-control/tasks/main.yml
@@ -17,7 +17,6 @@
     type: "{{ item.type }}"
     user: "{{ item.user }}"
     cmd: "{{ item.cmd }}"
-    config_dirs: "{{ item.config_dirs }}"
     config_files: "{{ item.config_files }}"
     restart: "{{ item.restart }}"
   with_items:

--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -72,7 +72,6 @@
       type: "{{ item.type }}"
       user: "{{ item.user }}"
       cmd: "{{ item.cmd }}"
-      config_dirs: "{{ item.config_dirs }}"
       config_files: "{{ item.config_files }}"
       restart: "{{ item.restart }}"
       kill_mode: "{{ item.kill_mode }}"
@@ -86,7 +85,6 @@
       type: "{{ item.type }}"
       user: "{{ item.user }}"
       cmd: "{{ item.cmd }}"
-      config_dirs: "{{ item.config_dirs }}"
       config_files: "{{ item.config_files }}"
       restart: "{{ item.restart }}"
     when: swift.enabled|default("false")|bool

--- a/roles/openstack-meta/defaults/main.yml
+++ b/roles/openstack-meta/defaults/main.yml
@@ -61,7 +61,6 @@ openstack_meta:
           type: simple
           user: cinder
           cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}cinder-api"
-          config_dirs: /etc/cinder
           config_files: /etc/cinder/cinder.conf
           restart: on-failure
       cinder_scheduler:
@@ -77,7 +76,6 @@ openstack_meta:
           type: simple
           user: cinder
           cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}cinder-scheduler"
-          config_dirs: /etc/cinder
           config_files: /etc/cinder/cinder.conf
           restart: on-failure
       cinder_volume:
@@ -93,7 +91,6 @@ openstack_meta:
           type: simple
           user: cinder
           cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}cinder-volume"
-          config_dirs: /etc/cinder
           config_files: /etc/cinder/cinder.conf
           restart: on-failure
           kill_mode: process
@@ -110,7 +107,6 @@ openstack_meta:
           type: simple
           user: cinder
           cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}cinder-backup"
-          config_dirs: /etc/cinder
           config_files: /etc/cinder/cinder.conf
           restart: on-failure
   nova:


### PR DESCRIPTION
cinder volume backup fails due to bug in oslo.privsep which is passing --config_dir as list. This bug is fix in oslo.privsep 14.x and up under https://review.openstack.org/#/c/361125/2/oslo_privsep/priv_context.py.

For newton oslo.privsep is pinned to 1.13.1 and that has this bug. Removing --config_dir from systemd fixes cinder backup issue. Given we are using default /etc/cinder as config dir it get's loaded by oslo even if not passed to start up cmd.