### PR TITLE
remove ntp server configuration in defaults.yml

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -595,9 +595,9 @@ common:
     method: tar # git|tar
     tar_url: https://file-mirror.openstack.blueboxgrid.com/ursula-monitoring/master.tar.gz
     tar_version: master
-  ntpd:
-    servers: []
-    #  - servertime.service.softlayer.com
+#  ntpd:
+#    servers: []
+#      - servertime.service.softlayer.com
   ssh:
     client_alive_interval: 1800
 


### PR DESCRIPTION
default ntp servers are configured in [roles/common/defaults/main.yml](https://github.com/blueboxgroup/ursula/blob/master/roles/common/defaults/main.yml#L13), while
[defatuls-2.0.yml](https://github.com/blueboxgroup/ursula/blob/master/envs/example/defaults-2.0.yml#L598) overwrites it with empty value. This causes that no ntp
server is configured. I have seen ceph clock skews because of no ntp
server configured.

This patch is to remove ntp server configuration in defaults.yml