### PR TITLE
update swift-fqdn to match the self-signed cert.

### DIFF
--- a/envs/example/ci-ceph_swift/group_vars/all.yml
+++ b/envs/example/ci-ceph_swift/group_vars/all.yml
@@ -5,7 +5,7 @@ ursula_os: 'ubuntu'
 state_path_base: /opt/stack/data
 
 swift_floating_ip: "{{ hostvars[groups['swiftnode'][0]][primary_interface]['ipv4']['address'] }}"
-swift_fqdn: "swift.{{ fqdn }}"
+swift_fqdn: "swift-{{ fqdn }}"
 
 etc_hosts:
   - name: "{{ fqdn }}"


### PR DESCRIPTION
CI env ci-ceph_swift had swift fqdn that is not matching the self signed cert wildcard domain. Thi PR updates the swift-fqdn for ci-ceph_swift envs.