### PR TITLE
use blockinfile to edit /etc/motd on rhel

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -155,22 +155,22 @@
 - name: drop an motd with ursula metadata for ubuntu
   template:
     src: etc/update-motd.d/90-ursula-motd
-    dest: /etc/update-motd.d/90-ursula-motd 
+    dest: /etc/update-motd.d/90-ursula-motd
     mode: 0755
   when: ursula_os == 'ubuntu'
 
-- block:
-  - name: drop an motd with ursula metadata for rhel
-    template:
-      src: etc/update-motd.d/90-ursula-motd
-      dest: /etc/90-ursula-motd
-      mode: 0755
-
-  - name: run the ursula-motd script from profile.d
-    template:
-      src: etc/profile.d/ursula-motd.sh
-      dest: /etc/profile.d/ursula-motd.sh
-      mode: 644
+- name: drop an motd with ursula metadata for rhel
+  lineinfile:
+    destfile: /etc/motd
+    regexp: "^{{ item.0 }}"
+    line: "{{ item.0 }}: {{ item.1 }}"
+  with_together:
+    - ['Ursula Node Data', 'Stack', 'Release', 'Deployed', 'Groups']
+    - - ""
+      - "{{ stack_env }}"
+      - "{{ ursula_revision }}"
+      - "{{ ansible_date_time['iso8601'] }}"
+      - "{{ group_names | join(', ') }}"
   when: ursula_os == 'rhel'
 
 - name: drop ursula release file

--- a/roles/common/templates/etc/profile.d/ursula-motd.sh
+++ b/roles/common/templates/etc/profile.d/ursula-motd.sh
@@ -1,1 +1,0 @@
-/etc/90-ursula-motd


### PR DESCRIPTION
…rather than a profile.d script that is run on every shell invocation.

The data is now surrounded by BEGIN/END lines that ansible uses to know what to edit.

The perl script is idempotent.