### PR TITLE
separate individual ceph nodes check from ceph cluster check

### DIFF
--- a/roles/preflight-checks/tasks/ceph.yml
+++ b/roles/preflight-checks/tasks/ceph.yml
@@ -35,12 +35,3 @@
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
   delegate_facts: yes
   when: result_osdhosts.stdout|int < groups['ceph_osds']|length
-
-- name: fail if current ceph version is less than Jewel
-  shell: test $(ceph --version |grep -oP "\d+\.\d+\.?\d{0,3}") \>
-         "{{ preflight_checks.ceph_minimum_version }}"
-  delegate_to: "{{ item }}" 
-  with_items: 
-    - "{{ groups['ceph_monitors']|default([]) }}"
-    - "{{ groups['ceph_osds_ssd']|default([]) }}"
-

--- a/roles/preflight-checks/tasks/check_items.yml
+++ b/roles/preflight-checks/tasks/check_items.yml
@@ -25,6 +25,7 @@
   delegate_to: "{{ groups['controller'][0] }}"
   run_once: true
 
+# ceph cluster checks
 - block:
   - name: check ceph installed
     command: ceph --version
@@ -43,6 +44,21 @@
       - result_ceph_installed.rc == 0
       - result_cinder_endpoint.rc == 0
 
-  when: ceph.enabled | default('False') | bool
+  when: ceph.enabled
   tags: ['precheck_ceph']
   run_once: true
+
+# individual ceph nodes checks
+- block:
+  - name: get ceph version number
+    shell: ceph --version |grep -oP "\d+\.\d+\.?\d{0,3}"
+    failed_when: false
+    register: result
+
+  - name: fail if current ceph version is less than Jewel
+    shell: test {{ result.stdout }} \> "{{ preflight_checks.ceph_minimum_version }}"
+    when: result.rc == 0
+  when:
+    - ceph.enabled
+    - "'ceph_monitors' in group_names or 'ceph_osds' in group_names"
+  tags: ['precheck_ceph']


### PR DESCRIPTION
ceph version check fails on new osd nodes when  do scale-out, because `ceph --version` fails.

when check ceph cluster, we check on only one node(cpm1). While ceph
version check need to be done on every ceph node. For ceph scale-out,
the check should pass on new osd nodes.