### PR TITLE
unbreak ci by pining novaclient.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pep8
 oslo.utils
 shade>=1.7.0
 ansible>=2.1.0.0,<3,<=2.1.3
-python-novaclient
+python-novaclient<8.0.0
 python-glanceclient
 python-cinderclient
 python-neutronclient

--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -2,17 +2,30 @@
 client:
   write_stackrc: True
   self_signed_cert: false
-  names:
-    - python-keystoneclient
-    - python-glanceclient
-    - python-novaclient
-    - python-neutronclient
-    - python-cinderclient
-    - python-heatclient
-    - python-ceilometerclient
-    - python-ironicclient
-    - python-swiftclient
-    - python-magnumclient
-    - python-openstackclient
-  apt_packages:
+  dep_pkgs:
     - python-prettytable
+  names:
+    pip_pkgs:
+      - python-keystoneclient
+      - python-glanceclient
+      - python-novaclient<8.0.0
+      - python-neutronclient
+      - python-cinderclient
+      - python-heatclient
+      - python-ceilometerclient
+      - python-ironicclient
+      - python-swiftclient
+      - python-magnumclient
+      - python-openstackclient
+    yum_pkgs:
+      - python-keystoneclient
+      - python-glanceclient
+      - python-novaclient
+      - python-neutronclient
+      - python-cinderclient
+      - python-heatclient
+      - python-ceilometerclient
+      - python-ironicclient
+      - python-swiftclient
+      - python-magnumclient
+      - python-openstackclient

--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -7,16 +7,16 @@
   package:
     name: "{{ item }}"
     state: present
-  with_items: "{{ client.apt_packages }}"
+  with_items: "{{ client.dep_pkgs }}"
   register: result
   until: result|succeeded
   retries: 5
-  
+
 - name: install required packages for clients
   package:
     name: "{{ item }}"
     state: present
-  with_items: "{{ client.names }}"
+  with_items: "{{ client.names['yum_pkgs'] }}"
   register: result
   until: result|succeeded
   retries: 5
@@ -24,7 +24,7 @@
 
 - name: install openstack clients
   pip: name={{ item }}
-  with_items: "{{ client.names }}"
+  with_items: "{{ client.names['pip_pkgs'] }}"
   notify:
     - update ca certs
   register: result


### PR DESCRIPTION
novalcient 8.0.0 got released today which is breaking calls to nova security group. To unblock CI this PR is pining novaclient to < 8.0.0.

We will remove this pinning once upstream release fix for novaclient.

calls failing:
openstack security group rule list