### PR TITLE
update openstack-source role

### DIFF
--- a/roles/aodh/defaults/main.yml
+++ b/roles/aodh/defaults/main.yml
@@ -17,8 +17,7 @@ aodh:
       - openstack-aodh-expirer
   source:
     rev: 'stable/newton'
-    constrain: True
-    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt'
+    upper_constraints: '{{ openstack_meta.upper_constraints }}'
     python_dependencies:
       - { name: PyMySQL }
       - { name: python-memcached }

--- a/roles/aodh/meta/main.yml
+++ b/roles/aodh/meta/main.yml
@@ -14,7 +14,6 @@ dependencies:
     alternatives: "{{ aodh.alternatives }}"
     system_dependencies: "{{ aodh.source.system_dependencies }}"
     python_dependencies: "{{ aodh.source.python_dependencies }}"
-    constrain: "{{ aodh.source.constrain }}"
     upper_constraints: "{{ aodh.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package

--- a/roles/ceilometer-common/defaults/main.yml
+++ b/roles/ceilometer-common/defaults/main.yml
@@ -23,8 +23,7 @@ ceilometer:
         - openstack-ceilometer-compute
   source:
     rev: 'stable/newton'
-    constrain: True
-    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt'
+    upper_constraints: '{{ openstack_meta.upper_constraints }}'
     python_dependencies:
       - { name: pymongo }
       - { name: python-memcached }

--- a/roles/ceilometer-common/meta/main.yml
+++ b/roles/ceilometer-common/meta/main.yml
@@ -19,7 +19,6 @@ dependencies:
     project_rev: "{{ ceilometer.source.rev }}"
     alternatives: "{{ ceilometer.alternatives }}"
     python_dependencies: "{{ ceilometer.source.python_dependencies }}"
-    constrain: "{{ ceilometer.source.constrain }}"
     upper_constraints: "{{ ceilometer.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package

--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -60,8 +60,7 @@ cinder:
       - openstack-cinder
   source:
     rev: 'stable/newton'
-    constrain: True
-    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt'
+    upper_constraints: '{{ openstack_meta.upper_constraints }}'
     python_dependencies:
       - { name: PyMySQL }
       - { name: python-memcached }

--- a/roles/cinder-common/meta/main.yml
+++ b/roles/cinder-common/meta/main.yml
@@ -21,7 +21,6 @@ dependencies:
     alternatives: "{{ cinder.alternatives }}"
     system_dependencies: "{{ cinder.source.system_dependencies }}"
     python_dependencies: "{{ cinder.source.python_dependencies }}"
-    constrain: "{{ cinder.source.constrain }}"
     upper_constraints: "{{ cinder.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package

--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 client:
+  upper_constraints: '{{ openstack_meta.upper_constraints }}'
   write_stackrc: True
   self_signed_cert: false
   dep_pkgs:

--- a/roles/client/meta/main.yml
+++ b/roles/client/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
+  - role: openstack-meta
   - role: endpoints

--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -22,15 +22,43 @@
   retries: 5
   when: ursula_os == 'rhel' and openstack_install_method == 'distro'
 
+- block:
+  - name: make sure /opt/stack/ exists
+    file: dest=/opt/stack state=directory
+
+  - name: write constraints file
+    copy:
+      src: ../../openstack-source/files/constraints.txt
+      dest: /opt/stack/constraints.txt
+      force: true
+    when: client.upper_constraints == None
+
+  - name: get constraints file
+    get_url:
+      url: "{{ client.upper_constraints }}"
+      dest: /opt/stack/constraints.txt
+      force: true
+    when: client.upper_constraints != None
+
+  - name: upgrade system setuptools using upper_contraints
+    pip:
+      name: setuptools
+      extra_args: "-c /opt/stack/constraints.txt --upgrade"
+    register: result
+    until: result|succeeded
+    retries: 5
+  when:
+    - openstack_install_method != 'distro'
+
 - name: install openstack clients
