### PR TITLE
fix monitoring handler missing in ceph-client

### DIFF
--- a/roles/ceph-client/meta/main.yml
+++ b/roles/ceph-client/meta/main.yml
@@ -6,3 +6,5 @@ dependencies:
         key_package: ubuntu-cloud-keyring
     when: ursula_os == 'ubuntu'
   - role: ceph-config
+  - role: monitoring-common
+    when: monitoring.enabled|default(True)|bool


### PR DESCRIPTION
Deployment failed when it could not find handler to restart sensu-client
in ceph-client in the inspec role