### PR TITLE
ntpd start on boot rhel

### DIFF
--- a/roles/common/tasks/ntp.yml
+++ b/roles/common/tasks/ntp.yml
@@ -15,6 +15,14 @@
   notify:
     - restart-ntp
 
+#Needed on rhel to start ntpd on boot
+- name: disable chronyd
+  service:
+    name: 'chronyd'
+    state: stopped
+    enabled: false
+  when: ursula_os == 'rhel'
+
 - name: ntp service enabled
   service:
     name: "{{ ntpd_service_name }}"


### PR DESCRIPTION
Ntpd won't start on boot on RHEL if chronyd is enabled. (https://access.redhat.com/solutions/1315793) 