-  pip: name={{ item }}
+  pip: name={{ item }} extra_args='-c /opt/stack/constraints.txt'
   with_items: "{{ client.names['pip_pkgs'] }}"
   notify:
     - update ca certs
   register: result
   until: result|succeeded
   retries: 5
-  when: (ursula_os == 'ubuntu') or (ursula_os == 'rhel' and openstack_install_method == 'source')
+  when: openstack_install_method != 'distro'
 
 - name: fix ssl certs for requests for keystone-client on trusty
   file: src=/etc/ssl/certs/ca-certificates.crt

--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -35,8 +35,7 @@ glance:
     python_post_dependencies: []
   source:
     rev: 'stable/newton'
-    constrain: True
-    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt'
+    upper_constraints: '{{ openstack_meta.upper_constraints }}'
     python_dependencies:
       - { name: PyMySQL }
       - { name: python-swiftclient }

--- a/roles/glance/meta/main.yml
+++ b/roles/glance/meta/main.yml
@@ -21,7 +21,6 @@ dependencies:
     system_dependencies: "{{ glance.source.system_dependencies }}"
     python_dependencies: "{{ glance.source.python_dependencies }}"
     python_post_dependencies: "{{ glance.source.python_post_dependencies }}"
-    constrain: "{{ glance.source.constrain }}"
     upper_constraints: "{{ glance.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package

--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -22,8 +22,7 @@ heat:
     python_post_dependencies: []
   source:
     rev: 'stable/newton'
-    constrain: True
-    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt'
+    upper_constraints: '{{ openstack_meta.upper_constraints }}'
     python_dependencies:
       - { name: PyMySQL }
     python_post_dependencies: []

--- a/roles/heat/meta/main.yml
+++ b/roles/heat/meta/main.yml
@@ -21,7 +21,6 @@ dependencies:
     system_dependencies: "{{ heat.source.system_dependencies }}"
     python_dependencies: "{{ heat.source.python_dependencies }}"
     python_post_dependencies: "{{ heat.source.python_post_dependencies }}"
-    constrain: "{{ heat.source.constrain }}"
     upper_constraints: "{{ heat.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package

--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -21,8 +21,7 @@ horizon:
   source:
     python_post_dependencies: []
     rev: 'stable/newton'
-    constrain: True
-    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt'
+    upper_constraints: '{{ openstack_meta.upper_constraints }}'
     python_dependencies:
       - { name: PyMySQL }
       - { name: python-memcached }

--- a/roles/horizon/meta/main.yml
+++ b/roles/horizon/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: openstack-meta
   - role: endpoints
   - role: monitoring-common
     when: monitoring.enabled|default(True)|bool
@@ -18,7 +19,6 @@ dependencies:
     project_rev: "{{ horizon.source.rev }}"
     system_dependencies: "{{ horizon.source.system_dependencies }}"
     python_dependencies: "{{ horizon.source.python_dependencies }}"
-    constrain: "{{ horizon.source.constrain }}"
     upper_constraints: "{{ horizon.source.upper_constraints }}"
     additional_handlers: [ "compress horizon assets" ]
     python_post_dependencies: "{{ horizon.source.python_post_dependencies }}"

--- a/roles/ironic-common/defaults/main.yml
+++ b/roles/ironic-common/defaults/main.yml
@@ -22,8 +22,7 @@ ironic:
       - openstack-ironic
   source:
     rev: 'stable/newton'
-    constrain: True
-    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt'
+    upper_constraints: '{{ openstack_meta.upper_constraints }}'
     python_dependencies:
       - { name: PyMySQL }
       - { name: python-memcached }

--- a/roles/ironic-common/meta/main.yml
+++ b/roles/ironic-common/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: openstack-meta
   - role: endpoints
   - role: logging-config
     when: logging.enabled|default(True)|bool
@@ -12,7 +13,6 @@ dependencies:
     alternatives: "{{ ironic.alternatives }}"
     system_dependencies: "{{ ironic.source.system_dependencies }}"
     python_dependencies: "{{ ironic.source.python_dependencies }}"
-    constrain: "{{ ironic.source.constrain }}"
     upper_constraints: "{{ ironic.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package

