### PR TITLE
Temporary CI metadata/haproxy fix

### DIFF
--- a/playbooks/tests/tasks/all.yml
+++ b/playbooks/tests/tasks/all.yml
@@ -13,6 +13,22 @@
       msg: "OS is {{ ansible_distribution }}"
     failed_when: ursula_os is not defined
 
+# bandaid metadata issue
+- name: restart haproxy service
+  hosts: controller
+  tasks:
+  - name: check haproxy status
+    shell: service haproxy status
+    register: haproxy_status
+
+  - debug:
+      var: haproxy_status.stdout_lines
+
+  - service:
+      name: haproxy
+      state: restarted
+    when: '"DOWN" in haproxy_status.stdout'
+
 - name: Test basic things on all hosts
   hosts: all
   tasks:

--- a/playbooks/tests/tasks/integration.yml
+++ b/playbooks/tests/tasks/integration.yml
@@ -135,7 +135,7 @@
   register: vm_log
 
 - debug:
-    var: vm_log
+    var: vm_log.stdout_lines
 
 - name: neutron dhcp namespace can ping instance
   shell: DHCP_NS=$( ip netns show | grep qdhcp- | awk '{print $1}' );


### PR DESCRIPTION
CI has been having intermittent metadata issue and it's caused by haproxy not started properly. Restart haproxy before CI tests to temporarily fix the issue.