### PR TITLE
enabled cinder without ceph in ci-full envs

### DIFF
--- a/envs/example/ci-full-centos/group_vars/all.yml
+++ b/envs/example/ci-full-centos/group_vars/all.yml
@@ -60,17 +60,28 @@ xtradb:
 haproxy:
   stats_group: root
 
+nova:
+  libvirt_type: kvm
+
 heat:
   enabled: True
 
 ironic:
   enabled: False
 
+glance:
+  store_smart: false
+  store_file: true
+
 cinder:
-  enabled: False
+  enabled: true
+
+lvm:
+  enabled: true
 
 # we don't enabled ceph server, but nova needs ceph client
 # so we specify ceph client version here
 ceph:
   client_version:
     rhel: 0.94.5
+

--- a/envs/example/ci-full-rhel/group_vars/all.yml
+++ b/envs/example/ci-full-rhel/group_vars/all.yml
@@ -63,6 +63,9 @@ keystone:
   uwsgi:
     method: port
 
+nova:
+  libvirt_type: kvm
+
 heat:
   enabled: True
   plugin_dirs:
@@ -72,5 +75,12 @@ heat:
 ironic:
   enabled: False
 
+glance:
+  store_smart: false
+  store_file: true
+
+lvm:
+  enabled: true
+
 cinder:
-  enabled: False
+  enabled: true

--- a/envs/example/ci-full-ubuntu/group_vars/all.yml
+++ b/envs/example/ci-full-ubuntu/group_vars/all.yml
@@ -5,10 +5,8 @@ ursula_os: 'ubuntu'
 undercloud_cidr:
   - cidr: 192.168.0.0/22
 
-ceph:
-  monitor_interface: eth0
-  enabled: false
 glance:
+  store_smart: false
   store_file: True
 primary_interface: ansible_eth0
 
@@ -74,5 +72,11 @@ heat:
 ironic:
   enabled: False
 
-cinder:
+ceph:
   enabled: false
+
+lvm:
+  enabled: true
+
+cinder:
+  enabled: true

--- a/envs/example/ci-full/group_vars/all.yml
+++ b/envs/example/ci-full/group_vars/all.yml
@@ -1,6 +1,14 @@
 ---
 stack_env: example_ci-full
 ursula_os: 'ubuntu'
+undercloud_cidr:
+  - cidr: 192.168.0.0/22
+
+primary_interface: ansible_eth0
+
+glance:
+  store_smart: false
+  store_file: True
 
 state_path_base: /opt/stack/data
 
@@ -16,13 +24,34 @@ neutron:
   lbaas:
     enabled: True
 
+common:
+  hwraid:
+    enabled: False
+
+logging:
+  enabled: true
+
 keystone:
   ldap_domain:
     enabled: True
     domain: users
+  uwsgi:
+    method: port
+
+nova:
+  libvirt_type: kvm
 
 serverspec:
   enabled: True
 
 inspec:
   enabled: False
+
+ceph:
+  enabled: false
+
+lvm:
+  enabled: true
+
+cinder:
+  enabled: true

--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -194,6 +194,9 @@ ceph:
   #  - sdd
   #bcache_ssd_device: sdg
 
+lvm:
+  enabled: false
+
 cinder:
   enabled: True
   enabled_backends: [] # rbd_volumes for Ceph

--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -11,6 +11,12 @@ cinder:
   default_backend:
   backends: []
   # determined automatically by Ceph roles
+
+  # backend   ->      available volume_type
+  # lvm       ->      LVM
+  # ceph      ->      CEPH_SSD, CEPH_HYBRID
+  # if we don't define default_volume_type, ursula will choose one by itself
+  #default_volume_type: xx # xx is one of ['LVM', 'CEPH_SSD', 'CEPH_HYBRID']
   api_workers: 5
   state_path: "{{ state_path_base }}/cinder"
   volume_type: file
@@ -30,16 +36,12 @@ cinder:
     rhel:
       - cryptsetup
       - lvm2
