### PR TITLE
support volume full clone

### DIFF
--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -178,7 +178,7 @@ ceph:
     rbd_user: cinder
     rbd_ceph_conf: /etc/ceph/ceph.conf
     rbd_flatten_volume_from_snapshot: false
-    rbd_max_clone_depth: 5
+    rbd_max_clone_depth: 0
     glance_api_version: 2
 
   # Logging


### PR DESCRIPTION
set rbd_max_clone_depth=0 to implement rbd volume full clone.

With this patch, we support two types of clone. They are full clone and copy-on-write clone.
Full clone:
The path is: source_volume -> target_volume
openstack volume create --source <source_volume> --size <size> <target_volume>

copy-on-write clone:
the path is: source_volume -> snapshot -> target_volume.
openstack snapshot create --name <snap_name> <source_volume>
openstack voluem create --snapshot <snap_name> --size <size> <target_volume>