### PR TITLE
Fix some issues for ci-ceph_swift

### DIFF
--- a/roles/openstack-source/defaults/main.yml
+++ b/roles/openstack-source/defaults/main.yml
@@ -6,7 +6,7 @@ openstack_source:
   virtualenv_base: /opt/bbc/openstack-2016.2-newton
   git_update: no
   rootwrap: "{{ rootwrap|default(False)|bool }}"
-  system_dependencies: "{{ system_dependencies|default([]) }}"
+  system_dependencies: "{{ system_dependencies|default({'ubuntu':[], 'rhel':[]}) }}"
   python_dependencies: "{{ python_dependencies|default([]) }}"
   python_post_dependencies: "{{ python_post_dependencies|default([]) }}"
   pip_extra_args: ""

--- a/roles/swift-account/tasks/main.yml
+++ b/roles/swift-account/tasks/main.yml
@@ -3,7 +3,7 @@
   upstart_service:
     name: "{{ item.name }}"
     cmd:  "{{ item.cmd }}"
-    args: "{{ item.config_dirs }}"
+    args: "{{ item.config_files }}"
     user: "{{ item.user }}"
   with_items:
     - "{{ swift.services.swift_account }}"

--- a/roles/swift-common/tasks/main.yml
+++ b/roles/swift-common/tasks/main.yml
@@ -38,7 +38,6 @@
     repo=https://github.com/blueboxgroup/swifttool.git
     dest=/opt/stack/{{ swift.swifttool_dir  }}
     update={{ openstack.git_update }}
-    virtualenv={{ swifttool_venv|default(omit) }}
   notify:
     - pip install swifttool
   when: swift.swifttool_method == 'git'

--- a/roles/swift-object/tasks/main.yml
+++ b/roles/swift-object/tasks/main.yml
@@ -15,7 +15,7 @@
       name: "{{ item.name }}"
       user: "{{ item.user }}"
       cmd:  "{{ item.cmd }}"
-      args: "{{ item.config_dirs }}"
+      args: "{{ item.config_files }}"
   with_items:
     - "{{ swift.services.swift_object }}"
     - "{{ swift.services.swift_object_expirer }}"


### PR DESCRIPTION
Met many issues when running ci-ceph_swift.
****************
TASK [swift-common : get swifttool repo] ***************************************
Sunday 26 March 2017  05:23:32 +0000 (0:00:00.525)       1:16:54.396 **********
fatal: [swift-0]: FAILED! => {"changed": false, "failed": true, "msg": "unsupported parameter for module: **virtualenv**"}
fatal: [swift-2]: FAILED! => {"changed": false, "failed": true, "msg": "unsupported parameter for module: virtualenv"}
fatal: [swift-1]: FAILED! => {"changed": false, "failed": true, "msg": "unsupported parameter for module: virtualenv"}
****************
TASK [swift-object : swift-object service scripts] *****************************
2017-03-23 09:55:24,395 p=28817 u=ubuntu |  task path: /home/ubuntu/ursula/roles/swift-object/tasks/main.yml:13
2017-03-23 09:55:24,395 p=28817 u=ubuntu |  Thursday 23 March 2017  09:55:24 +0000 (0:00:00.540)       1:22:58.075 ********
2017-03-23 09:55:24,807 p=28817 u=ubuntu |  
fatal: [swift-1]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'dict object' has no attribute '**config_dirs**'\n\nThe error appears to have been in '/home/ubuntu/ursula/roles/swift-object/tasks/main.yml': line 13, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: swift-object service scripts\n  ^ here\n"}...
****************
TASK [openstack-source : install project system dependencies] ******************
2017-03-24 08:23:23,052 p=13386 u=ubuntu |  task path: /home/ubuntu/ursula_ubuntu/roles/openstack-source/tasks/main.yml:2
2017-03-24 08:23:23,052 p=13386 u=ubuntu |  Friday 24 March 2017  08:23:23 +0000 (0:00:00.770)       1:43:08.116 ********** 
2017-03-24 08:23:23,170 p=13386 u=ubuntu |  [DEPRECATION WARNING]: Skipping task due to undefined Error, in the future this will be a fatal error.: 'list object' has no attribute u'ubuntu'.
This feature will be removed in a 
future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
2017-03-24 08:23:23,206 p=13386 u=ubuntu |  [DEPRECATION WARNING]: Skipping task due to undefined Error, in the future this will be a fatal error.: 'list object' has no attribute u'ubuntu'.
This feature will be removed in a 
future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
2017-03-24 08:23:23,526 p=13386 u=ubuntu |  fatal: [controller-1]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'item' is undefined\n\nThe error appears to have been in '/home/ubuntu/ursula_ubuntu/roles/openstack-source/tasks/main.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: install project system dependencies\n  ^ here\n"}
2017-03-24 08:23:23,607 p=13386 u=ubuntu |  fatal: [controller-0]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'item' is undefined\n\nThe error appears to have been in '/home/ubuntu/ursula_ubuntu/roles/openstack-source/tasks/main.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: install project system dependencies\n  ^ here\n"}