-      - targetcli
       - nbd
-      - iscsi-initiator-utils
+      - scsi-target-utils
       - qemu-kvm-tools
-  iscsi_helper:
-    ubuntu: tgtadm
-    rhel: targetcli
   tgt_service:
     ubuntu: tgt
-    rhel: target
+    rhel: tgtd
   iscsi_service:
     ubuntu: open-iscsi
     rhel: iscsid

--- a/roles/cinder-common/tasks/main.yml
+++ b/roles/cinder-common/tasks/main.yml
@@ -59,13 +59,17 @@
     - etype: other
       permission: r
 
-# needs to happen before 'cinder config'
-- include: ceph_integration.yml
-  when: ceph.enabled
-
 - name: error out when swift haproxy vip is not updated
   fail: msg="swift haproxy vip needs to be updated for use with cinder backup"
   when: swift.enabled|bool and (endpoints.swift.haproxy_vip == fqdn)
+
+# used in cinder.conf
+- name: fetch contents of uuid file
+  slurp: path=/etc/ceph/cinder_uuid
+  run_once: true
+  delegate_to: "{{ groups['ceph_monitors'][0] }}"
+  register: cinder_uuid_file
+  when: ceph.enabled
 
 - name: cinder config
   template: src={{ item }} dest=/etc/cinder mode=0640

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -19,13 +19,6 @@ state_path = {{ cinder.state_path }}
 rootwrap_config=/etc/cinder/rootwrap.conf
 api_paste_config = /etc/cinder/api-paste.ini
 
-{% if not ceph.enabled|bool -%}
-iscsi_helper={{ cinder.iscsi_helper[ursula_os] }}
-iscsi_ip_address = {{ primary_ip }}
-volume_group = cinder-volumes
-use_forwarded_for = true
-{% endif -%}
-
 volume_name_template = volume-%s
 auth_strategy = keystone
 
@@ -45,28 +38,43 @@ backup_driver = cinder.backup.drivers.swift
 backup_swift_url = http://{{ endpoints.swift.haproxy_vip }}:{{ endpoints.swift.port.cinder_backup }}/v1/
 {% endif -%}
 
-{% if ceph.enabled|bool -%}
-{% if cinder.common_volume_name -%}
-host = ceph
-{% endif -%}
+enabled_backends =
+{%- for backend, enabled in [('lvm', lvm.enabled),
+                            ('rbd_hybrid', ceph.enabled and ceph_pools.rbd_hybrid.enabled),
+                            ('rbd_ssd', ceph.enabled and ceph_pools.rbd_ssd.enabled)] if enabled -%}
+{{ backend + ',' }}
+{%- endfor %}
+
 
 {% if cinder.default_volume_type | default(false) -%}
 default_volume_type = {{ cinder.default_volume_type }}
 {% else %}
-default_volume_type = {{ ceph_pools[ceph_default_backend]['volume_type'] }}
+{% for volume_type, enabled in [('LVM', lvm.enabled),
+                                (ceph_pools[ceph_default_backend]['volume_type'] if ceph.enabled else '', ceph.enabled)] if enabled %}
+{% if loop.last %}
+default_volume_type = {{ volume_type }}
+{% endif %}
+{% endfor%}
 {% endif %}
 
-{% if ceph_pools.rbd_ssd.enabled and ceph_pools.rbd_hybrid.enabled -%}
-enabled_backends = rbd_hybrid,rbd_ssd
-{% elif ceph_pools.rbd_ssd.enabled -%}
-enabled_backends = rbd_ssd
-{% elif ceph_pools.rbd_hybrid.enabled -%}
-enabled_backends = rbd_hybrid
-{% endif %}
+{% if lvm.enabled -%}
+[lvm]
+volume_backend_name = lvm
+volume_driver = cinder.volume.drivers.lvm.LVMVolumeDriver
+iscsi_helper=tgtadm
+iscsi_ip_address = {{ primary_ip }}
+volume_group = cinder-volumes
+use_forwarded_for = true
+{% endif -%}
+
+{% if ceph.enabled|bool -%}
 
 {% for key, value in ceph_pools.iteritems() %}
 {% if value.enabled %}
 [{{ key }}]
