### PR TITLE
allow igmp in template

### DIFF
--- a/envs/example/ci-ceph-redhat/heat_stack.yml
+++ b/envs/example/ci-ceph-redhat/heat_stack.yml
@@ -160,6 +160,9 @@ resources:
           remote_mode: 'remote_group_id'
         - ethertype: 'IPv6'
           remote_mode: 'remote_group_id'
+        - ethertype: IPv4
+          remote_ip_prefix: 192.168.0.0/22
+          protocol: igmp
         - ethertype: 'IPv4'
           remote_mode: 'remote_group_id'
           protocol: tcp

--- a/envs/example/ci-ceph-swift-rhel/heat_stack.yml
+++ b/envs/example/ci-ceph-swift-rhel/heat_stack.yml
@@ -172,6 +172,9 @@ resources:
           remote_mode: 'remote_group_id'
         - ethertype: 'IPv6'
           remote_mode: 'remote_group_id'
+        - ethertype: IPv4
+          remote_ip_prefix: 192.168.0.0/22
+          protocol: igmp
         - ethertype: 'IPv4'
           remote_mode: 'remote_group_id'
           protocol: tcp

--- a/envs/example/ci-ceph-ubuntu/heat_stack.yml
+++ b/envs/example/ci-ceph-ubuntu/heat_stack.yml
@@ -160,6 +160,9 @@ resources:
           remote_mode: 'remote_group_id'
         - ethertype: 'IPv6'
           remote_mode: 'remote_group_id'
+        - ethertype: IPv4
+          remote_ip_prefix: 192.168.0.0/22
+          protocol: igmp
         - ethertype: 'IPv4'
           remote_mode: 'remote_group_id'
           protocol: tcp

--- a/envs/example/ci-full-centos/heat_stack.yml
+++ b/envs/example/ci-full-centos/heat_stack.yml
@@ -126,16 +126,19 @@ resources:
           protocol: icmp
         - ethertype: 'IPv4'
           remote_mode: 'remote_group_id'
+        - ethertype: 'IPv6'
+          remote_mode: 'remote_group_id'
+        - ethertype: IPv4
+          remote_ip_prefix: 192.168.0.0/22
+          protocol: igmp
+        - ethertype: 'IPv4'
+          remote_mode: 'remote_group_id'
           protocol: tcp
         - ethertype: 'IPv4'
           remote_mode: 'remote_group_id'
           protocol: udp
         - ethertype: 'IPv4'
           remote_mode: 'remote_group_id'
-          protocol: igmp
-        - ethertype: IPv4
-          remote_ip_prefix: 192.168.0.0/22
-          protocol: igmp
 
   ssh_keypair:
     type: OS::Nova::KeyPair

--- a/envs/example/ci-full-ubuntu/heat_stack.yml
+++ b/envs/example/ci-full-ubuntu/heat_stack.yml
@@ -136,6 +136,9 @@ resources:
           remote_mode: 'remote_group_id'
         - ethertype: 'IPv6'
           remote_mode: 'remote_group_id'
+        - ethertype: IPv4
+          remote_ip_prefix: 192.168.0.0/22
+          protocol: igmp
         - ethertype: 'IPv4'
           remote_mode: 'remote_group_id'
           protocol: tcp


### PR DESCRIPTION
Without igmp, multicast is not supported. It means many things don't work, .e.g vxlan, vrrp
In the openstack which deploy on tardis by using VMs, the router on both controller nodes are active, because vrrp is not supported.
We can't get connect to VMs, because vxlan is not supported.

This patch is to add igmp in all envs, it was only in ci-full-centos and ci-full-rhel.