### PR TITLE
Add more checks from inspec-openstack-security 

### DIFF
--- a/roles/aodh/meta/main.yml
+++ b/roles/aodh/meta/main.yml
@@ -2,6 +2,12 @@
 dependencies:
   - role: openstack-meta
   - role: endpoints
+  - role: inspec
+    install_inspec_controls: [aodh]
+    tags: inspec
+    when:
+      - inspec.enabled|bool
+      - inspec.controls.aodh.enabled|bool
   - role: openstack-source
     project_name: aodh
     project_rev: "{{ aodh.source.rev }}"

--- a/roles/ceilometer-common/meta/main.yml
+++ b/roles/ceilometer-common/meta/main.yml
@@ -8,6 +8,12 @@ dependencies:
     when: logging.enabled|default(True)|bool
     service: ceilometer
     logdata: "{{ ceilometer.logs }}"
+  - role: inspec
+    install_inspec_controls: [ceilometer]
+    tags: inspec
+    when:
+      - inspec.enabled|bool
+      - inspec.controls.ceilometer.enabled|bool
   - role: openstack-source
     project_name: ceilometer
     project_rev: "{{ ceilometer.source.rev }}"

--- a/roles/glance/meta/main.yml
+++ b/roles/glance/meta/main.yml
@@ -1,5 +1,11 @@
 ---
 dependencies:
+  - role: inspec
+    install_inspec_controls: [glance]
+    tags: inspec
+    when:
+      - inspec.enabled|bool
+      - inspec.controls.glance.enabled|bool
   - role: openstack-meta
   - role: endpoints
   - role: monitoring-common

--- a/roles/heat/meta/main.yml
+++ b/roles/heat/meta/main.yml
@@ -8,6 +8,12 @@ dependencies:
     when: logging.enabled|default(True)|bool
     service: heat
     logdata: "{{ heat.logs }}"
+  - role: inspec
+    install_inspec_controls: [heat]
+    tags: inspec
+    when:
+      - inspec.enabled|bool
+      - inspec.controls.heat.enabled|bool
   - role: openstack-source
     project_name: heat
     project_rev: "{{ heat.source.rev }}"

--- a/roles/inspec/defaults/main.yml
+++ b/roles/inspec/defaults/main.yml
@@ -57,10 +57,34 @@ inspec:
     glance:
       enabled: true
       profile: openstack_security
+      attributes:
+        glance_config_files:
+          - glance_api_audit_map.conf
+          - glance-api-paste.ini
+          - glance-api.conf
+          - glance-cache.conf
+          - glance-glare.conf
+          - glance-registry-paste.ini
+          - glance-registry.conf
+          - glance-scrubber.conf
+          - glance-swift-store.conf
+          - policy.json
+          - schema-image.json
       required_controls:
+        - check-image-01
+        - check-image-02
         - check-image-03
         - check-image-04
-    nova:
+    nova_data:
+      enabled: true
+      profile: openstack_security
+      required_controls:
+        - check-compute-01
+        - check-compute-02
+        - check-compute-03
+        - check-compute-04
+        - check-compute-05
+    nova_control:
       enabled: true
       profile: openstack_security
       required_controls:
@@ -78,7 +102,7 @@ inspec:
         - check-identity-04
         - check-identity-05
         - check-identity-06
-    neutron:
+    neutron_data:
       enabled: true
       profile: openstack_security
       required_controls:
@@ -86,3 +110,40 @@ inspec:
         - check-neutron-02
         - check-neutron-03
         - check-neutron-04
+    neutron_control:
+      enabled: true
+      profile: openstack_security
+      required_controls:
+        - check-neutron-01
+        - check-neutron-02
+        - check-neutron-03
+        - check-neutron-04
+        - check-neutron-05
+    heat:
+      enabled: true
+      attributes:
+        heat_enabled: true
+      profile: openstack_security
+      required_controls:
+        - check-orchestration-01
+        - check-orchestration-02
+        - check-orchestration-03
+    ceilometer:
+      enabled: true
+      profile: openstack_security
+      attributes:
+        ceilometer_enabled: true
+      required_controls:
+        - check-telemetry-01
+        - check-telemetry-02
+        - check-telemetry-03
+        - check-telemetry-04
+    aodh:
+      enabled: true
+      profile: openstack_security
+      attributes:
+        aodh_enabled: true
+      required_controls:
+        - check-telemetry-alarming-01
+        - check-telemetry-alarming-02
+        - check-telemetry-alarming-03

--- a/roles/inspec/templates/etc/inspec/host-controls/attributes.yml
+++ b/roles/inspec/templates/etc/inspec/host-controls/attributes.yml
@@ -1,7 +1,14 @@
 {% for profile_name,profile in inspec.controls.iteritems() %}
 {% if profile.enabled|default('False')|bool and profile.attributes is defined %}
 {% for name,value in profile.attributes.iteritems() %}
+{% if value is iterable and value is not string %}
+{{ name }}:
+{% for list_item in value %}
+  - {{ list_item }}
+{% endfor %}
+{% else %}
 {{ name }}: {{ value }}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% endfor %}

--- a/roles/neutron-control/meta/main.yml
+++ b/roles/neutron-control/meta/main.yml
@@ -2,6 +2,12 @@
 dependencies:
   - role: openstack-database
     database_name: neutron
+  - role: inspec
+    install_inspec_controls: [neutron_control]
+    tags: inspec
+    when:
+      - inspec.enabled|bool
+      - inspec.controls.neutron_control.enabled|bool
   - role: neutron-common
   - role: sensu-check
   - role: collectd-plugin

--- a/roles/neutron-data/meta/main.yml
+++ b/roles/neutron-data/meta/main.yml
@@ -6,6 +6,12 @@ dependencies:
         key_url: '{{ apt_repos.bbg_openstack_ppa.key_url }}'
     when: ansible_distribution_version == "12.04"
   - role: sensu-check
+  - role: inspec
+    install_inspec_controls: [neutron_data]
+    tags: inspec
+    when:
+      - inspec.enabled|bool
+      - inspec.controls.neutron_data.enabled|bool
   - role: neutron-common
   - role: openstack-firewall
     rule_name: VXLAN

--- a/roles/nova-control/meta/main.yml
+++ b/roles/nova-control/meta/main.yml
@@ -1,5 +1,11 @@
 ---
 dependencies:
+  - role: inspec
+    install_inspec_controls: [nova_control]
+    tags: inspec
+    when:
+      - inspec.enabled|bool
+      - inspec.controls.nova_control.enabled|bool
   - role: nova-common
   - role: openstack-database
     database_name: nova

--- a/roles/nova-data/meta/main.yml
+++ b/roles/nova-data/meta/main.yml
@@ -1,5 +1,12 @@
 ---
 dependencies:
+  - role: inspec
+    install_inspec_controls:
+      - nova_data
+    tags: inspec
+    when:
+      - inspec.enabled|bool
+      - inspec.controls.nova_data.enabled|bool
   - role: nova-common
   - role: docker
     when: nova.compute_driver == "novadocker.virt.docker.DockerDriver"


### PR DESCRIPTION
This refactors the openstack checks to be set up in the inspec meta
role for glance, neutron, nova. It also adds additional checks for
aodh, ceilometer, and heat. More checks for glance was also added
and the list of glance configuration files has been added as well.