### PR TITLE
pin setuptools version

### DIFF
--- a/roles/openstack-source/tasks/main.yml
+++ b/roles/openstack-source/tasks/main.yml
@@ -33,7 +33,7 @@
     extra_args: "{{ pip_extra_args }}"
   with_items:
     - pip
-    - setuptools>=16.0,!=24.0.0,!=34.0.0,!=34.0.1,!=34.0.2,!=34.0.3,!=34.1.0,!=34.1.1,!=34.2.0,!=34.3.0,!=34.3.1,!=34.3.2
+    - setuptools>=16.0,!=24.0.0,<34.0
   register: result
   until: result|succeeded
   retries: 5


### PR DESCRIPTION
New setuptools version 34.3.3 was released that is still affected by the bug outlined in this PR:
https://github.com/blueboxgroup/ursula/pull/2616

Blocking setuptools 34.x.x until this is resolved upstream. 