--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -27,8 +27,7 @@ keystone:
   #     pip_extra_args: '--extra-index-url https://pypi-mirror.openstack.blueboxgrid.com/root/pypi...'
   source:
     rev: 'stable/newton'
-    constrain: True
-    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt'
+    upper_constraints: '{{ openstack_meta.upper_constraints }}'
     python_dependencies:
       - { name: PyMySQL }
       - { name: uwsgi }

--- a/roles/keystone/meta/main.yml
+++ b/roles/keystone/meta/main.yml
@@ -22,7 +22,6 @@ dependencies:
     system_dependencies: "{{ keystone.source.system_dependencies }}"
     python_dependencies: "{{ keystone.source.python_dependencies }}"
     python_post_dependencies: "{{ keystone.source.python_post_dependencies }}"
-    constrain: "{{ keystone.source.constrain }}"
     upper_constraints: "{{ keystone.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package

--- a/roles/magnum/defaults/main.yml
+++ b/roles/magnum/defaults/main.yml
@@ -8,8 +8,7 @@ magnum:
       - openstack-magnum
   source:
     rev: 'stable/newton'
-    constrain: True
-    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt'
+    upper_constraints: '{{ openstack_meta.upper_constraints }}'
     virtualenv: "/opt/openstack/magnum"
     python_dependencies:
       - { name: PyMySQL }

--- a/roles/magnum/meta/main.yml
+++ b/roles/magnum/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: openstack-meta
   - role: endpoints
   - role: monitoring-common
     when: monitoring.enabled|default(True)|bool
@@ -13,7 +14,6 @@ dependencies:
     virtualenv: "{{ magnum.source.virtualenv }}"
     system_dependencies: "{{ magnum.source.system_dependencies }}"
     python_dependencies: "{{ magnum.source.python_dependencies }}"
-    constrain: "{{ magnum.source.constrain }}"
     upper_constraints: "{{ magnum.source.upper_constraints }}"
     alternatives: "{{ magnum.alternatives }}"
     when: openstack_install_method == 'source'

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -96,8 +96,7 @@ neutron:
   #     pip_extra_args: '--extra-index-url https://pypi-mirror.openstack.blueboxgrid.com/root/pypi...'
   source:
     rev: 'stable/newton'
-    constrain: True
-    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt'
+    upper_constraints: '{{ openstack_meta.upper_constraints }}'
     python_dependencies:
       - { name: "git+git://github.com/openstack/neutron-lbaas.git@stable/newton#egg=neutron-lbaas" }
       - { name: PyMySQL }

--- a/roles/neutron-common/meta/main.yml
+++ b/roles/neutron-common/meta/main.yml
@@ -16,7 +16,6 @@ dependencies:
     system_dependencies: "{{ neutron.source.system_dependencies }}"
     python_dependencies: "{{ neutron.source.python_dependencies }}"
     python_post_dependencies: "{{ neutron.source.python_post_dependencies }}"
-    constrain: "{{ neutron.source.constrain }}"
     upper_constraints: "{{ neutron.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -83,8 +83,7 @@ nova:
         - openstack-nova-compute
   source:
     rev: 'stable/newton'
-    constrain: True
-    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt'
+    upper_constraints: '{{ openstack_meta.upper_constraints }}'
     python_dependencies:
       - { name: PyMySQL }
       - { name: python-memcached }

--- a/roles/nova-common/meta/main.yml
+++ b/roles/nova-common/meta/main.yml
@@ -23,7 +23,6 @@ dependencies:
     alternatives: "{{ nova.alternatives }}"
     system_dependencies: "{{ nova.source.system_dependencies }}"
     python_dependencies: "{{ nova.source.python_dependencies }}"
-    constrain: "{{ nova.source.constrain }}"
     upper_constraints: "{{ nova.source.upper_constraints }}"
     when: openstack_install_method == 'source'
   - role: openstack-package

--- a/roles/openstack-meta/defaults/main.yml
+++ b/roles/openstack-meta/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 openstack_meta:
+  upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt'
   keystone:
     services:
       keystone_api:

