### PR TITLE
adjust libvirt-bin version to new version in cloudarchive repo.

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -25,7 +25,7 @@ nova:
   vnc_keymap: en-us
   scheduler_default_filters: RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,CoreFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,AggregateInstanceExtraSpecsFilter,NUMATopologyFilter
   scheduler_host_subset_size: 1
-  libvirt_bin_version: 1.3.1-1ubuntu10.6~cloud0
+  libvirt_bin_version: 1.3.1-1ubuntu10.8~cloud0
   python_libvirt_version: 1.3.1-1ubuntu1~cloud0
   qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.30
   librdb1_version: 10.2.3-0ubuntu0.16.04.2~cloud0


### PR DESCRIPTION
Adjust to libvirt-bin version bump in cloudarchive mirror.