### PR TITLE
add HTTP Strict Transport Security header to Horizon responses

### DIFF
--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -155,6 +155,7 @@ frontend {{ name }}
   {% endif %}
 
   {% if name == "horizon" -%}
+  rspadd Strict-Transport-Security:\ max-age=31536000;\ includeSubDomains
   bind :::80
   redirect scheme https if !{ ssl_fc }
   {% endif -%}


### PR DESCRIPTION
HTTP Strict Transport Security (HSTS) is an opt-in security enhancement that
is specified by a web application through the use of a special response header.
Once a supported browser receives this header that browser will prevent any
communications from being sent over HTTP to the specified domain and will
instead send all communications over HTTPS. It also prevents HTTPS click
through prompts on browsers.