### PR TITLE
increase pg number in small step

### DIFF
--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -70,6 +70,11 @@ ceph:
     - parted
   bcache_pkgs:
     - bcache-tools
+  bbg_ceph_utils_pkg: {}
+  # bbg_ceph_utils_pkg:
+  #   name: bbg-ceph-utils
+  #   version: ~
+  #   pip_extra_args: ~
   # ubuntu and redhat have different package version connector.
   # for ceph as example
   #   ubuntu: apt-get install ceph-common=10.2.3
@@ -78,6 +83,10 @@ ceph:
     ubuntu: "="
     rhel: "-"
 
+  target_pgs_per_osd: 200
+  max_pgs_per_osd: 300
+  adjust_inveral: 5 # minutes
+
   # Ceph options
   cephx: true
   cephx_require_signatures: true # Kernel RBD does NOT support signatures for Kernels < 3.18!
@@ -85,6 +94,7 @@ ceph:
   cephx_service_require_signatures: false
   max_open_files: 131072
   disable_in_memory_logs: true # set this to false while enabling the options below
+  mon_osd_max_split_count: 32
 
   # Debug logs
   enable_debug_global: false

--- a/roles/ceph-monitor/tasks/main.yml
+++ b/roles/ceph-monitor/tasks/main.yml
@@ -104,6 +104,28 @@
 
 - include: restart_flags.yml
 
+# setup ceph-utils
+- block:
+  - name: create config directory for ceph_utils
+    file: path=/etc/bbg-ceph-utils state=directory
+
+  - name: setup config file for ceph_utils
+    template: src=etc/bbg-ceph-utils/ceph-utils.conf
+              dest=/etc/bbg-ceph-utils/ceph-utils.conf
+
+  - name: install ceph_utils module
+    pip: name={{ ceph.bbg_ceph_utils_pkg.name }}
+         version={{ ceph.bbg_ceph_utils_pkg.version|default(omit) }}
+         virtualenv={{ basevenv|default(omit)  }}
+         extra_args={{ ceph.bbg_ceph_utils_pkg.pip_extra_args|default(omit) }}
+    no_log: true
+
+  - name: add cron to adjust ceph pg number
+    cron: name='ceph-utils' minute='*/{{ ceph.adjust_inveral }}'
+          job='{{ basevenv+"/bin/" if basevenv else "" }}ceph-utils adjust-all'
+          cron_file='ceph_utils' user=root
+  when: ceph.bbg_ceph_utils_pkg
+
 - include: monitoring.yml
   tags:
     - monitoring

--- a/roles/ceph-monitor/templates/etc/bbg-ceph-utils/ceph-utils.conf
+++ b/roles/ceph-monitor/templates/etc/bbg-ceph-utils/ceph-utils.conf
@@ -1,0 +1,16 @@
+# {{ ansible_managed }}
+[default]
+# ceph pool size
+pool_default_size = {{ ceph.pool_default_size }}
+
+# how many pgs do we want to place on each osd
+target_pgs_per_osd = {{ ceph.target_pgs_per_osd }}
+
+# PGs number on each osd will never exceed this value
+max_pgs_per_osd = {{ ceph.max_pgs_per_osd }}
+
+# max PG number we can increase in one time
+mon_osd_max_split_count = {{ ceph.mon_osd_max_split_count }}
+
+# number PGs to increase in one round
+step_length = 4


### PR DESCRIPTION
ceph wants pg number be power of 2(good for cursh).
So if we increase pg number from 1024, the next number will be 2048.
Increasing so many pg numbers will cause much data rebalancing.
This patch is to increase pg number in small step