### PR TITLE
specify librbd version for ci-full-centos

### DIFF
--- a/envs/example/ci-full-centos/group_vars/all.yml
+++ b/envs/example/ci-full-centos/group_vars/all.yml
@@ -68,3 +68,9 @@ ironic:
 
 cinder:
   enabled: False
+
+# we don't enabled ceph server, but nova needs ceph client
+# so we specify ceph client version here
+ceph:
+  client_version:
+    rhel: 0.94.5


### PR DESCRIPTION
As repos of centos doesn't have librbd1-10.2.3, we use specify
librbd1-0.94.5 to be installed.