### PR TITLE
unbuffer ansible to display ansible console log in realtime

### DIFF
--- a/test/common
+++ b/test/common
@@ -7,7 +7,7 @@ set +x
 set -x
 
 export ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
-
+export PYTHONUNBUFFERED=1
 export ANSIBLE_VAR_DEFAULTS_FILE="${ROOT}/envs/test/defaults-2.0.yml"
 export IMAGE_ID=${IMAGE_ID:=ubuntu-14.04}
 export AVAILABILITY_ZONE=${OS_AVAILABILITY_ZONE:=nova}


### PR DESCRIPTION
jenkins can't display log in realtime and can't find what is real issue from the following log
https://jenkins.ci.blueboxgrid.com/job/Ursula_Test_Ubuntu_Master_PRs/267/console

make sure that jenkins console can display log in realtime.

