### PR TITLE
pin system setuptools

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -31,7 +31,7 @@ common:
     disable_dns: True
     client_alive_interval: 1800
   pip_version: 8.0.2
-  setuptools_version: system
+  setuptools_version: '>=16.0,!=24.0.0,<34.0'
   ursula_monitoring:
     path: /opt/ursula-monitoring
     method: git # git|tar

--- a/roles/common/tasks/python.yml
+++ b/roles/common/tasks/python.yml
@@ -86,13 +86,16 @@
 - block:
   - name: uninstall python-setuptools
     package: name=python-setuptools state=absent
-    when: common.setuptools_version != "system"
+    when:
+      - common.setuptools_version != "system"
+      - ursula_os == 'ubuntu'
     register: result
     until: result|succeeded
     retries: 5
 
   - name: install pip setuptools
-    pip: name=setuptools version={{ common.setuptools_version }}
+    pip:
+      name: setuptools"{{ common.setuptools_version }}"
     when: common.setuptools_version != "system"
     register: result
     until: result|succeeded


### PR DESCRIPTION
Pinning system tools to <34.x per the bug outlined in this PR:

https://github.com/blueboxgroup/ursula/pull/2616