### PR TITLE
fix minor apache security issues

### DIFF
--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -55,6 +55,31 @@
 
   - name: remove ports.conf
     file: dest=/etc/apache2/ports.conf state=absent
+
+  - name: update security.conf to mask details of apache version and modules
+    lineinfile: dest=/etc/apache2/conf-available/security.conf
+                regexp="^ServerTokens"
+                line='ServerTokens Prod'
+                state=present
+    notify:
+      - reload apache
+
+  - name: mask the version number and the ServerName of apache
+    lineinfile: dest=/etc/apache2/conf-available/security.conf
+                regexp="^ServerSignature"
+                line='ServerSignature Off'
+                state=present
+    notify:
+      - reload apache
+
+  - name: disable trace method on apache
+    lineinfile: dest=/etc/apache2/conf-available/security.conf
+                regexp="^TraceEnable"
+                line='TraceEnable Off'
+                state=present
+    notify:
+      - reload apache
+
   when: ursula_os == 'ubuntu'
 
 - block:

--- a/roles/apache/templates/httpd.conf
+++ b/roles/apache/templates/httpd.conf
@@ -58,6 +58,9 @@ AddDefaultCharset UTF-8
 
 #EnableMMAP off
 EnableSendfile on
+ServerTokens Prod
+ServerSignature Off
+TraceEnable off
 
 # Supplemental configuration
 #


### PR DESCRIPTION
Mask the information shown by apache to end users. This includes
information about modules loaded and the version of apache. This
may make it diffcult for an attacker to exploit any known issues
about a module easily.
Disable the HTTP Trace method.