+{% if cinder.common_volume_name -%}
+host = ceph
+{% endif -%}
 volume_backend_name = {{ key }}
 volume_driver = cinder.volume.drivers.rbd.RBDDriver
 rbd_pool = {{ value.pool_name }}
@@ -76,9 +84,6 @@ rbd_ceph_conf = {{ ceph.cinder.rbd_ceph_conf }}
 rbd_flatten_volume_from_snapshot = {{ ceph.cinder.rbd_flatten_volume_from_snapshot }}
 rbd_max_clone_depth = {{ ceph.cinder.rbd_max_clone_depth }}
 glance_api_version = {{ ceph.cinder.glance_api_version }}
-{% if cinder.volume_clear_size is defined -%}
-volume_clear_size = {{ cinder.volume_clear_size }}
-{% endif -%}
 {% for backend in cinder.backends %}
 {% if backend.name == key %}
 {% if backend.volume_group is defined %}

--- a/roles/cinder-data/tasks/ceph_integration.yml
+++ b/roles/cinder-data/tasks/ceph_integration.yml
@@ -31,10 +31,3 @@
     mode: 0644
     owner: cinder
     group: cinder
-
-# used in cinder.conf
-- name: fetch contents of uuid file
-  slurp: path=/etc/ceph/cinder_uuid
-  run_once: true
-  delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  register: cinder_uuid_file

--- a/roles/cinder-data/tasks/lvm_integration.yml
+++ b/roles/cinder-data/tasks/lvm_integration.yml
@@ -1,0 +1,41 @@
+---
+- name: install cinder-data required packages
+  package: name={{ item }}
+  with_items: "{{ cinder.data_pkgs[ursula_os] }}"
+  register: result
+  until: result|succeeded
+  retries: 5
+
+- name: iscsi target framework conf dir
+  file: dest=/etc/tgt/conf.d state=directory
+
+- name: tgt config files
+  template: src={{ item.value.src }} dest={{ item.value.dest }} mode=0644
+  with_dict:
+    targets:
+      src: etc/tgt/targets.conf
+      dest: /etc/tgt/targets.conf
+    cinder_tgt:
+      src: etc/tgt/conf.d/cinder_tgt.conf
+      dest: /etc/tgt/conf.d/cinder_tgt.conf
+  notify: restart tgt service
+
+- name: ensure tgt service is running
+  service: name="{{ cinder.tgt_service[ursula_os] }}" state=started enabled=true
+
+# TODO: allow for device-backed VGs in addition to file-backed VGs
+- block:
+  - name: file based cinder volume group
+    cinder_volume_group: file={{ cinder.volume_file }}
+                         size={{ cinder.volume_file_size }}
+    when: cinder.volume_type == "file"
+  
+  - name: device based cinder volume group
+    lvg:  vg={{ cinder.volume_group }} pvs={{ cinder.volume_device }}
+    when: cinder.volume_type == "device"
+  when:
+    - cinder.create_vg|bool
+    - cinder.fixed_key is not defined or (cinder.fixed_key is defined and "compute" not in group_names)
+
+- name: iscsi start
+  service: name="{{ cinder.iscsi_service[ursula_os] }}" state=started enabled=true

--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -1,36 +1,18 @@
 ---
-- name: install cinder-data required packages
-  package: name={{ item }}
-  with_items: "{{ cinder.data_pkgs[ursula_os] }}"
-  register: result
-  until: result|succeeded
-  retries: 5
+- include: lvm_integration.yml
+  when: lvm.enabled
 
-- name: iscsi target framework conf dir
-  file: dest=/etc/tgt/conf.d state=directory
+- include: ceph_integration.yml
+  when: ceph.enabled
 
