### PR TITLE
custom cafile support swift-dispersion

### DIFF
--- a/roles/openstack-setup/tasks/dispersion.yml
+++ b/roles/openstack-setup/tasks/dispersion.yml
@@ -1,4 +1,14 @@
 ---
+#FIXME swift-dispersion-populate does not support pointing to custom cafile.
+#This is an ugly hack to get self signed envs to work and should be fixed upstream.
+- name: add custom cafile support to swift simpleclient
+  replace:
+    dest: /usr/lib/python2.7/site-packages/swift/common/internal_client.py
+    regexp: 'urllib2\.urlopen\(req, timeout=timeout\)'
+    replace: >
+       urllib2.urlopen(req, cafile='{{ ssl.cafile }}', timeout=timeout)
+    when: client.self_signed_cert|default('False')|bool
+
 - name: run insecure swift dispersion populate
   command: swift-dispersion-populate --insecure
   when: client.self_signed_cert|default('False')|bool


### PR DESCRIPTION
Swift-dispersion-populate does not support custom cafiles. In self signed environments there is no way to get swift-dispersion-populate to run. This hack adds the cafile parameter to the URLlib call within the SimpleClient class. This should be addressed upstream at some point in the future. 