### PR TITLE
enable L3HA and fix  ping tests for CI

### DIFF
--- a/envs/example/ci-ceph-redhat/group_vars/all.yml
+++ b/envs/example/ci-ceph-redhat/group_vars/all.yml
@@ -26,6 +26,13 @@ etc_hosts:
 
 neutron:
   enable_external_interface: True
+  l3ha:
+    enabled: True
+    max_agents: 2
+    min_agents: 2
+    cidr: 169.254.192.0/18
+    password: "{{ secrets.service_password }}"
+    interval: 2
   lbaas:
     enabled: False
 

--- a/envs/example/ci-ceph_swift/group_vars/all.yml
+++ b/envs/example/ci-ceph_swift/group_vars/all.yml
@@ -15,6 +15,13 @@ etc_hosts:
 
 neutron:
   enable_external_interface: True
+  l3ha:
+    enabled: True
+    max_agents: 2
+    min_agents: 2
+    cidr: 169.254.192.0/18
+    password: "{{ secrets.service_password }}"
+    interval: 2  
   lbaas:
     enabled: True
 

--- a/envs/example/ci-full-centos/group_vars/all.yml
+++ b/envs/example/ci-full-centos/group_vars/all.yml
@@ -11,6 +11,13 @@ etc_hosts:
 
 neutron:
   enable_external_interface: True
+  l3ha:
+    enabled: True
+    max_agents: 2
+    min_agents: 2
+    cidr: 169.254.192.0/18
+    password: "{{ secrets.service_password }}"
+    interval: 2
   lbaas:
     enabled: False
 

--- a/envs/example/ci-full-rhel/group_vars/all.yml
+++ b/envs/example/ci-full-rhel/group_vars/all.yml
@@ -18,6 +18,13 @@ etc_hosts:
 
 neutron:
   enable_external_interface: True
+  l3ha:
+    enabled: True
+    max_agents: 2
+    min_agents: 2
+    cidr: 169.254.192.0/18
+    password: "{{ secrets.service_password }}"
+    interval: 2
   lbaas:
     enabled: False
 

--- a/envs/example/ci-full/group_vars/all.yml
+++ b/envs/example/ci-full/group_vars/all.yml
@@ -6,6 +6,13 @@ state_path_base: /opt/stack/data
 
 neutron:
   enable_external_interface: True
+  l3ha:
+    enabled: True
+    max_agents: 2
+    min_agents: 2
+    cidr: 169.254.192.0/18
+    password: "{{ secrets.service_password }}"
+    interval: 2
   lbaas:
     enabled: True
 

--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -228,6 +228,7 @@ neutron:
   network_vlan_ranges: ''
   tenant_network_type: vxlan
   arp_responder: false
+  l2_population: false
   tunnel_types:
     - vxlan
   lbaas:

--- a/playbooks/tests/tasks/integration.yml
+++ b/playbooks/tests/tasks/integration.yml
@@ -1,134 +1,127 @@
 ---
-- name: integration testing
-  hosts: controller[0]
+- name: generate ssh key for root
+  user: name=root generate_ssh_key=yes
+  register: rootuser
 
-  tasks:
-    - name: generate ssh key for root
-      user: name=root generate_ssh_key=yes
-      register: rootuser
+- name: generate nova key-pair
+  environment:
+    PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
+  os_keypair:
+    name: turtle-key
+    auth:
+      auth_url: "{{ endpoints.auth_uri }}"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
+    public_key: "{{ rootuser.ssh_public_key }}"
+    state: present
 
-    - name: generate nova key-pair
-      environment:
-        PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
-      os_keypair:
-        name: turtle-key
-        auth:
-          auth_url: "{{ endpoints.auth_uri }}"
-          project_name: admin
-          username: admin
-          password: "{{ secrets.admin_password }}"
-        public_key: "{{ rootuser.ssh_public_key }}"
+- name: generate test security group
+  environment:
+    PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
+  os_security_group:
+    auth:
+      auth_url: "{{ endpoints.auth_uri }}"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
+    name: turtle-sec
+    description: turtle-sec
 
