### PR TITLE
update nova endpoint url's to v2.1

### DIFF
--- a/library/keystone_service.py
+++ b/library/keystone_service.py
@@ -180,8 +180,19 @@ def ensure_endpoint_present(keystone, name, public_url, internal_url,
         # Endpoint doesn't exist yet, we'll need to create one
         pass
     else:
-        # endpoints can't be updated with this module (v2 API)
-        return (False, endpoint.id)
+        # Re-create endpoint if endpoint urls do not match
+        # Note: Keystone v2.0 endpoint is created outside of this library by
+        # keystone-manage bootstrap so them them alone
+        if ( (name != 'keystone') and (endpoint.adminurl != admin_url or
+            endpoint.internalurl != internal_url or
+            endpoint.publicurl != public_url) ):
+            # Existing endpoint does not match with passed endpoint arguments
+            keystone.endpoints.delete(endpoint.id)
+            # Clear out endpoint to get it recreated with passed information
+            endpoint = None
+        else:
+            # endpoints can't be updated with this module (v2 API)
+            return (False, endpoint.id)
 
     # At this point, we know we will need to make a change
     if check_mode:

--- a/roles/endpoints/defaults/main.yml
+++ b/roles/endpoints/defaults/main.yml
@@ -12,12 +12,12 @@ endpoints:
     name: nova
     type: compute
     description: Compute Service
-    version: v2
+    version: v2.1
     url:
       admin: https://{{ fqdn }}:8774
       internal: https://{{ fqdn }}:8774
       public: https://{{ fqdn }}:8774
-      path: v2/%(project_id)s
+      path: v2.1/%(project_id)s
     port:
       backend_api: 9774
       haproxy_api: 8774


### PR DESCRIPTION
For newton release our nova api endpoints url's should be v2.1 to take advantage of api micro-version 2.1 and up. 

This PR will recreate endpoint if url's are different and up the endpoint definition for nova to use v2.1 in endpoint urls.

The library will skip checking keystone endpoint as it is created outside of the library via keystone-setup role using keystone-manage bootstrap and does not include /v2.0 in url. Also, we cannot delete/create keystone endpoint in library as keystone client used by library depends on this endpoint. 