### PR TITLE
add nova compute data out of sync check

### DIFF
--- a/roles/nova-data/tasks/monitoring.yml
+++ b/roles/nova-data/tasks/monitoring.yml
@@ -20,3 +20,10 @@
     name: "check-qemu-crash"
     check: "{{ sensu_checks.nova.check_qemu_crash }}"
   notify: restart sensu-client
+
+- name: nova compute data out of sync check
+  sensu_check: name=check-nova-compute-not-sync plugin=check-log.rb use_sudo=true
+               auto_resolve=false interval=120 occurrences=1
+               args="-f '/var/log/nova/nova-compute.log' -q 'ERROR nova.compute.manager.*Error updating resources for node' --silent"
+               state=absent
+  notify: restart sensu-client


### PR DESCRIPTION
nova compute data out of sync is a defect in mitaka version.  Add this check to remind
operator to take action. With this check an operator will be alerted and can correct the situation thus avoiding false vm boot errors (due to nova hypervisor stats out of sync)