-    - name: generate test security group
-      environment:
-        PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
-      os_security_group:
-        auth:
-          auth_url: "{{ endpoints.auth_uri }}"
-          project_name: admin
-          username: admin
-          password: "{{ secrets.admin_password }}"
-        name: turtle-sec
-        description: turtle-sec
+- name: add security group rule
+  environment:
+    PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
+  os_security_group_rule:
+    auth:
+      auth_url: "{{ endpoints.auth_uri }}"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
+    security_group: turtle-sec
+    remote_ip_prefix: 0.0.0.0/0
 
-    - name: test security group rule
-      environment:
-        PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
-      os_security_group_rule:
-        auth:
-          auth_url: "{{ endpoints.auth_uri }}"
-          project_name: admin
-          username: admin
-          password: "{{ secrets.admin_password }}"
-        security_group: turtle-sec
-        remote_ip_prefix: 0.0.0.0/0
+- name: nova can boot an instance
+  environment:
+    PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
+  os_server:
+      name: turtle-stack
+      auth:
+        auth_url: "{{ endpoints.auth_uri }}"
+        project_name: admin
+        username: admin
+        password: "{{ secrets.admin_password }}"
+      image: cirros
+      security_groups: turtle-sec
+      key_name: turtle-key
+      flavor: 1
+      auto_floating_ip: no
+      nics:
+        - net-name: internal
+  register: turtle_stack
 
-    - name: nova can boot an instance
-      environment:
-        PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
-      os_server:
-          name: turtle-stack
-          auth:
-            auth_url: "{{ endpoints.auth_uri }}"
-            project_name: admin
-            username: admin
-            password: "{{ secrets.admin_password }}"
-          image: cirros
-          security_groups: turtle-sec
-          key_name: turtle-key
-          flavor: 1
-          auto_floating_ip: no
-          nics:
-            - net-name: internal
-      register: turtle_stack
+- name: delete any existing floating IP associated with instance
+  shell: . /root/stackrc; openstack floating ip delete $(openstack floating ip list | grep {{ turtle_stack.openstack.private_v4 }}  | awk '{ print $2 }')
+  failed_when: false
 
-    - name: nova can associate floating IP with test instance
-      environment:
-        PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
-      os_floating_ip:
-        auth:
-          auth_url: "{{ endpoints.auth_uri }}"
-          project_name: admin
-          username: admin
-          password: "{{ secrets.admin_password }}"
-        network: external
-        server: turtle-stack
-        reuse: true
-        fixed_address: "{{ item.addr }}"
-        wait: true
-      register: floating_ip
-      with_items: "{{ turtle_stack.openstack.addresses.internal }}"
-      when: item.version == 4
+- name: nova can associate floating IP with test instance
+  environment:
+    PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
+  os_floating_ip:
+    auth:
+      auth_url: "{{ endpoints.auth_uri }}"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
+    network: external
+    server: turtle-stack
+    reuse: true
+    fixed_address: "{{ turtle_stack.openstack.private_v4 }}"
+    wait: true
+  register: floating_ip
 
-    - name: nova can create a volume via cinder
-      environment:
-        PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
-      os_volume:
-        auth:
-          auth_url: "{{ endpoints.auth_uri }}"
-          project_name: admin
-          username: admin
-          password: "{{ secrets.admin_password }}"
-        display_name: turtle-vol
-        size: 2
-      when: cinder.enabled|bool
+- name: nova can create a volume via cinder
+  environment:
+    PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
+  os_volume:
+    auth:
+      auth_url: "{{ endpoints.auth_uri }}"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
+    display_name: turtle-vol
+    size: 2
+  when: cinder.enabled|bool
 
-    - name: nova can attach cinder volume
-      environment:
-        PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
-      os_server_volume:
-        auth:
-          auth_url: "{{ endpoints.auth_uri }}"
-          project_name: admin
-          username: admin
-          password: "{{ secrets.admin_password }}"
-        server: turtle-stack
-        volume: turtle-vol
-      when: cinder.enabled|bool
+- name: nova can attach cinder volume
+  environment:
+    PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
+  os_server_volume:
+    auth:
+      auth_url: "{{ endpoints.auth_uri }}"
+      project_name: admin
+      username: admin
+      password: "{{ secrets.admin_password }}"
+    server: turtle-stack
+    volume: turtle-vol
+  when: cinder.enabled|bool
 
