### PR TITLE
update upstart for aodh-api and ceilometer-api.

### DIFF
--- a/roles/aodh/tasks/main.yml
+++ b/roles/aodh/tasks/main.yml
@@ -18,7 +18,8 @@
     name: "{{ item.name }}"
     user: "{{ item.user }}"
     cmd: "{{ item.cmd }}"
-    config_dirs: "{{ item.config_dirs }}"
+    args: "{{ (item.name == 'aodh-api') | ternary('--port %s' % endpoints.aodh.port.backend_api, '') }}"
+    config_dirs: "{{ (item.name == 'aodh-api') | ternary('', '%s' % item.config_dirs ) }}"
   with_items:
     - "{{ aodh.services.aodh_api }}"
     - "{{ aodh.services.aodh_evaluator }}"

--- a/roles/ceilometer-control/tasks/main.yml
+++ b/roles/ceilometer-control/tasks/main.yml
@@ -4,6 +4,7 @@
     name: "{{ item.name }}"
     user: "{{ item.user }}"
     cmd: "{{ item.cmd }}"
+    args: "{{ (item.name == 'ceilometer-api') | ternary('--port %s' % endpoints.ceilometer.port.backend_api, '') }}"
   with_items:
     - "{{ ceilometer.services.ceilometer_api }}"
     - "{{ ceilometer.services.ceilometer_collector }}"


### PR DESCRIPTION
Adjust upstart for aodh-api and ceilometer-api to pass --port which is a change needed for newton.
In addition, remove passing --config-dir to aodh-api.