### PR TITLE
remove obsolete task from rabbitmq role.

### DIFF
--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -21,16 +21,6 @@
     until: result|succeeded
     retries: 5
     notify: restart rabbitmq
-
-  - name: upgrade rabbitmq for CVEs on upgrade/update (ubuntu)
-    apt:
-      pkg: "{{ item }}"
-      update_cache: yes
-    with_items:
-      - esl-erlang={{ rabbitmq.version.esl_erlang }}
-      - rabbitmq-server={{ rabbitmq.version.rabbitmq_server }}
-    notify: restart rabbitmq
-    when: upgrade | default('False') | bool
   when: ursula_os == "ubuntu"
 
 - block:


### PR DESCRIPTION
Given we are now pining rabbitmq-server and esl-erlang to a tested version we no longer need special handling of rabbitmq-server version bump for update path.