### PR TITLE
Use curl to download rally installation file

### DIFF
--- a/playbooks/tests/tasks/rally/run.sh
+++ b/playbooks/tests/tasks/rally/run.sh
@@ -22,7 +22,7 @@ source /root/stackrc
 install_rally() {
     attempt=1
     until [[ $attempt == ${RALLY_MAX_RETRY} ]]; do
-        wget -O  install_rally.sh ${RALLY_INSTALL_URL};chmod +x install_rally.sh; ./install_rally.sh -y -d rally
+        curl -O ${RALLY_INSTALL_URL};chmod +x install_rally.sh; ./install_rally.sh -y -d rally
         if [[ -d rally ]]; then
             break
         else


### PR DESCRIPTION
wget is not installed on centos and redhat, so use curl instead to download rally installation file.