### PR TITLE
Update nova files to be compliant with inspecs

### DIFF
--- a/roles/inspec/defaults/main.yml
+++ b/roles/inspec/defaults/main.yml
@@ -87,7 +87,6 @@ inspec:
         - check-compute-02
         - check-compute-03
         - check-compute-04
-        - check-compute-05
     nova_control:
       enabled: true
       profile: openstack_security

--- a/roles/nova-data/tasks/libvirt.yml
+++ b/roles/nova-data/tasks/libvirt.yml
@@ -96,6 +96,22 @@
       line: "listen_tls = 0"
   notify: restart libvirt-bin
 
+- name: update variables in libvirtd.conf for compliance
+  ini_file:
+    dest: /etc/libvirt/libvirtd.conf
+    section: ~
+    option: '{{ item.option }}'
+    value: '{{ item.value }}'
+  with_items:
+    - option: 'unix_sock_group'
+      value: '"libvirt"'
+    - option: 'unix_sock_ro_perms'
+      value: '"0770"'
+    - option: 'unix_sock_rw_perms'
+      value: '"0770"'
+  notify: restart libvirt-bin
+  when: ursula_os == 'rhel'
+
 - name: remove libvirtd defaults
   lineinfile:
     dest: "{{ nova.libvirt[ursula_os].defaults }}"
@@ -110,6 +126,20 @@
     regexp: '^allow_incoming_qemukvm\s*='
     line: 'allow_incoming_qemukvm = 1'
   notify: restart libvirt-bin
+
+- name: update qemu options for compliance
+  ini_file:
+    dest: /etc/libvirt/qemu.conf
+    section: ~
+    option: '{{ item.option }}'
+    value: '{{ item.value }}'
+  with_items:
+    - option: 'user'
+      value: '"qemu"'
+    - option: 'group'
+      value: '"qemu"'
+  notify: restart libvirt-bin
+  when: ursula_os == 'rhel'
 
 - name: ensure kvm is supported by cpu and enabled in bios (ubuntu)
   command: kvm-ok

--- a/roles/nova-data/tasks/main.yml
+++ b/roles/nova-data/tasks/main.yml
@@ -132,3 +132,9 @@
   tags:
     - serverspec
   when: serverspec.enabled|default('False')|bool
+
+- name: /dev/kvm permissions should be 0660 for compliance
+  file:
+    dest: /dev/kvm
+    mode: 0660
+  when: ursula_os == 'rhel'


### PR DESCRIPTION
This sets up libvirt files to be compliant with our inspec checks. This
also drops the check for the secure glance endpoint.

This is similar to the closed PR: https://github.com/blueboxgroup/ursula/pull/2638
I couldn't reopen the previous PR.