### PR TITLE
ursula should fail is ursula_os is undefined

### DIFF
--- a/roles/preflight-checks/tasks/main.yml
+++ b/roles/preflight-checks/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: validate ursula_os is a supported operating system and matches host system 
   fail: msg="ursula_os does not match host operating system or {{ ursula_os }} is not a supported operating system (must be rhel or ubuntu)"
-  when: (ursula_os is defined) and ( ursula_os not in ['rhel', 'ubuntu'] or
+  when: (ursula_os is undefined) or ( ursula_os not in ['rhel', 'ubuntu'] or
                                      ursula_os != "{{ ansible_distribution | regex_replace('RedHat|CentOS', 'rhel')|lower }}")
 
 - name: set ssh_service fact for ubuntu


### PR DESCRIPTION
make ursula_os check covering the case that `ursula_os is undefined`.

Also, I notice that we support defined ursula_os in envs file, e.g group_vars/all.yml
Why should we support this feature?
Ursula always run setup to fetch ansible_distribution, then we set ursula_os according to ansible_distribution. May we meet the case that no ansible_distribution exists?