### PR TITLE
move cinder-data package installation out from lvm

### DIFF
--- a/roles/cinder-data/tasks/lvm_integration.yml
+++ b/roles/cinder-data/tasks/lvm_integration.yml
@@ -1,11 +1,4 @@
 ---
-- name: install cinder-data required packages
-  package: name={{ item }}
-  with_items: "{{ cinder.data_pkgs[ursula_os] }}"
-  register: result
-  until: result|succeeded
-  retries: 5
-
 - name: iscsi target framework conf dir
   file: dest=/etc/tgt/conf.d state=directory
 

--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: install cinder-data required packages
+  package: name={{ item }}
+  with_items: "{{ cinder.data_pkgs[ursula_os] }}"
+  register: result
+  until: result|succeeded
+  retries: 5
+
 - include: lvm_integration.yml
   when: lvm.enabled
 


### PR DESCRIPTION
 We need package qemu-utils even when lvm not enabled.