### PR TITLE
Get Saml IDP metadata from file

### DIFF
--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -112,6 +112,9 @@ keystone:
             enabled: True
             k2k_enabled: False
             verify_idp_cert: True
+            metadata_provider_type: url
+            metadata_file_path: /etc/shibboleth/idp_metadata.xml
+            metadata_file_content: None
             idp_metadata_min_refresh_delay: 600
             idp_metadata_max_refresh_delay: 3600
             idp_metadata_factor_refresh_delay: 0.75

--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -103,6 +103,7 @@ keystone:
         enabled: False
         horizon_enabled: False
         support_contact: ""
+        auth_signing: True
         # These are service providers that will be configured into Shibboleth
         providers:
           - keystone_id: Place_holder_IDP

--- a/roles/keystone/tasks/saml.yml
+++ b/roles/keystone/tasks/saml.yml
@@ -18,6 +18,12 @@
             dest=/etc/shibboleth/attribute-map.xml
   notify: restart shibboleth
 
+- name: Create idp metadata file
+  template: src=etc/shibboleth/idp_metadata.xml
+            dest=/etc/shibboleth/idp_metadata.xml
+  when: keystone.federation.sp.saml.providers[0].metadata_provider_type == 'file'
+  notify: restart shibboleth
+
 - name: configure shibboleth settings
   template:
     src: etc/shibboleth/shibboleth2.xml

--- a/roles/keystone/templates/etc/apache2/sites-available/keystone.conf
+++ b/roles/keystone/templates/etc/apache2/sites-available/keystone.conf
@@ -6,6 +6,7 @@ Listen {{ endpoints.keystone.port.backend_api }}
     ShibCompatValidUser On
 
     <Location /Shibboleth.sso>
+        ProxyPass !
         SetHandler shib
     </Location>
 

--- a/roles/keystone/templates/etc/keystone/keystone.conf
+++ b/roles/keystone/templates/etc/keystone/keystone.conf
@@ -94,13 +94,6 @@ methods = external,password,token{{ ',saml2' if keystone.federation.enabled|bool
 {%- endfor -%}
 {%- endif %}
 
-{% if keystone.federation.enabled|bool and keystone.federation.sp.oidc.enabled|bool -%}
-{% for sp in keystone.federation.sp.oidc.providers_info %}
-{{ sp.protocol_name }} = keystone.auth.plugins.mapped.Mapped
-{% endfor %}
-{% endif %}
-{{ 'saml2 = keystone.auth.plugins.mapped.Mapped' if keystone.federation.enabled|bool and keystone.federation.sp.saml.enabled|bool else '' }}
-
 [federation]
 driver = sql
 trusted_dashboard = https://{{ fqdn }}/auth/websso/
@@ -115,7 +108,7 @@ remote_id_attribute = {{ sp.remote_id_attribute }}
 
 {% if keystone.federation.enabled|bool  and keystone.federation.sp.saml.enabled|bool -%}
 
-[saml]
+[saml2]
 remote_id_attribute = Shib-Identity-Provider
 {% endif -%}
 

--- a/roles/keystone/templates/etc/shibboleth/attribute-map.xml
+++ b/roles/keystone/templates/etc/shibboleth/attribute-map.xml
@@ -1,5 +1,5 @@
 <Attributes xmlns="urn:mace:shibboleth:2.0:attribute-map" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 {% for attribute in keystone.federation.sp.saml.providers[0].attributes -%}
-    <Attribute name="{{ attribute.name }}" id="{{ attribute.id }}"/>
-{% endfor -%}
+    <Attribute name="{{ attribute.name }}" id="{{ attribute.id }}" {% if attribute.format is defined -%}nameFormat="{{ attribute.format }}"{%- endif-%}/>
+{% endfor %}
 </Attributes>

--- a/roles/keystone/templates/etc/shibboleth/idp_metadata.xml
+++ b/roles/keystone/templates/etc/shibboleth/idp_metadata.xml
@@ -1,0 +1,1 @@
+{{ keystone.federation.sp.saml.providers[0].metadata_file_content }}

--- a/roles/keystone/templates/etc/shibboleth/shibboleth2.xml
+++ b/roles/keystone/templates/etc/shibboleth/shibboleth2.xml
@@ -48,6 +48,10 @@
             helpLocation="/about.html"
             styleSheet="/shibboleth-sp/main.css"/>
 
+{% if keystone.federation.sp.saml.providers[0].metadata_provider_type == 'file' %}
+        <MetadataProvider type="XML" path="{{keystone.federation.sp.saml.providers[0].metadata_file_path}}" />
+{% endif %}
+{% if keystone.federation.sp.saml.providers[0].metadata_provider_type == 'url' %}
         <MetadataProvider type="XML" uri="{{ keystone.federation.sp.saml.providers[0].idp_metadata_url }}"
           backingFilePath="idp-metadata-provider-backup.xml"
           {% if keystone.federation.sp.saml.providers[0].idp_metadata_min_refresh_delay is defined %}
@@ -65,6 +69,7 @@
           <TransportOption provider="CURL" option="10065">/etc/ssl/certs/ca-certificates.crt</TransportOption>
           {% endif -%}
         </MetadataProvider>
+{% endif %}
         <AttributeExtractor type="XML" validate="true" reloadChanges="false" path="attribute-map.xml"/>
         <AttributeResolver type="Query" subjectMatch="true"/>
         <AttributeFilter type="XML" validate="true" path="attribute-policy.xml"/>

--- a/roles/keystone/templates/etc/shibboleth/shibboleth2.xml
+++ b/roles/keystone/templates/etc/shibboleth/shibboleth2.xml
@@ -28,7 +28,8 @@
     <ReplayCache StorageService="mc"/>
     <ArtifactMap StorageService="mc" artifactTTL="180"/>
 
-    <ApplicationDefaults entityID="{{ keystone.federation.sp.saml.sp_id }}">
+    <ApplicationDefaults entityID="{{ keystone.federation.sp.saml.sp_id }}"
+      {%- if keystone.federation.sp.saml.auth_signing %} signing="true"{%- endif-%}>
         <Sessions lifetime="28800" timeout="3600" relayState="ss:mc"
                   checkAddress="false" handlerSSL="false" cookieProps="http">
             <SSO entityID="{{ keystone.federation.sp.saml.providers[0].saml_entity_id }}" ECP="true">


### PR DESCRIPTION
This PR makes the SAML integration more flexible. This PR allows setting a file source for the identity metadata instead of just using a URL. This also enables the auth signing request when the service provider redirects the user to the identity provider.