### PR TITLE
workaround key injection issues

### DIFF
--- a/playbooks/tests/tasks/main.yml
+++ b/playbooks/tests/tasks/main.yml
@@ -26,6 +26,18 @@
     when: item in host_result.stdout
     with_items: "{{ groups['controller'] }}"
 
+  - name: Find host in host backup default router
+    shell: . /root/stackrc; neutron l3-agent-list-hosting-router default | grep " standby "
+    register: backup_host_result
+
+  - set_fact:
+      host_backup_default_router: "{{ item }}"
+    when: item in backup_host_result.stdout
+    with_items: "{{ groups['controller'] }}"
+
+  - include: workaround_network.yml
+    delegate_to: "{{ host_backup_default_router }}"
+
   - include: integration.yml
     delegate_to: "{{ host_hosting_default_router }}"
 

--- a/playbooks/tests/tasks/workaround_network.yml
+++ b/playbooks/tests/tasks/workaround_network.yml
@@ -1,0 +1,11 @@
+---
+- name: shutdown interface in standby router
+  shell: ROUTER_NS=$( ip netns show | grep qrouter- | awk '{print $1}' );
+         QR_INTERFACES=($(ip netns exec ${ROUTER_NS} ip a|grep ' qr'|awk '{print $2}'|awk -F "@" '{print $1}'|sed 's/\://g'));
+         for i in "${QR_INTERFACES[@]}"; do ip netns exec ${ROUTER_NS} ip link set dev $i down ;done
+  args:
+    executable: /bin/bash
+  register: result
+  until: result|success
+  retries: 6
+  delay: 10


### PR DESCRIPTION
Since key injection break more than 50% of CI running. It seems that the issue is caused by HA issue.  key injection issues are caused by interface migration between two controller. I  are several way to solve CI HA issue.
1. find the root of HA issue in CI env. It is under investigation and take more times. Further actions:
    - check security group
    - check keepalive configuration
    - check why gratutious arp send from standby router

2. Workaround injected key issues. 

This PR is targeted to workaround key injection issue. The n this PR, the interface in backup router will be shutdown before integration test running and it will not impact other env except ci envs.
