### PR TITLE
fix ceph package dependency

### DIFF
--- a/roles/ceph-client/tasks/main.yml
+++ b/roles/ceph-client/tasks/main.yml
@@ -1,10 +1,13 @@
 ---
 - name: install ceph client
-  package: name=ceph-common{{ ceph.pkg_version_connector[ursula_os] }}{{ ceph.client_version[ursula_os] }}
+  package: name={{ item }}{{ ceph.pkg_version_connector[ursula_os] }}{{ ceph.client_version[ursula_os] }}
            state=present
   register: result_cephclient
   until: result_cephclient|succeeded
   retries: 5
+  with_items:
+    - librgw2
+    - ceph-common
 
 # set flag for ceph client upgrade
 - name: set upgrade flag true

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -47,8 +47,8 @@ nova:
   libvirt_bin_version: 1.3.1-1ubuntu10.6~cloud0
   python_libvirt_version: 1.3.1-1ubuntu1~cloud0
   qemu_kvm_version: 2.0.0+dfsg-2ubuntu1.30
-  # librdb1 version should match the ceph client version
-  librdb1_version: "{{ ceph.client_version[ursula_os] }}"
+  # librbd1 version should match the ceph client version
+  librbd1_version: "{{ ceph.client_version[ursula_os] }}"
   qemu_system_package: qemu-system-x86
   glance_endpoint: http://{{ endpoints.main }}:9393
   reserved_host_disk_mb: 51200
@@ -78,6 +78,7 @@ nova:
         - openstack-nova-console
     compute:
       project_packages:
+        - "librbd1-{{ ceph.client_version[ursula_os] }}"
         - openstack-selinux
         - openstack-nova-compute
   source:

--- a/roles/nova-data/tasks/libvirt.yml
+++ b/roles/nova-data/tasks/libvirt.yml
@@ -8,13 +8,13 @@
 - name: install nova-compute packages (ubuntu)
   package: name={{ item }}
   with_items:
+    - librbd1={{ nova.librbd1_version }}
     - cpu-checker
     - libvirt-bin={{ nova.libvirt_bin_version }}
     - python-libvirt={{ nova.python_libvirt_version }}
     - qemu-kvm={{ nova.qemu_kvm_version }}
     - "{{ nova.qemu_system_package }}={{ nova.qemu_kvm_version }}"
     - qemu-system-common={{ nova.qemu_kvm_version }}
-    - librbd1={{ nova.librdb1_version }}
     - open-iscsi
     - libvirt-dev={{ nova.libvirt_bin_version }}
     - pkg-config
@@ -30,10 +30,10 @@
 - name: install nova-compute packages
   package: name={{ item }}
   with_items:
+    - "librbd1-{{ nova.librbd1_version }}"
     - libvirt-python
     - qemu-kvm
     - "{{ nova.qemu_system_package }}"
-    - librbd1
     - libiscsi
     - iscsi-initiator-utils
     - libvirt-devel


### PR DESCRIPTION
We use ceph 10.2.3, the newest ceph version in redhat repo is 10.2.5
If we don't specify the ceph version, default 10.2.5 is installed.
So we specify ceph version in this patch.