### PR TITLE
enable lbaas testing in ci

### DIFF
--- a/playbooks/tests/tasks/lbaas.yml
+++ b/playbooks/tests/tasks/lbaas.yml
@@ -9,8 +9,8 @@
   tasks:
   - name: copy heat stack yaml file to hosts
     copy: >
-      src={{ lookup('env', 'URSULA_ENV') }}/../../playbooks/tests/tasks/lb_stack.yml
-      dest=/tmp/lb_stack.yml owner=ubuntu group=ubuntu
+      src=lb_stack.yml
+      dest=/tmp/lb_stack.yml
 
   - name: create heat stack for lbaas
     shell: >


### PR DESCRIPTION
1) remove the restriction on ubuntu and support rhel
2) use relative path to support running test from envs/example/ci-full-rhel instead of env/test