### PR TITLE
remove obsolete bbg_ubuntu repo usage.

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -102,9 +102,6 @@ apt_repos:
   docker:
     repo: https://apt-mirror.openstack.blueboxgrid.com/docker/ubuntu
     key_url: https://apt-mirror.openstack.blueboxgrid.com/keys/docker.key
-  bbg_ubuntu:
-    repo: https://apt-mirror.openstack.blueboxgrid.com/bbg_ubuntu/ubuntu
-    key_url: https://apt-mirror.openstack.blueboxgrid.com/keys/bbg_ubuntu.key
   blueboxcloud_giftwrap:
     repo: https://apt-mirror.openstack.blueboxgrid.com/blueboxcloud_giftwrap/blueboxcloud/giftwrap/ubuntu
     key_url: https://apt-mirror.openstack.blueboxgrid.com/keys/blueboxcloud_giftwrap.key

--- a/envs/example/mirrors/group_vars/all.yml
+++ b/envs/example/mirrors/group_vars/all.yml
@@ -16,9 +16,6 @@ apt_repos:
   docker:
     repo: https://apt-mirror.openstack.blueboxgrid.com/docker/ubuntu
     key_url: https://apt-mirror.openstack.blueboxgrid.com/keys/docker.key
-  bbg_ubuntu:
-    repo: https://apt-mirror.openstack.blueboxgrid.com/bbg_ubuntu/ubuntu
-    key_url: https://apt-mirror.openstack.blueboxgrid.com/keys/bbg_ubuntu.key
   blueboxcloud_giftwrap:
     repo: https://apt-mirror.openstack.blueboxgrid.com/blueboxcloud_giftwrap/blueboxcloud/giftwrap/ubuntu
     key_url: https://apt-mirror.openstack.blueboxgrid.com/keys/blueboxcloud_giftwrap.key

--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -3,11 +3,6 @@ dependencies:
   - role: endpoints
   - role: apt-repos
     repos:
-      - repo: 'deb {{ apt_repos.bbg_ubuntu.repo }} {{ ansible_lsb.codename }} main'
-        key_url: '{{ apt_repos.bbg_ubuntu.key_url }}'
-    when: ansible_architecture != "ppc64le" and ursula_os == 'ubuntu'
-  - role: apt-repos
-    repos:
       - repo: 'deb {{ apt_repos.hwraid.repo }} {{ ansible_lsb.codename }} main'
         key_url: '{{ apt_repos.hwraid.key_url }}'
     when: common.hwraid.enabled|bool and ursula_os == 'ubuntu'

--- a/roles/repos/defaults/main.yml
+++ b/roles/repos/defaults/main.yml
@@ -6,9 +6,6 @@ apt_repos:
   docker:
     repo: 'https://get.docker.com/ubuntu'
     key_url: 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xD8576A8BA88D21E9'
-  bbg_ubuntu:
-    repo: 'https://apt-mirror.openstack.blueboxgrid.com/bbg_ubuntu/ubuntu'
-    key_url: 'https://apt-mirror.openstack.blueboxgrid.com/keys/bbg_ubuntu.key'
   blueboxcloud_giftwrap:
     repo: 'https://packagecloud.io/blueboxcloud/giftwrap/ubuntu/'
     key_url: 'https://packagecloud.io/gpg.key'


### PR DESCRIPTION
bbg_ubuntu repo is obsolete repo and this PR removes all the references of it from ursula.