### PR TITLE
pin rabbitmq-server and esl-erlang versions.

### DIFF
--- a/roles/rabbitmq/defaults/main.yml
+++ b/roles/rabbitmq/defaults/main.yml
@@ -11,7 +11,9 @@ rabbitmq:
   numqueues_warning_multiplier: 60
   numqueues_critical_multiplier: 120
   nofile: 10240
-  version_for_upgrade: 3.6.9*
+  version:
+    rabbitmq_server: '3.6.9*'
+    esl_erlang: '1:19*'
   monitoring:
     sensu_checks:
       rabbitmq_cluster:
@@ -27,4 +29,3 @@ rabbitmq:
       fields:
         type: rabbitmq
         tags: rabbitmq
-

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -4,62 +4,72 @@
 - name: add rabbitmq config directory
   file: dest=/etc/rabbitmq state=directory owner=root mode=0755
 
-# pin version of esl-erlang for
-# https://github.com/rabbitmq/rabbitmq-management/issues/244
-# lift when rabbitmq-server 3.6.4 is released
-- name: install erlang-solutions erlang
-  apt:
-    pkg: esl-erlang=1:18.3
-    force: True
-  register: result
-  until: result|succeeded
-  retries: 5
-  when: ansible_distribution in ['Ubuntu']
+- block:
+  - name: install erlang-solutions erlang (ubuntu)
+    apt:
+      pkg: esl-erlang={{ rabbitmq.version.esl_erlang }}
+      force: True
+    register: result
+    until: result|succeeded
+    retries: 5
+    notify: restart rabbitmq
 
-- name: install EPEL erlang
-  package:
-    name: erlang
-  register: result
-  until: result|succeeded
-  retries: 5
-  when: ansible_distribution in ['CentOS','RedHat']
+  - name: install rabbitmq-server (ubuntu)
+    package:
+      name: rabbitmq-server={{ rabbitmq.version.rabbitmq_server }}
+    register: result
+    until: result|succeeded
+    retries: 5
+    notify: restart rabbitmq
 
-- name: install rabbitmq-server
-  package:
-    name: rabbitmq-server
-  with_items:
-    - rabbitmq-server
-  register: result
-  until: result|succeeded
-  retries: 5
+  - name: upgrade rabbitmq for CVEs on upgrade/update (ubuntu)
+    apt:
+      pkg: "{{ item }}"
+      update_cache: yes
+    with_items:
+      - esl-erlang={{ rabbitmq.version.esl_erlang }}
+      - rabbitmq-server={{ rabbitmq.version.rabbitmq_server }}
+    notify: restart rabbitmq
+    when: upgrade | default('False') | bool
+  when: ursula_os == "ubuntu"
 
-- name: upgrade rabbitmq for CVEs on upgrade
-  apt:
-    pkg: "{{ item }}"
-    update_cache: yes
-  with_items:
-    - rabbitmq-server={{ rabbitmq.version_for_upgrade }}
-  when: upgrade | default('False') | bool
+- block:
+  - name: install EPEL erlang (rhel)
+    package:
+      name: erlang
+      state: latest
+    register: result
+    until: result|succeeded
+    retries: 5
+    notify: restart rabbitmq
 
-- name: create systemd override dir
-  file:
-    dest: /etc/systemd/system/rabbitmq-server.service.d
-    state: directory
-  when: ursula_os == 'rhel' 
+  - name: install rabbitmq-server (rhel)
+    package:
+      name: rabbitmq-server
+      state: latest
+    register: result
+    until: result|succeeded
+    retries: 5
+    notify: restart rabbitmq
 
-- name: set systemd overrides
-  copy:
-    dest: /etc/systemd/system/rabbitmq-server.service.d/override.conf
-    content: "{{ rabbitmq.systemd.custom }}"
-    force: yes
-  register: override
-  when: ursula_os == 'rhel'
+  - name: create systemd override dir
+    file:
+      dest: /etc/systemd/system/rabbitmq-server.service.d
+      state: directory
 
-- name: restart systemd
-  command: systemctl daemon-reload
-  when: override.changed and ursula_os == 'rhel'
-  notify: 
-    - restart rabbitmq
+  - name: set systemd overrides
+    copy:
+      dest: /etc/systemd/system/rabbitmq-server.service.d/override.conf
+      content: "{{ rabbitmq.systemd.custom }}"
+      force: yes
+    register: override
+
+  - name: restart systemd
+    command: systemctl daemon-reload
+    when: override.changed
+    notify:
+      - restart rabbitmq
+  when: ursula_os == "rhel"
 
 - name: add rabbitmq environment configuration
   template: src=etc/rabbitmq/rabbitmq-env.conf


### PR DESCRIPTION
Currently we are installing latest rabbitmq-server (3.6.9*) and have esl-erlang pinned at 1:18.3. This is causing memory leak which would crash rabbitmq when performing a rally test 20 concurrent VM's. We start seeing crash around 100 VM.

Moving up esl-erlang to 1:19.3 let's us successfully provision upto 900 VM which is max vm limit for the environment. 

This PR pin's rabbitmq-server and esl-erlang to latest tested version. For RHOSP we always install latest as those are tested by redhat before publishing to their repo.

We will cherry pick this fix to RELEASE-3.1.x branch as well.