### PR TITLE
use upper_constriants for centos.

### DIFF
--- a/envs/example/ci-full-centos/group_vars/all.yml
+++ b/envs/example/ci-full-centos/group_vars/all.yml
@@ -24,8 +24,6 @@ neutron:
 keystone:
   uwsgi:
     method: port
-  source:
-    upper_constraints: ~
 
 common:
   hwraid:


### PR DESCRIPTION
PR fixes ci-full-centos envs for keystone to use upper_contraints rather than local one.