-- name: tgt config files
-  template: src={{ item.value.src }} dest={{ item.value.dest }} mode=0644
-  with_dict:
-    targets:
-      src: etc/tgt/targets.conf
-      dest: /etc/tgt/targets.conf
-    cinder_tgt:
-      src: etc/tgt/conf.d/cinder_tgt.conf
-      dest: /etc/tgt/conf.d/cinder_tgt.conf
-  notify: restart tgt service
-
-- name: ensure tgt service is running
-  service: name="{{ cinder.tgt_service[ursula_os] }}" state=started
-
-- include: volume_group.yml
-  when: cinder.create_vg|bool and ( cinder.fixed_key is not defined or (cinder.fixed_key is defined and "compute" not in group_names) )
-
-- name: iscsi start
-  service: name="{{ cinder.iscsi_service[ursula_os] }}" state=started
+- name: persistent new backend
+  copy: dest=/etc/ansible/facts.d/persis_cinder_backend.fact
+        content={{ "{'lvm':%s,'ceph':%s}" % (lvm.enabled, ceph.enabled) }}
+  register: result_cinder_backend
 
 - name: enable cinder encryption
-  template: src=etc/cinder/cinder.encryption.conf dest=/etc/cinder/cinder.encryption.conf mode=0640
+  template: src=etc/cinder/cinder.encryption.conf
+            dest=/etc/cinder/cinder.encryption.conf mode=0640
             owner=root group=cinder
   notify: restart cinder services
   when: cinder.fixed_key is defined
@@ -100,7 +82,8 @@
     - restart cinder services
     - restart cinder backup service
   when: (code_has_changed | default('False') | bool and upgrade | default('False') | bool) or
-        (ceph.enabled and cephclient_upgraded|default(false))
+        (ceph.enabled and cephclient_upgraded|default(false)) or
+        result_cinder_backend.changed
 
 - meta: flush_handlers
 

--- a/roles/cinder-data/tasks/volume_group.yml
+++ b/roles/cinder-data/tasks/volume_group.yml
@@ -1,9 +1,0 @@
-# TODO: allow for device-backed VGs in addition to file-backed VGs
-- name: file based cinder volume group
-  cinder_volume_group: file={{ cinder.volume_file }}
-                       size={{ cinder.volume_file_size }}
-  when: cinder.volume_type == "file"
-
-- name: device based cinder volume group
-  lvg:  vg={{ cinder.volume_group }} pvs={{ cinder.volume_device }}
-  when: cinder.volume_type == "device"

--- a/roles/openstack-setup/tasks/cinder.yml
+++ b/roles/openstack-setup/tasks/cinder.yml
@@ -1,5 +1,5 @@
 ---
-- name: create cinder volume types
+- name: create cinder volume types(ceph backend)
   environment:
     PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
   cinder_volume_type: volume_type={{ item.value.volume_type }}
@@ -13,6 +13,19 @@
     - ceph.enabled
     - item.value.enabled
   with_dict: "{{ ceph_pools | default({}) }}"
+  run_once: true
+
+- name: create cinder volume types(lvm backend)
+  environment:
+    PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
+  cinder_volume_type: volume_type=LVM
+                      auth_url={{ endpoints.auth_uri }}
+                      login_username=admin
+                      login_password={{ secrets.admin_password }}
+                      login_tenant_name=admin
+                      extra_specs="volume_backend_name=lvm"
+                      insecure={{ insecure|default(omit) }}
+  when: lvm.enabled
   run_once: true
 
 - name: create cinder encryption volume types


### PR DESCRIPTION
Cinder is able to use lvm as backend, not only ceph.
So we can enabled cinder service for ci-full envs.

changes:
1. use kvm as accelerator instead of qemu. Otherwise, volume is not able to be attached to VM
2. move ceph integration from cinder-common to cinder-data
3. create LVM volume-type in `openstack-setupt` if lvm is the backend of cinder