### PR TITLE
Skip inspec checks for /dev/kvm

### DIFF
--- a/roles/inspec/defaults/main.yml
+++ b/roles/inspec/defaults/main.yml
@@ -261,7 +261,6 @@ inspec:
       profile: ursula-inspec
       required_controls:
         - KVM001
-        - KVM002
         - KVM003
         - KVM004
     mongodb:


### PR DESCRIPTION
/dev/kvm is not being set to correct permissions. We will skip this
check for now and will continue investigating.