### PR TITLE
workaround defect 344951 by touch security group before running ursula playbook

### DIFF
--- a/test/setup
+++ b/test/setup
@@ -115,5 +115,13 @@ zones:
 eof
 fi
 
+#workaround security group issue for defect 344951 and security rules can take effect after retouch securitygroup
+
+secgroup=$(nova secgroup-list|grep ${SECURITYGROUP_NAME})
+secgroup_id=$(echo ${secgroup}|awk '{print $2}')
+
+nova secgroup-add-rule    ${secgroup_id} tcp 23 23 192.168.1.1/32
+nova secgroup-delete-rule ${secgroup_id} tcp 23 23 192.168.1.1/32
+
 ring_bell
 echo "vms are up: ${VMS} !!"


### PR DESCRIPTION
It seems that the security rules have not been taken effect in CI env.
Have rune the following testing 
1. using heat-stack to create ci vm
2. setup listen on port 4444(for mysql xtrabackup) and port (5672) in controller 0
3.try to connect to port 4444 of controller 0 from controller 1
4.try to connect to port 5672 of controller 0 from compute 0

There are 4 failures in 40 testing.  If adding security group touch, there is no failure.
