### PR TITLE
skip check for snmp conf file from rhel7-stig

### DIFF
--- a/roles/inspec/defaults/main.yml
+++ b/roles/inspec/defaults/main.yml
@@ -145,6 +145,7 @@ inspec:
         - RHEL-07-020670
         - RHEL-07-020250
         - RHEL-07-021060
+        - RHEL-07-040580
       attributes:
         RHEL_07_030710_audit_key_name: audit_account_changes-V-38531
         client_alive_interval: "{{ common.ssh.client_alive_interval }}"


### PR DESCRIPTION
The check looks at the config file for snmp even when the snmp service is not enabled. We do not start snmp so the check is not relevant. Also the check fails even when the relevant lines that it is checking for are commented out.