### PR TITLE
install rally through script file

### DIFF
--- a/playbooks/tests/tasks/rally/run.sh
+++ b/playbooks/tests/tasks/rally/run.sh
@@ -22,7 +22,7 @@ source /root/stackrc
 install_rally() {
     attempt=1
     until [[ $attempt == ${RALLY_MAX_RETRY} ]]; do
-        curl ${RALLY_INSTALL_URL} | bash -s -- -y -d rally
+        wget -O  install_rally.sh ${RALLY_INSTALL_URL};chmod +x install_rally.sh; ./install_rally.sh -y -d rally
         if [[ -d rally ]]; then
             break
         else


### PR DESCRIPTION
using bash pipeline to install rally is not stable and replace it by downloading install_rally.sh and install