### PR TITLE
Use uwsgi between Apache and Keystone

### DIFF
--- a/roles/apache/defaults/main.yml
+++ b/roles/apache/defaults/main.yml
@@ -13,6 +13,7 @@ apache:
     ubuntu:
       - libapache2-mod-wsgi
       - libapache2-mod-uwsgi
+      - libapache2-mod-proxy-uwsgi
     rhel:
       - mod_wsgi
       - mod_proxy_uwsgi

--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -34,6 +34,7 @@
       - uwsgi
       - proxy
       - proxy_http
+      - proxy_uwsgi
     notify: reload apache
 
   - name: disable apache status
@@ -106,6 +107,16 @@
       - userdir.conf
       - welcome.conf
     notify: restart apache
+
+  - name: enable the mod_proxy_uwsgi module
+    template:
+      src: etc/httpd/conf.modules.d/43-mod_proxy_uwsgi.conf
+      dest: /etc/httpd/conf.modules.d/43-mod_proxy_uwsgi.conf
+      mode: 0644
+      owner: root
+      group: root
+    notify: restart apache
+
   when: ursula_os == 'rhel'
 
 - name: enable apache server
@@ -114,9 +125,9 @@
     enabled: true
 
 - name: create horizon config directory
-  file: 
+  file:
     dest: "/etc/openstack-dashboard"
-    state: directory 
+    state: directory
     group: "{{ openstack_meta.apache[ursula_os].group }}"
     mode: 0750
 

--- a/roles/apache/templates/etc/httpd/conf.modules.d/43-mod_proxy_uwsgi.conf
+++ b/roles/apache/templates/etc/httpd/conf.modules.d/43-mod_proxy_uwsgi.conf
@@ -1,0 +1,1 @@
+LoadModule proxy_uwsgi_module modules/mod_proxy_uwsgi.so

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -83,11 +83,13 @@
   template: src=etc/keystone/uwsgi/keystone-admin.ini
             dest=/etc/keystone/uwsgi/keystone-admin.ini mode=0775
             owner=keystone group=keystone
+  notify: restart keystone services
 
 - name: configure keystone public wsgi
   template: src=etc/keystone/uwsgi/keystone-main.ini
             dest=/etc/keystone/uwsgi/keystone-main.ini mode=0775
             owner=keystone group=keystone
+  notify: restart keystone services
 
 - name: setup keystone sso template
   template: src=etc/keystone/sso_callback_template.html

--- a/roles/keystone/templates/etc/apache2/sites-available/keystone.conf
+++ b/roles/keystone/templates/etc/apache2/sites-available/keystone.conf
@@ -109,38 +109,45 @@ Listen {{ endpoints.keystone.port.backend_api }}
 
 <VirtualHost *:{{ endpoints.keystone_admin.port.backend_api }}>
 ServerName https://{{ fqdn }}
-
 {% if keystone.federation.enabled|bool and keystone.federation.sp.oidc.enabled|bool -%}
     {{ setup_oidc() }}
-{% endif -%}
+{% endif %}
+
     <Location />
 {% if keystone.uwsgi.method == 'socket' %}
-        ProxyPass /run/uwsgi/keystone-admin.socket
+        Options FollowSymLinks Indexes
+        SetHandler uwsgi-handler
+        uWSGImaxVars 255
+        uWSGISocket /run/uwsgi/keystone-admin.socket
 {% else %}
-        ProxyPass http://127.0.0.1:{{ keystone.uwsgi.http_port.admin }}/
+        ProxyPass uwsgi://127.0.0.1:{{ keystone.uwsgi.http_port.admin }}/
         SetEnv force-proxy-request-1.0 1
         SetEnv proxy-nokeepalive 1
 {% endif %}
     </Location>
+
     ErrorLog {{ apache_log_path[ursula_os] }}/error.log
     LogLevel error
 </VirtualHost>
 
 <VirtualHost *:{{ endpoints.keystone.port.backend_api }}>
 ServerName https://{{ fqdn }}
-
 {% if keystone.federation.enabled|bool and keystone.federation.sp.oidc.enabled|bool -%}
     {{ setup_oidc() }}
-{% endif -%}
+{% endif %}
 
     <Location />
-{% if keystone.uwsgi.method == 'socket' %}
-        ProxyPass /run/uwsgi/keystone-public.socket
-{% else %}
-        ProxyPass http://127.0.0.1:{{ keystone.uwsgi.http_port.public }}/
+    {% if keystone.uwsgi.method == 'socket' %}
+        Options FollowSymLinks Indexes
+        SetHandler uwsgi-handler
+        uWSGImaxVars 255
+        uWSGISocket /run/uwsgi/keystone-main.socket
+    {% else %}
+        ProxyPass uwsgi://127.0.0.1:{{ keystone.uwsgi.http_port.public }}/
         SetEnv force-proxy-request-1.0 1
         SetEnv proxy-nokeepalive 1
-{% endif %}
+    {% endif %}
+
     </Location>
 
 {% if keystone.federation.enabled|bool and keystone.federation.sp.saml.enabled|bool -%}

--- a/roles/keystone/templates/etc/keystone/uwsgi/keystone-admin.ini
+++ b/roles/keystone/templates/etc/keystone/uwsgi/keystone-admin.ini
@@ -11,9 +11,9 @@ logto = /var/log/keystone/keystone-all.log
 logfile-chmod = 644
 
 {% if keystone.uwsgi.method == 'socket' %}
-socket = /run/uwsgi/keystone-admin.socket
+uwsgi-socket = /run/uwsgi/keystone-admin.socket
 {% else %}
-http-socket = 127.0.0.1:{{ keystone.uwsgi.http_port.admin }}
+uwsgi-socket = 127.0.0.1:{{ keystone.uwsgi.http_port.admin }}
 {% endif %}
 
 name = keystone

--- a/roles/keystone/templates/etc/keystone/uwsgi/keystone-main.ini
+++ b/roles/keystone/templates/etc/keystone/uwsgi/keystone-main.ini
@@ -11,9 +11,9 @@ logto = /var/log/keystone/keystone-all.log
 logfile-chmod = 644
 
 {% if keystone.uwsgi.method == 'socket' %}
-socket = /run/uwsgi/keystone-main.socket
+uwsgi-socket = /run/uwsgi/keystone-main.socket
 {% else %}
-http-socket = 127.0.0.1:{{ keystone.uwsgi.http_port.public }}
+uwsgi-socket = 127.0.0.1:{{ keystone.uwsgi.http_port.public }}
 {% endif %}
 
 name = keystone


### PR DESCRIPTION
This switches from using http to uwsgi between Apache and Keystone.
If the uwsgi port setting is used, then mod_proxy_uwsgi will be used.
Otherwise if the file socket setting is used, then the uwsgi module will be used.
Both Ubuntu and Redhat will be able to use the port setting, but
only Ubuntu can use the file socket setting. The file socket was
previously broken but now will work on Ubuntu with this change.