### PR TITLE
replace run_once

### DIFF
--- a/roles/ceph-osd/tasks/bcache.yml
+++ b/roles/ceph-osd/tasks/bcache.yml
@@ -10,14 +10,14 @@
   shell: ceph osd crush add-bucket {{ hybrid_pool }} root
   register: result
   changed_when: result.stdout |search("added bucket")
-  run_once: true
+  when: inventory_hostname == (play_hosts | intersect(groups['ceph_osds_hybrid']))[0]
 
 # Create crush ruleset for the hybrid root bucket
 - name: Create crush ruleset hybrid root bucket
   shell: ceph osd crush rule create-simple {{ hybrid_ruleset }} {{ hybrid_pool }} host firstn
   register: result
   changed_when: not result.stdout |search("already exists")
-  run_once: true
+  when: inventory_hostname == (play_hosts | intersect(groups['ceph_osds_hybrid']))[0]
 
 - name: Create osd host bucket
   shell: ceph osd crush add-bucket {{ ansible_hostname }} host
@@ -154,11 +154,10 @@
     ceph_init_ssd: "{{ hostvars[item].ceph_init_ssd }}"
     journal_guid: "{{ ceph.journal_guid }}"
   delegate_to: "{{ item }}"
-  with_items: "{{ groups['ceph_osds_hybrid']|default([]) }}"
+  with_items: "{{ groups['ceph_osds_hybrid']|default([])|intersect(play_hosts) }}"
   when:
-    - item in play_hosts
+    - inventory_hostname == (play_hosts | intersect(groups['ceph_osds_hybrid']))[0]
     - hostvars[item].ceph_init_ssd or hostvars[item].result_bcache_backs.changed
-  run_once: true
 
 - name: make sure ceph-osd-all started
   service: name=ceph-osd-all state=started
@@ -170,11 +169,11 @@
     pool_name: "{{ hybrid_pool }}"
     osds: "{{ groups['ceph_osds_hybrid']|length * ceph.disks|length }}"
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  run_once: true
+  when: inventory_hostname == (play_hosts | intersect(groups['ceph_osds_hybrid']))[0]
 
 # not sure is there a better way to get ruleset id
 - name: set ruleset for pool
   shell: ceph osd pool set {{ hybrid_pool }} crush_ruleset
          $(ceph osd crush rule dump |grep {{ hybrid_ruleset }} -A1 |grep -oP '\d+')
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  run_once: true
+  when: inventory_hostname == (play_hosts | intersect(groups['ceph_osds_hybrid']))[0]

--- a/roles/ceph-osd/tasks/standard.yml
+++ b/roles/ceph-osd/tasks/standard.yml
@@ -4,7 +4,7 @@
   shell: ceph osd crush add-bucket {{ ssd_pool }} root
   register: result
   changed_when: result.stdout |search("added bucket")
-  when: inventory_hostname == groups['ceph_osds_ssd'][0]
+  when: inventory_hostname == (play_hosts | intersect(groups['ceph_osds_ssd']))[0]
 
 # Create crush ruleset for the ssd root bucket
 - name: Create crush ruleset ssd root bucket
@@ -12,7 +12,7 @@
   register: result
   changed_when: not result.stdout |search("already exists")
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  run_once: true
+  when: inventory_hostname == (play_hosts | intersect(groups['ceph_osds_ssd']))[0]
 
 # Create osd host bucket
 - name: Create osd host bucket
@@ -37,11 +37,10 @@
 - name: activate new osds(full ssd)
   include: activate_fullssd.yml
   delegate_to: "{{ outer_item }}"
-  with_items: "{{ groups['ceph_osds_ssd']|default([]) }}"
+  with_items: "{{ groups['ceph_osds_ssd']|default([])|intersect(play_hosts) }}"
   loop_control:
     loop_var: outer_item
-  when: outer_item in play_hosts
-  run_once: true
+  when: inventory_hostname == (play_hosts | intersect(groups['ceph_osds_ssd']))[0]
 
 # pool pg number is based on osd amount
 # we should create pool when all osds are up
@@ -50,11 +49,11 @@
     pool_name: "{{ ssd_pool }}"
     osds: "{{ groups['ceph_osds_ssd']|length * ceph.disks|length }}"
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  run_once: true
+  when: inventory_hostname == (play_hosts | intersect(groups['ceph_osds_ssd']))[0]
 
 # not sure is there a better way to get ruleset id
 - name: set ruleset for pool
   shell: ceph osd pool set {{ ssd_pool }} crush_ruleset
          $(ceph osd crush rule dump |grep {{ ssd_ruleset }} -A1 |grep -oP '\d+')
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
-  run_once: true
+  when: inventory_hostname == (play_hosts | intersect(groups['ceph_osds_ssd']))[0]


### PR DESCRIPTION
When run_once comes to `when` condition, ansbile checks run_once first.
For example,
inventory:
```
[ceph_osds_ssd]
ceph1
ceph2
ceph3
[ceph_osds_hybrid]
ceph4
ceph5
ceph6
```

play:
```
- name: run_once test
  hosts: group['ceph_osds_ssd']:groups['ceph_osds_hybrid']
  tasks
    - name: run ssd stuff once
      debug: msg='ssd task'
      when: "'ceph_osds_ssd' in group_names"
      run_once: true

    - name: run hybrid stuff once
      debug: msg='hybrid task'
      when: "'ceph_osds_hybrid' in group_names"
      run_once: true
```

The first task will run once as expected. But when it comes to second
task. The first host is `ceph1`, it's skipped because the `when`
condition. ceph2 and ceph3 are skipped as well.
Now it comes to ceph4, ansible checks run_once first, and it finds that
ceph4 is not the first host in play_hosts, it skip ceph4 because
run_once.
[ansible source code](https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/strategy/linear.py#L253) shows why it has the behavior. Ansible sets run_once flag no matter the
task is skipped on the first play host. Then it uses run_once flag to skips all left hosts.

This patch is to replace these special run_once in ceph-osd role