### PR TITLE
add openstack-meta role dependency to keystone-defaults.

### DIFF
--- a/roles/keystone-defaults/meta/main.yml
+++ b/roles/keystone-defaults/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: openstack-meta


### PR DESCRIPTION
keystone-defaults has references to upper_contraints variable in openstack-meta. this PR adds openstack-meta role dependency to keystone-defaults role.