### PR TITLE
fix typo error

### DIFF
--- a/roles/openstack-meta/defaults/main.yml
+++ b/roles/openstack-meta/defaults/main.yml
@@ -407,7 +407,7 @@ openstack_meta:
         rhel:
           name: openstack-swift-account
           desc: OpenStack Object Storage (swift) - Account Service
-          cmd: /usr/bin/swift-account-service
+          cmd: /usr/bin/swift-account-server
           args: /etc/swift/account-server.conf
           user: swift
           restart: on-failure


### PR DESCRIPTION
to check the process name correctly. This configuration only used by
monitoring. and swift account installation for rhosp didn't use this
configuration.