### PR TITLE
bug default('True') and default('False') modification

### DIFF
--- a/roles/aodh/handlers/main.yml
+++ b/roles/aodh/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: restart aodh services
   service: name={{ item.name }} state=restarted must_exist=false
-  when: restart|default('True')
+  when: restart|default(True)
   with_items:
     - "{{ aodh.services.aodh_api }}"
     - "{{ aodh.services.aodh_evaluator }}"

--- a/roles/ceilometer-common/handlers/main.yml
+++ b/roles/ceilometer-common/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: restart ceilometer services
   service: name={{ item.name }} state=restarted must_exist=false
-  when: restart|default('True')
+  when: restart|default(True)
   failed_when: false
   with_items:
     - "{{ ceilometer.services.ceilometer_api }}"
@@ -11,7 +11,7 @@
 
 - name: restart ceilometer data services
   service: name={{ item.name }} state=restarted must_exist=false
-  when: restart|default('True')
+  when: restart|default(True)
   failed_when: false
   with_items:
     - "{{ ceilometer.services.ceilometer_polling }}"

--- a/roles/cinder-common/handlers/main.yml
+++ b/roles/cinder-common/handlers/main.yml
@@ -11,7 +11,7 @@
   run_once: True
   failed_when: false
   delegate_to: "{{ item[0] }}"
-  when: restart|default('True')
+  when: restart|default(True)
   with_nested:
     - "{{ play_hosts }}"
     - ["{{ cinder.services.cinder_api }}",
@@ -25,7 +25,7 @@
     must_exist: false
   run_once: True
   delegate_to: "{{ item }}"
-  when: restart|default('True') and swift.enabled|default('False')
+  when: restart|default(True) and swift.enabled|default(False)
   with_items: "{{ play_hosts }}"
 
 - name: restart tgt service

--- a/roles/glance/handlers/main.yml
+++ b/roles/glance/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: restart glance services
   service: name={{ item.name }} state=restarted must_exist=false
-  when: restart|default('True')
+  when: restart|default(True)
   with_items:
     - "{{ glance.services.glance_api }}"
     - "{{ glance.services.glance_registry }}"

--- a/roles/heat/handlers/main.yml
+++ b/roles/heat/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: restart heat services
   service: name={{ item.name }} state=restarted must_exist=false
-  when: restart|default('True')
+  when: restart|default(True)
   with_items:
     - "{{ heat.services.heat_api }}"
     - "{{ heat.services.heat_api_cfn }}"

--- a/roles/ironic-common/handlers/main.yml
+++ b/roles/ironic-common/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: restart ironic services
   service: name={{ item }} state=restarted must_exist=false
-  when: restart|default('True')
+  when: restart|default(True)
   with_items:
     - ironic-api
     - ironic-conductor

--- a/roles/keystone-setup/handlers/main.yml
+++ b/roles/keystone-setup/handlers/main.yml
@@ -4,4 +4,4 @@
     name: "{{ openstack_meta.keystone.services.keystone_api[ursula_os].name }}"
     state: restarted
     must_exist: false
-  when: restart|default('True')
+  when: restart|default(True)

--- a/roles/keystone/handlers/main.yml
+++ b/roles/keystone/handlers/main.yml
@@ -7,9 +7,9 @@
     must_exist: false
   run_once: True
   delegate_to: "{{ item }}"
-  when: restart|default('True')
+  when: restart|default(True)
   with_items: play_hosts
 
 - name: restart shibboleth
   service: name=shibd state=restarted
-  when: restart|default('True')
+  when: restart|default(True)

--- a/roles/magnum/handlers/main.yml
+++ b/roles/magnum/handlers/main.yml
@@ -4,4 +4,4 @@
   with_items:
     - magnum-api
     - magnum-conductor
-  when: restart|default('True')
+  when: restart|default(True)

--- a/roles/neutron-common/handlers/main.yml
+++ b/roles/neutron-common/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: restart neutron services
   service: name={{ item.name }} state=restarted_if_running must_exist=false
-  when: restart|default('True')
+  when: restart|default(True)
   failed_when: false
   with_items:
     - "{{ neutron.services.neutron_server }}"

--- a/roles/nova-common/handlers/main.yml
+++ b/roles/nova-common/handlers/main.yml
@@ -9,7 +9,7 @@
   failed_when: false
   run_once: True
   delegate_to: "{{ item[0] }}"
-  when: restart|default('True')
+  when: restart|default(True)
   with_nested:
     - "{{ play_hosts }}"
     - ["{{ nova.services.nova_api }}",

--- a/roles/swift-common/handlers/main.yml
+++ b/roles/swift-common/handlers/main.yml
@@ -43,7 +43,7 @@
 
 - name: restart swift services
   service: name={{ item.name }} state=restarted must_exist=false
-  when: restart|default('True')
+  when: restart|default(True)
   with_items:
     - "{{ swift.services.swift_container }}"
     - "{{ swift.services.swift_container_auditor }}"


### PR DESCRIPTION
Under normal conditions, `default('True')` will return true as well as `default('arbitrary string')`, even default('False') will also return true.
[line 28](https://github.com/blueboxgroup/ursula/blob/master/roles/cinder-common/handlers/main.yml#L28)
`when: restart|default('True') and swift.enabled|default('False')`
when swift.enabled is undefined, `swift.enabled|default('False')` will return true. 
The correct writing are shown as follows(I have tested it under ansible 2.1.0.0 and ansible 2.1.3.0):
```
xx.enabled|default('True')|bool
xx.enabled|default('False')|bool
xx.enabled|default(True)
xx.enabled|default(False)
```
In order to simplify, we can use later ones.