### PR TITLE
fast fail for ssh

### DIFF
--- a/playbooks/tests/tasks/integration.yml
+++ b/playbooks/tests/tasks/integration.yml
@@ -153,14 +153,14 @@
   when: floating_ip.floating_ip.floating_ip_address is defined
 
 - name: test instance can ping 8.8.8.8
-  command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+  command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o BatchMode=yes
            -i /root/.ssh/id_rsa
            cirros@{{ floating_ip.floating_ip.floating_ip_address }}
            ping -c 5 8.8.8.8
   when: floating_ip.floating_ip.floating_ip_address is defined
 
 - name: test instance can ping Google
-  command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+  command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o BatchMode=yes
            -i /root/.ssh/id_rsa
            cirros@{{ floating_ip.floating_ip.floating_ip_address }}
            ping -c 5 www.google.com
@@ -180,7 +180,7 @@
   when: cinder.enabled|bool
 
 - name: write volume in VM
-  shell: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+  shell: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o BatchMode=yes
          -i /root/.ssh/id_rsa
          cirros@{{ floating_ip.floating_ip.floating_ip_address }}
          sudo dd if=/dev/zero of=/dev/vdb count=100 bs=1M


### PR DESCRIPTION
A lot of jobs fails at waiting for timeout. In this PR, ssh will fail fast if key is not injected into vm.