### PR TITLE
avoid custom cafile swift-dispersion support for non-distro.

### DIFF
--- a/roles/openstack-setup/tasks/dispersion.yml
+++ b/roles/openstack-setup/tasks/dispersion.yml
@@ -7,9 +7,11 @@
     regexp: 'urllib2\.urlopen\(req, timeout=timeout\)'
     replace: >
        urllib2.urlopen(req, cafile='{{ ssl.cafile }}', timeout=timeout)
-  when: client.self_signed_cert|default('False')|bool
+  when:
+    - client.self_signed_cert|default('False')|bool
+    - openstack_install_method == 'distro'
   delegate_to: "{{ item }}"
-  with_items: "{{ groups['swiftnode'] }}" 
+  with_items: "{{ groups['swiftnode'] }}"
 
 - name: run insecure swift dispersion populate
   command: swift-dispersion-populate --insecure


### PR DESCRIPTION
custom cafile support for swift-dispersion using self-signed cert is only needed for distro install. On ubuntu swiftclient works fine swift-dispersion --insecure

This PR add's when condition to restrict "custom cafile support swift-dispersion" to distro install method.