### PR TITLE
if we're installing snmp, ensure we're not allowing v1,v2 etc

### DIFF
--- a/roles/ceilometer-common/tasks/main.yml
+++ b/roles/ceilometer-common/tasks/main.yml
@@ -34,6 +34,16 @@
     mode: 0640
   when: inventory_hostname in groups['controller']
 
+- name: remove v1,v2,etc from snmpd config file
+  lineinfile:
+    dest: /etc/snmp/snmpd.conf
+    regexp: "^{{ item }}"
+    line: "# {{ item }}"
+  with_items:
+    - "com2sec notConfigUser  default       public"
+    - "group   notConfigGroup v1           notConfigUser"
+    - "group   notConfigGroup v2c           notConfigUser"
+
 - include: logging.yml
   tags:
     - logrotate


### PR DESCRIPTION
net-snmp is installed via ceilometer dependency on controller and compute nodes. The PR ensure that part of ceilometer role  snmpd.conf is adjust to not allow v1,v2 etc.