### PR TITLE
Monitoring fix for ubuntu release

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -126,7 +126,8 @@ common:
         - libssl-dev
         - libxml2-dev
         - libxslt1-dev
-      extra_packages: []
+      extra_packages:
+        - python-dateutil
     rhel:
       system_packages:
         - python-pip

--- a/roles/common/templates/monitoring/sensu-sudoers
+++ b/roles/common/templates/monitoring/sensu-sudoers
@@ -31,3 +31,6 @@ sensu ALL= NOPASSWD: /etc/sensu/plugins/check-ipmi-sensors.py
 sensu ALL= NOPASSWD: /etc/sensu/plugins/metrics-ceph-pool-capacity.rb
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check-inspec.rb
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check-netif.rb
+sensu ALL= NOPASSWD: /etc/sensu/plugins/check-haproxy.rb
+sensu ALL= NOPASSWD: /etc/sensu/plugins/execute-on-ip.sh
+sensu ALL= NOPASSWD: /etc/sensu/plugins/metrics-nova-oversub.sh

--- a/roles/haproxy/tasks/monitoring.yml
+++ b/roles/haproxy/tasks/monitoring.yml
@@ -7,6 +7,7 @@
 - name: haproxy check backends
   sensu_check: name=haproxy_servers plugin=check-haproxy.rb
                args="-c 100 -S /var/run/haproxy/stats.sock -A"
+               use_sudo=true
   notify: restart sensu-client
 
 - name: haproxy metrics

--- a/roles/nova-control/tasks/monitoring.yml
+++ b/roles/nova-control/tasks/monitoring.yml
@@ -50,6 +50,7 @@
   sensu_metrics_check: name=nova-oversubscribe-metrics plugin=metrics-nova-oversub.sh
                        args='-s {{ monitoring.graphite.cluster_prefix }}.nova.oversubscription'
                        interval=3600
+                       use_sudo=true
                        only_on_ip="{{ undercloud_floating_ip | default(floating_ip) }}"
   notify: restart sensu-client
 
@@ -84,7 +85,7 @@
     plugin: metrics-nova-project-usage.py
     state: absent
   notify: restart sensu-client
-  
+
 - name: nova limit metrics (quota/usage)
   sensu_metrics_check:
     name: compute-limit-metrics

--- a/roles/nova-data/tasks/monitoring.yml
+++ b/roles/nova-data/tasks/monitoring.yml
@@ -13,7 +13,9 @@
   sensu_metrics_check: name=check-cinder-sessions plugin=check-cinder-sessions.py
                        interval=10
   notify: restart sensu-client
-  when: not ceph.enabled
+  when:
+    - not ceph.enabled
+    - cinder.enabled|bool or cinderv2.enabled|bool
 
 - name: qemu crash check
   sensu_check_dict:

--- a/roles/sensu-check/defaults/main.yml
+++ b/roles/sensu-check/defaults/main.yml
@@ -93,6 +93,7 @@ sensu_checks:
 
   nova:
     check_nova_services:
+      auto_resolve: true
       handler: default
       interval: 120
       standalone: true


### PR DESCRIPTION
1. Python-dateutil package missing in base venv
2. Some check need be added into shudders after security hardening
3.  Check-cinder-sessions check should be only installed for ceph
disabled and cinder enabled env
4.  Set explicit auto_resolve attribute for  check_nova_services.