### PR TITLE
Fix neutron services scripts

### DIFF
--- a/roles/neutron-common/templates/usr/local/bin/neutron-restart-all
+++ b/roles/neutron-common/templates/usr/local/bin/neutron-restart-all
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-restart {{ neutron.services.neutron_server.name }}
-restart {{ neutron.services.neutron_linuxbridge_agent.name }}
-restart {{ neutron.services.neutron_metadata_agent.name }}
+service {{ neutron.services.neutron_server.name }} restart
+service {{ neutron.services.neutron_linuxbridge_agent.name }} restart
+service {{ neutron.services.neutron_metadata_agent.name }} restart
 
 # neutron-dhcp-agent and neutron-l3-agent will be restarted
 # when neutron-linuxbridge-agent is restarted due to service deps

--- a/roles/neutron-common/templates/usr/local/bin/neutron-start-all
+++ b/roles/neutron-common/templates/usr/local/bin/neutron-start-all
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-start {{ neutron.services.neutron_server.name }}
-start {{ neutron.services.neutron_linuxbridge_agent.name }}
-start {{ neutron.services.neutron_metadata_agent.name }}
+service {{ neutron.services.neutron_server.name }} start
+service {{ neutron.services.neutron_linuxbridge_agent.name }} start
+service {{ neutron.services.neutron_metadata_agent.name }} start
 
 # neutron-dhcp-agent and neutron-l3-agent will be started
 # when neutron-linuxbridge-agent is started due to service deps

--- a/roles/neutron-common/templates/usr/local/bin/neutron-stop-all
+++ b/roles/neutron-common/templates/usr/local/bin/neutron-stop-all
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-stop {{ neutron.services.neutron_server.name }}
-stop {{ neutron.services.neutron_linuxbridge_agent.name }}
-stop {{ neutron.services.neutron_metadata_agent.name }}
+service {{ neutron.services.neutron_server.name }} stop
+service {{ neutron.services.neutron_linuxbridge_agent.name }} stop
+service {{ neutron.services.neutron_metadata_agent.name }} stop
 
 # neutron-dhcp-agent and neutron-l3-agent will be stopped
 # when neutron-linuxbridge-agent is stopped due to service deps


### PR DESCRIPTION
neutron services start/stop/restart scripts need to use `service <service_name> start|stop|restart` syntax for it to be compatible with Red Hat/CentOS and Ubuntu