### PR TITLE
enable admin access to glance location apis.

### DIFF
--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -7,6 +7,7 @@ glance:
   rsync:
     service: "{{ ( ursula_os == 'ubuntu' ) | ternary('rsync', 'rsyncd') }}"
     defaults: "{{ ( ursula_os == 'ubuntu' ) | ternary('/etc/default/rsync', '/etc/sysconfig/rsyncd') }}"
+  allow_image_locations: False
   api_workers: 5
   rbd_store_chunk_size: 8
   registry_workers: 5

--- a/roles/glance/templates/etc/glance/glance-api.conf
+++ b/roles/glance/templates/etc/glance/glance-api.conf
@@ -24,6 +24,7 @@ log_dir = /var/log/glance
 use_stderr = false
 
 image_cache_dir = {{ glance.state_path }}/image-cache
+show_multiple_locations = True
 
 registry_host = 0.0.0.0
 registry_port = 9191

--- a/roles/glance/templates/etc/glance/policy.json
+++ b/roles/glance/templates/etc/glance/policy.json
@@ -15,9 +15,14 @@
     "download_image": "",
     "upload_image": "",
 
-    "delete_image_location": "",
     "get_image_location": "",
+{% if glance.allow_image_locations|default('False')|bool %}
+    "delete_image_location": "",
     "set_image_location": "",
+{% else %}
+    "delete_image_location": "role:admin or role:cloud_admin",
+    "set_image_location": "role:admin or role:cloud_admin",
+{% endif %}
 
     "add_member": "",
     "delete_member": "",


### PR DESCRIPTION
This change restricts set_locations and delete_locations to admin and cloud_admin. In addition, it allows ability to extend set_locations and delete_locations to all via attribute in all.yml.

For glance member-create to function without 403 get_locations needs to be available to all.