### PR TITLE
disable l2pop for ci-ceph-swift-rhel envs.

### DIFF
--- a/envs/example/ci-ceph-swift-rhel/group_vars/all.yml
+++ b/envs/example/ci-ceph-swift-rhel/group_vars/all.yml
@@ -35,11 +35,6 @@ haproxy:
 
 neutron:
   enable_external_interface: True
-  l2_population: True
-  enable_tunneling: True
-  tenant_network_type: vxlan
-  tunnel_types:
-    - vxlan
   allow_overlapping_ips: true
   l3ha:
     enabled: True

--- a/playbooks/tests/tasks/all.yml
+++ b/playbooks/tests/tasks/all.yml
@@ -1,5 +1,5 @@
 ---
-- name: gather some extr facts
+- name: gather some extra facts
   hosts: all
   tags: always
   tasks:


### PR DESCRIPTION
Disable l2pop until is fix or supported in ci envs.