### PR TITLE
Add checks from ursula-inspec

### DIFF
--- a/roles/inspec/defaults/main.yml
+++ b/roles/inspec/defaults/main.yml
@@ -16,6 +16,10 @@ inspec:
       name: inspec-stig-rhel7
       version: master
       url: https://github.com/inspec-stigs/inspec-stig-rhel7/archive/master.tar.gz
+    ursula-inspec:
+      name: ursula-inspec
+      version: master
+      url: https://github.com/blueboxgroup/ursula-inspec/archive/master.tar.gz
   controls:
     rhel7:
       enabled: true
@@ -147,3 +151,44 @@ inspec:
         - check-telemetry-alarming-01
         - check-telemetry-alarming-02
         - check-telemetry-alarming-03
+    kvm:
+      enabled: true
+      profile: ursula-inspec
+      required_controls:
+        - KVM001
+        - KVM002
+        - KVM003
+        - KVM004
+    mongodb:
+      enabled: true
+      profile: ursula-inspec
+      required_controls:
+        - MON001
+        - MON002
+        - MON003
+        - MON004
+        - MON005
+        - MON006
+        - MON007
+        - MON008
+    mysql:
+      enabled: true
+      profile: ursula-inspec
+      required_controls:
+        - MYSQL001
+        - MYSQL002
+        - MYSQL003
+        - MYSQL004
+        - MYSQL005
+        - MYSQL006
+    rabbitmq:
+      enabled: true
+      profile: ursula-inspec
+      required_controls:
+        - RABBITMQ001
+        - RABBITMQ002
+        - RABBITMQ003
+        - RABBITMQ004
+        - RABBITMQ005
+        - RABBITMQ006
+        - RABBITMQ007

--- a/roles/mongodb-common/meta/main.yml
+++ b/roles/mongodb-common/meta/main.yml
@@ -7,6 +7,12 @@ dependencies:
     when: logging.enabled|default(True)|bool
     service: mongodb
     logdata: "{{ mongodb.logs }}"
+  - role: inspec
+    install_inspec_controls: [mongodb]
+    tags: inspec
+    when:
+      - inspec.enabled|bool
+      - inspec.controls.mongodb.enabled|bool
   - role: apt-repos
     repos:
       - repo: 'deb {{ apt_repos.mongodb.repo }} {{ ansible_distribution_release }}/mongodb-org/3.0 multiverse'

--- a/roles/nova-data/meta/main.yml
+++ b/roles/nova-data/meta/main.yml
@@ -7,6 +7,13 @@ dependencies:
     when:
       - inspec.enabled|bool
       - inspec.controls.nova_data.enabled|bool
+  - role: inspec
+    install_inspec_controls:
+      - kvm
+    tags: inspec
+    when:
+      - inspec.enabled|bool
+      - inspec.controls.kvm.enabled|bool
   - role: nova-common
   - role: docker
     when: nova.compute_driver == "novadocker.virt.docker.DockerDriver"

--- a/roles/percona-server/meta/main.yml
+++ b/roles/percona-server/meta/main.yml
@@ -3,6 +3,12 @@ dependencies:
   - role: monitoring-common
     when: monitoring.enabled|default(True)|bool
   - role: sensu-check
+  - role: inspec
+    install_inspec_controls: [mysql]
+    tags: inspec
+    when:
+      - inspec.enabled|bool
+      - inspec.controls.mysql.enabled|bool
   - role: logging-config
     when: logging.enabled|default(True)|bool
     service: mysql

--- a/roles/rabbitmq/meta/main.yml
+++ b/roles/rabbitmq/meta/main.yml
@@ -13,5 +13,11 @@ dependencies:
     when: logging.enabled|default(True)|bool
     service: rabbitmq
     logdata: "{{ rabbitmq.logs }}"
+  - role: inspec
+    install_inspec_controls: [rabbitmq]
+    tags: inspec
+    when:
+      - inspec.enabled|bool
+      - inspec.controls.rabbitmq.enabled|bool
   - role: collectd-plugin
     when: collectd is defined and collectd.enabled|bool


### PR DESCRIPTION
Inspec checks from ursula-inspec have been added.
This includes mongodb, kvm, mysql, and rabbitmq.

This depends on https://github.com/blueboxgroup/ursula-inspec/pull/5
This is in conflict and needs to be rebased with https://github.com/blueboxgroup/ursula/pull/2632.