### PR TITLE
Specify Fixed IPs When Setting Gateway

### DIFF
--- a/roles/openstack-setup/tasks/networks.yml
+++ b/roles/openstack-setup/tasks/networks.yml
@@ -66,6 +66,7 @@
                           router_name={{ item.name }}
                           network_name={{ item.ext_network|default("external") }}
                           enable_snat={{ item.enable_snat|default(true) }}
+                          fixed_ip={{ item.gateway_ip|default(omit) }}
                           auth_url={{ endpoints.auth_uri }}
                           login_tenant_name=admin
                           login_username=admin


### PR DESCRIPTION
The default router gets assigned a random IP from within the subnet allocation pool, not the second IP after gateway IP. This commit allows us to accept an optional input from all.yml to specify the fixed IP.