### PR TITLE
fix ceph ssh check

### DIFF
--- a/playbooks/tests/tasks/ceph.yml
+++ b/playbooks/tests/tasks/ceph.yml
@@ -70,7 +70,8 @@
       poll: 0
        
     - name: wait for {{ inventory_hostname }} to become reachable
-      local_action: wait_for port=22 host={{ ansible_ssh_host | default(inventory_hostname) }} search_regex=OpenSSH delay=20
+      wait_for: port=22 host={{ ansible_default_ipv4.address }}  search_regex=OpenSSH delay=20
+      delegate_to: localhost
       become: false
 
     - name: check ceph status


### PR DESCRIPTION
The following check only guaranttee ssh service in deployer is up. 
```
local_action: wait_for port=22 host="{{ ansible_host | default(inventory_hostname) }}"  search_regex=OpenSSH delay=2 timeout

```
ansible_host= localhost.

should check if cpm01 and osd0 is up