### PR TITLE
use bash instead sh

### DIFF
--- a/playbooks/tests/tasks/integration.yml
+++ b/playbooks/tests/tasks/integration.yml
@@ -188,6 +188,8 @@
 
 - name: detach volume and delete volume
   shell: . /root/stackrc && {{ item }}
+  args:
+    executable: /bin/bash
   with_items:
     - openstack server remove volume turtle-stack turtle-vol
     - while [[ $(cinder list |grep turtle-vol|awk '{print $4}') != 'available' ]]; do echo "wait for volume detach";sleep 1 ;done 


### PR DESCRIPTION
In ansible shell, default will use /bin/sh. /bin/sh will not handle this [[ ]] well.  SO force to use /bin/bash