### PR TITLE
fix ntp config to pass the RHEL STIG inspec checks

### DIFF
--- a/roles/common/templates/etc/ntp.conf
+++ b/roles/common/templates/etc/ntp.conf
@@ -13,7 +13,7 @@ filegen clockstats file clockstats type day enable
 
 # Specify one or more NTP servers.
 {% for server in common.ntpd.servers %}
-server {{ server }} iburst
+server {{ server }} iburst maxpoll 10
 {% endfor %}
 
 # Access control configuration; see /usr/share/doc/ntp-doc/html/accopt.html for


### PR DESCRIPTION
Adds the maxpoll parameter to the servers in the ntp.conf
maxpoll value is required to be set to 10, which is also the
default. If not set the STIG check fails