### PR TITLE
skip installing hwraid clients for rhosp.

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -133,7 +133,10 @@
 - include: disable-swap.yml
 
 - include: hwraid.yml
-  when: common.hwraid.enabled and ansible_architecture != "ppc64le"
+  when:
+    - common.hwraid.enabled
+    - ansible_architecture != "ppc64le"
+    - ursula_os == 'ubuntu'
   tags: hwraid
 
 - include: hwraid-ppc.yml


### PR DESCRIPTION
We do not need to install hwraid clients on rhel as our environment comes with storcli installed.