### PR TITLE
add X-XSS-Protection header to horizon requests

### DIFF
--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -156,6 +156,7 @@ frontend {{ name }}
 
   {% if name == "horizon" -%}
   rspadd Strict-Transport-Security:\ max-age=31536000;\ includeSubDomains
+  rspadd X-XSS-Protection:\ 1 
   bind :::80
   redirect scheme https if !{ ssl_fc }
   {% endif -%}


### PR DESCRIPTION
X-XSS-Protection header forces the Cross-Site Scripting filter into Enabled mode,
even if disabled by the user.This filter is built into most recent web
browsers (IE 8+, Chrome 4+), and is usually enabled by default.The X-XSS-Protection
header is a best-practice to help prevent reflected Cross-Site Scripting attacks.