### PR TITLE
set the default check for ClientAliveInterval to be 1800 sec

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -598,6 +598,8 @@ common:
   ntpd:
     servers: []
     #  - servertime.service.softlayer.com
+  ssh:
+    client_alive_interval: 1800
 
 heat:
   enabled: True

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -29,6 +29,7 @@ common:
     #  - ::/0
     disable_root: False
     disable_dns: True
+    client_alive_interval: 1800
   pip_version: 8.0.2
   setuptools_version: system
   ursula_monitoring:

--- a/roles/common/templates/etc/sshd_config
+++ b/roles/common/templates/etc/sshd_config
@@ -115,6 +115,6 @@ GatewayPorts no
 UseDNS no
 {% endif %}
 
-ClientAliveInterval 1800
+ClientAliveInterval {{ common.ssh.client_alive_interval }}
 ClientAliveCountMax 0
 Compression delayed

--- a/roles/inspec/defaults/main.yml
+++ b/roles/inspec/defaults/main.yml
@@ -27,7 +27,7 @@ inspec:
       skip_controls: []
       attributes:
         RHEL_07_030710_audit_key_name: audit_account_changes-V-38531
-        client_alive_interval: '900'
+        client_alive_interval: "{{ common.ssh.client_alive_interval }}"
         RHEL_07_030523_audit_key_name: actions-V-38578
     horizon:
       enabled: true


### PR DESCRIPTION
This is the default timeout value for ssh sessions that is set. Matching the inspec check to look for this value otherwise the check will fail.