### PR TITLE
add re-tries to nova-compute start.

### DIFF
--- a/roles/nova-data/tasks/main.yml
+++ b/roles/nova-data/tasks/main.yml
@@ -119,6 +119,9 @@
     name: "{{ nova.services.nova_compute.name }}"
     state: started
     enabled: True
+  register: result
+  until: result|succeeded
+  retries: 3
 
 - include: monitoring.yml
   tags:


### PR DESCRIPTION
During our RHOSP PR CI runs we been intermittently seeing some ci run job failing with temout at starting nova-compute. This PR adds retries logic to nova-compute service started.