### PR TITLE
handle inspec/serverspec enablement within each ci envs.

### DIFF
--- a/envs/example/allinone-centos/group_vars/all.yml
+++ b/envs/example/allinone-centos/group_vars/all.yml
@@ -62,9 +62,6 @@ logging:
     host: 127.0.0.1
     port: 4560
 
-serverspec:
-  enabled: false
-
 xtradb:
   galera_version: 3
   client_version: 56

--- a/envs/example/allinone-rhel/group_vars/all.yml
+++ b/envs/example/allinone-rhel/group_vars/all.yml
@@ -65,9 +65,6 @@ logging:
     host: 127.0.0.1
     port: 4560
 
-serverspec:
-  enabled: false
-
 xtradb:
   galera_version: 3
   client_version: 56

--- a/envs/example/allinone/group_vars/all.yml
+++ b/envs/example/allinone/group_vars/all.yml
@@ -12,7 +12,6 @@ percona:
 neutron:
   enable_external_interface: True
 
-
 sensu_checks:
     percona:
       check_cluster_size:

--- a/envs/example/ci-ceph-redhat/group_vars/all.yml
+++ b/envs/example/ci-ceph-redhat/group_vars/all.yml
@@ -56,8 +56,8 @@ logging:
     host: 127.0.0.1
     port: 4560
 
-serverspec:
-  enabled: false
+inspec:
+  enabled: True
 
 xtradb:
   galera_version: 3

--- a/envs/example/ci-ceph-ubuntu/group_vars/all.yml
+++ b/envs/example/ci-ceph-ubuntu/group_vars/all.yml
@@ -53,7 +53,7 @@ logging:
     port: 4560
 
 serverspec:
-  enabled: false
+  enabled: True
 
 haproxy:
   stats_group: root

--- a/envs/example/ci-ceph_swift/group_vars/all.yml
+++ b/envs/example/ci-ceph_swift/group_vars/all.yml
@@ -21,7 +21,7 @@ neutron:
     min_agents: 2
     cidr: 169.254.192.0/18
     password: "{{ secrets.service_password }}"
-    interval: 2  
+    interval: 2
   lbaas:
     enabled: True
 

--- a/envs/example/ci-full-centos/group_vars/all.yml
+++ b/envs/example/ci-full-centos/group_vars/all.yml
@@ -49,8 +49,8 @@ logging:
     host: 127.0.0.1
     port: 4560
 
-serverspec:
-  enabled: false
+inspec:
+  enabled: True
 
 xtradb:
   galera_version: 3

--- a/envs/example/ci-full-rhel/group_vars/all.yml
+++ b/envs/example/ci-full-rhel/group_vars/all.yml
@@ -48,8 +48,8 @@ logging:
     host: 127.0.0.1
     port: 4560
 
-serverspec:
-  enabled: false
+inspec:
+  enabled: True
 
 xtradb:
   galera_version: 3

--- a/envs/example/ci-full-ubuntu/group_vars/all.yml
+++ b/envs/example/ci-full-ubuntu/group_vars/all.yml
@@ -53,7 +53,7 @@ logging:
     port: 4560
 
 serverspec:
-  enabled: false
+  enabled: True
 
 haproxy:
   stats_group: root

--- a/envs/example/ci-full/group_vars/all.yml
+++ b/envs/example/ci-full/group_vars/all.yml
@@ -23,3 +23,6 @@ keystone:
 
 serverspec:
   enabled: True
+
+inspec:
+  enabled: False

--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -653,7 +653,7 @@ serverspec:
   enabled: False
 
 inspec:
-  enabled: true
+  enabled: False
 
 #openstack-ansible-security overrides
 security_enable_chrony: false
@@ -677,4 +677,4 @@ security_audit_DAC_lsetxattr: yes                  # V-38561
 security_audit_DAC_setxattr: yes                   # V-38565
 security_audit_deletions: yes                      # V-38575
 security_audit_failed_access: yes                  # V-38566
-security_enable_grub_update: no 
+security_enable_grub_update: no


### PR DESCRIPTION
Currently envs/examples/defaults-2.0.yml has inspec set to true. Inspecs is not applicable for ubuntu ci envs. This PR defaults serverspec and inspec to false in defaults-2.0.yml and handles enablement at each ci envs group_vars/all.yml