### PR TITLE
deploy the keystone token flush cron job on both controllers

### DIFF
--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -195,7 +195,6 @@
     owner: root
     group: root
     mode: 0640
-  run_once: true
 
 - name: delete old token flush job
   file:


### PR DESCRIPTION
The keystone expired token flush cron job needs to be deployed on both the controllers. It was getting installed on only one controller as `run_once` was specified. The job itself has logic in it to check if the controller on which it is running has the ucarp and only then runs the token flush. However, since it was deployed on only one controller and when the ucarp failed over, the expired tokens were not getting flushed.