### PR TITLE
add o+rx permission to directory /var/log/ceph

### DIFF
--- a/roles/ceph-monitor/tasks/main.yml
+++ b/roles/ceph-monitor/tasks/main.yml
@@ -60,6 +60,13 @@
     - ceph.log
     - ceph.audit.log
 
+- name: make sure /var/log/ceph has rx permissions for other user
+  file: path=/var/log/ceph
+        state=touch
+        owner=ceph
+        group=ceph
+        mode="o+rx"
+
 - name: activate monitor with upstart
   file: path=/var/lib/ceph/mon/ceph-{{ ansible_hostname }}/{{ item }}
         state=touch


### PR DESCRIPTION
for release 3.1.x:
user and group of `/var/log/ceph` is not ceph:ceph. This PR fix that.
chanages:
1. user:group change to ceph:ceph.
2. add o+rx.