### PR TITLE
pin setuptools in venv

### DIFF
--- a/roles/openstack-source/tasks/main.yml
+++ b/roles/openstack-source/tasks/main.yml
@@ -33,7 +33,7 @@
     extra_args: "{{ pip_extra_args }}"
   with_items:
     - pip
-    - setuptools
+    - setuptools>=16.0,!=24.0.0,!=34.0.0,!=34.0.1,!=34.0.2,!=34.0.3,!=34.1.0,!=34.1.1,!=34.2.0,!=34.3.0,!=34.3.1,!=34.3.2
   register: result
   until: result|succeeded
   retries: 5


### PR DESCRIPTION
There is currently a bug that is being investigated in pip/setuptools that we are running into where an existing version of a package is already installed that is different then what is defined in upper_constraints.  Pip trys to uninstall the existing package and replace it with the pinned version in contraints, but fails due to a race condition and then rolls back the install of the correct version:

Output from failed install:  

" Found existing installation: appdirs 1.4.3\n    Uninstalling appdirs-1.4.3:\n      Successfully uninstalled appdirs-1.4.3\n  Rolling back uninstall of appdirs. No such file or directory: '/opt/bbc/openstack-2016.1-mitaka/keystone/lib/python2.7/site-packages/appdirs-1.4.3.dist-info/METADATA'\n"}" 

It seems the 34.x versions of setuptools are currently affected, here is a bug that outlines what's occurring in more detail:

https://github.com/pypa/setuptools/issues/951

This fix mirrors what is being done in upstream global requirements (https://github.com/openstack/requirements/blob/stable/mitaka/global-requirements.txt#L346). 