-    - block:
-      - name: wait for instance to boot
-        wait_for:
-          host: "{{ item.floating_ip.floating_ip_address }}"
-          port: 22
-          timeout: 180
-        with_items: "{{ floating_ip.results }}"
-        when: item.floating_ip is defined
+- name: wait for instance to boot
+  wait_for:
+    host: "{{ floating_ip.floating_ip.floating_ip_address }}"
+    port: 22
+    timeout: 180
+  when: floating_ip.floating_ip.floating_ip_address is defined
 
-      - name: test instance can ping 8888
-        command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
-                 -i /root/.ssh/id_rsa
-                 cirros@{{ item.floating_ip.floating_ip_address }}
-                 ping -c 5 8.8.8.8
-        with_items: "{{ floating_ip.results }}"
-        when: item.floating_ip is defined
+- name: test instance can ping 8.8.8.8
+  command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+           -i /root/.ssh/id_rsa
+           cirros@{{ floating_ip.floating_ip.floating_ip_address }}
+           ping -c 5 8.8.8.8
+  when: floating_ip.floating_ip.floating_ip_address is defined
 
-      - name: test instance can ping Google
-        command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
-                 -i /root/.ssh/id_rsa
-                 cirros@{{ item.floating_ip.floating_ip_address }}
-                 ping -c 5 www.google.com
-        with_items: "{{ floating_ip.results }}"
-        when: item.floating_ip is defined
-      when: ursula_os == 'ubuntu' or ansible_distribution =='CentOS'
-      #Temporarily skipping above tests on rhel until we have a fix.
+- name: test instance can ping Google
+  command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+           -i /root/.ssh/id_rsa
+           cirros@{{ floating_ip.floating_ip.floating_ip_address }}
+           ping -c 5 www.google.com
+  when: floating_ip.floating_ip.floating_ip_address is defined

--- a/playbooks/tests/tasks/main.yml
+++ b/playbooks/tests/tasks/main.yml
@@ -1,17 +1,39 @@
 ---
 - include: all.yml
+
 - include: controller.yml
+
 - include: network.yml
+
 - include: ceph.yml
   when: ceph.enabled|default('False')|bool
+
 - include: swift.yml
   when: swift.enabled|default('False')|bool
+
 - include: lbaas.yml
   when: neutron.lbaas.enabled|default('False')|bool
-- include: integration.yml
+
+- name: Begin intergration test
+  hosts: controller[0]
+  tasks:
+  - name: Find host hosting default router
+    shell: . /root/stackrc; neutron l3-agent-list-hosting-router default | grep " active "
+    register: host_result
+
+  - set_fact:
+      host_hosting_default_router: "{{ item }}"
+    when: item in host_result.stdout
+    with_items: "{{ groups['controller'] }}"
+
+  - include: integration.yml
+    delegate_to: "{{ host_hosting_default_router }}"
+
 - include: ironic.yml
   when: ironic.enabled|default('False')|bool
+
 - include: ceilometer.yml
   when: ceilometer.enabled|default('False')|bool
+
 - include: aodh.yml
   when: aodh.enabled|default('False')|bool

--- a/playbooks/tests/tasks/network.yml
+++ b/playbooks/tests/tasks/network.yml
@@ -50,18 +50,14 @@
   - name: neutron has the default router
     shell: . /root/stackrc; neutron router-list | grep default
 
-  - block:
-    # try ping internet for 5 minutes
-    - name: neutron router can ping internet
-      shell: ROUTER_NS=$( ip netns show | grep qrouter- | awk '{print $1}' );
-             ip netns exec ${ROUTER_NS} ping -c 5 8.8.8.8
-      when: neutron.l3ha.enabled is defined and neutron.l3ha.enabled|bool
-      register: result
-      until: result|success
-      retries: 30
-      delay: 10
-    when: ursula_os == 'ubuntu' or ansible_distribution =='CentOS'
-    #Temporarily skipping above tests on rhel until we have a fix.
+# try ping internet for 5 minutes
+  - name: neutron network namespace can ping internet
+    shell: DHCP_NS=$( ip netns show | grep qdhcp- | awk '{print $1}' );
+           ip netns exec ${DHCP_NS} ping -c 5 8.8.8.8
+    register: result
+    until: result|success
+    retries: 30
+    delay: 10
 
 - name: network tests across all network nodes
   hosts: network


### PR DESCRIPTION
Below changes are made for CI:
- enables L3HA  
- arp_responder=false, l2_population=false
- fix VM ping to take place in controller with active L3-agent
- change ping from router namespace to network namespace
