### PR TITLE
backport rabbitmq fix from PR 2743.

### DIFF
--- a/roles/rabbitmq/defaults/main.yml
+++ b/roles/rabbitmq/defaults/main.yml
@@ -11,6 +11,9 @@ rabbitmq:
   numqueues_warning_multiplier: 60
   numqueues_critical_multiplier: 120
   nofile: 10240
+  version:
+    rabbitmq_server: '3.6.9*'
+    esl_erlang: '1:19*'
   monitoring:
     sensu_checks:
       rabbitmq_cluster:

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -5,35 +5,31 @@
 - name: add rabbitmq config directory
   file: dest=/etc/rabbitmq state=directory owner=root mode=0755
 
-# pin version of esl-erlang for
-# https://github.com/rabbitmq/rabbitmq-management/issues/244
-# lift when rabbitmq-server 3.6.4 is released
 - name: install erlang-solutions erlang
   apt:
-    pkg: "{{ item }}"
+    pkg: esl-erlang={{ rabbitmq.version.esl_erlang }}
     force: True
-  with_items:
-    - esl-erlang=1:18.3
   register: result
   until: result|succeeded
   retries: 5
+  notify: restart rabbitmq
 
 - name: install rabbitmq-server
   apt:
-    pkg: "{{ item }}"
-  with_items:
-    - rabbitmq-server
-    #- esl-erlang
+    pkg: rabbitmq-server={{ rabbitmq.version.rabbitmq_server }}
   register: result
   until: result|succeeded
   retries: 5
+  notify: restart rabbitmq
 
 - name: upgrade rabbitmq for CVEs on upgrade
   apt:
     pkg: "{{ item }}"
     update_cache: yes
   with_items:
-    - rabbitmq-server=3.6.9*
+    - esl-erlang={{ rabbitmq.version.esl_erlang }}
+    - rabbitmq-server={{ rabbitmq.version.rabbitmq_server }}
+  notify: restart rabbitmq
   when: upgrade | default('False') | bool
 
 - name: add rabbitmq environment configuration


### PR DESCRIPTION
Currently we are installing latest rabbitmq-server (3.6.9*) and have esl-erlang pinned at 1:18.3. This is causing memory leak which would crash rabbitmq when performing a rally test 20 concurrent VM's. We start seeing crash around 100 VM.

Moving up esl-erlang to 1:19.3 let's us successfully provision upto 900 VM which is max vm limit for the environment.

This PR pin's rabbitmq-server and esl-erlang to latest tested version.