### PR TITLE
add re-try to rhn unsubscribe.

### DIFF
--- a/playbooks/rhn_unsubscribe.yml
+++ b/playbooks/rhn_unsubscribe.yml
@@ -3,9 +3,12 @@
   hosts: all:!vyatta-*
   gather_facts: true
   environment: "{{ env_vars|default({}) }}"
- 
+
   tasks:
     - name: unsubscribe from redhat subscription
       redhat_subscription:
         state: absent
       when: ansible_distribution == 'RedHat'
+      register: unsubscribe
+      until: unsubscribe|succeeded
+      retries: 5

--- a/roles/rhn-subscription/tasks/main.yml
+++ b/roles/rhn-subscription/tasks/main.yml
@@ -15,7 +15,7 @@
   when: not osp_rhn.stdout | search("Current")
   register: subscription
   until: subscription|succeeded
-  retries: 3
+  retries: 5
 
 - block:
   - name: disable all redhat repositories
@@ -27,5 +27,5 @@
     command: subscription-manager repos --enable={{ rhn_subscription.repos.enable | join(' --enable=') }}
     register: result
     until: result|succeeded
-    retries: 3
+    retries: 5
   when: subscription.changed or rhn_subscription.repos.refresh|bool


### PR DESCRIPTION
See random rhn subscription/un-subscription error due to rhn timeouts. This PR add re-tries option to unsubscribe as well as up's the re-try count to 5 for subscription.