--- a/roles/openstack-source/tasks/main.yml
+++ b/roles/openstack-source/tasks/main.yml
@@ -17,8 +17,7 @@
 
 - name: set pip args fact
   set_fact:
-    pip_extra_args: "{{ openstack_source.pip_extra_args|default('') }}"
-  when: openstack.pypi_mirror is defined
+    pip_extra_args: "{{ openstack_source.pip_extra_args }}"
 
 - name: set pip proxy args
   set_fact:
@@ -27,53 +26,45 @@
 
 - name: update pip in virtualenv
   pip:
-    name: "{{ item }}"
+    name: pip
     state: latest
     virtualenv: "{{ openstack_source.virtualenv_base }}/{{ project_name }}"
     extra_args: "{{ pip_extra_args }}"
-  with_items:
-    - pip
   register: result
   until: result|succeeded
   retries: 5
 
-- block:
-  - name: write constraints file
-    copy:
-      src: files/constraints.txt
-      dest: /opt/stack/constraints.txt
-      force: true
-    when: not upper_constraints|bool
+- name: write constraints file
+  copy:
+    src: files/constraints.txt
+    dest: /opt/stack/constraints.txt
+    force: true
+  when: upper_constraints == None
 
-  - name: get constraints file
-    get_url:
-      url: "{{ upper_constraints }}"
-      dest: /opt/stack/constraints.txt
-      force: true
-    when: upper_constraints|bool
+- name: get constraints file
+  get_url:
+    url: "{{ upper_constraints }}"
+    dest: /opt/stack/constraints.txt
+    force: true
+  when: upper_constraints != None
 
-  - name: set pip constraints args
-    set_fact:
-      pip_extra_args: "{{ pip_extra_args }} -c /opt/stack/constraints.txt"
-
-  when: constrain | bool
+- name: set pip constraints args
+  set_fact:
+    pip_extra_args: "{{ pip_extra_args }} -c /opt/stack/constraints.txt"
 
 - name: update setuptools in virtualenv
   pip:
-    name: "{{ item }}"
+    name: setuptools
     state: latest
     virtualenv: "{{ openstack_source.virtualenv_base }}/{{ project_name }}"
     extra_args: "{{ pip_extra_args }}"
-  with_items:
-    - setuptools
   register: result
   until: result|succeeded
   retries: 5
 
 - name: set code has changed fact
   set_fact:
-    code_has_changed: True
-  when: git_result | changed
+    code_has_changed: git_result | changed
 
 - name: python requirements for project
   pip:

--- a/roles/swift-common/defaults/main.yml
+++ b/roles/swift-common/defaults/main.yml
@@ -35,8 +35,7 @@ swift:
       - openstack-swift-object
   source:
     rev: 'stable/newton'
-    constrain: True
-    upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt'
+    upper_constraints: '{{ openstack_meta.upper_constraints }}'
     python_dependencies:
       - { name: keystonemiddleware }
       - { name: python-swiftclient }

--- a/roles/swift-common/meta/main.yml
+++ b/roles/swift-common/meta/main.yml
@@ -12,7 +12,6 @@ dependencies:
     project_name: swift
     python_dependencies: "{{ swift.source.python_dependencies }}"
     system_dependencies: "{{ swift.source.system_dependencies }}"
-    constrain: "{{ swift.source.constrain }}"
     upper_constraints: "{{ swift.source.upper_constraints }}"
     project_rev: "{{ swift.source.rev }}"
     alternatives: "{{ swift.alternatives }}"


### PR DESCRIPTION
This patch makes following changes:
1. restrain pip package version when installing openstack clients
2. pass variables of the same names with openstack-source, so the passed
variables can overwrite the variable in openstack-source role.
3. define openstack.upper_constaints in defaults-2.0.yml, instead of
defining it every where.
4. use `local_constrain` to decide use openstack upper_constraints.txt or local constraints file. Because `upper_constaints|bool` doesn't work, my test shows that `upper_constaints|bool` is false then upper_constraints='https://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt'