### PR TITLE
 provide multipath support for V7K

### DIFF
--- a/roles/nova-common/meta/main.yml
+++ b/roles/nova-common/meta/main.yml
@@ -44,3 +44,4 @@ dependencies:
     when:
       - openstack_install_method == 'distro'
       - inventory_hostname in groups['compute']
+  - role: v7k-defaults

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -160,6 +160,13 @@ reserved_host_memory_mb = 4096
 {% endif %}
 disk_cachemodes = "network=writeback"
 
+{% if v7k.enabled %}
+{% if v7k.multipath.enabled %}
+iscsi_use_multipath = True
+{% endif %}
+{% endif %}
+
+
 [neutron]
 url = {{ endpoints.neutron.url.internal }}
 auth_url = {{ endpoints.keystone.url.admin}}

--- a/roles/nova-data/handlers/main.yml
+++ b/roles/nova-data/handlers/main.yml
@@ -11,3 +11,10 @@
   service: name={{ item.name }} state=restarted must_exist=false
   with_items:
     - "{{ nova.services.nova_compute }}"
+
+- name: restart multipath service
+  service:
+    name: "{{ v7k.multipath[ursula_os].service_name }}"
+    state: restarted
+
+

--- a/roles/nova-data/tasks/main.yml
+++ b/roles/nova-data/tasks/main.yml
@@ -133,3 +133,6 @@
     dest: /dev/kvm
     mode: 0660
   when: ursula_os == 'rhel'
+
+- include: v7k.yml
+  when: v7k.enabled|bool and v7k.multipath.enabled|bool

--- a/roles/nova-data/tasks/v7k.yml
+++ b/roles/nova-data/tasks/v7k.yml
@@ -1,0 +1,20 @@
+---
+- name: install device-mapper-multipath packages
+  package: name="{{ v7k.multipath[ursula_os].package_name }}"
+  register: result
+  until: result|succeeded
+  retries: 5
+
+- name: generate multipath.conf
+  template: src=etc/multipath.conf dest=/etc/multipath.conf 
+            mode=0640
+            owner=root group=root
+  notify:
+    - restart multipath service
+
+- name: start multipath
+  service:
+    name: "{{ v7k.multipath[ursula_os].service_name }}"
+    state: started
+    enabled: True
+

--- a/roles/nova-data/templates/etc/multipath.conf
+++ b/roles/nova-data/templates/etc/multipath.conf
@@ -1,0 +1,3 @@
+defaults {
+        user_friendly_names no
+}

--- a/roles/openstack-setup/meta/main.yml
+++ b/roles/openstack-setup/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - role: endpoints
+  - role: v7k-defaults

--- a/roles/preflight-checks/meta/main.yml
+++ b/roles/preflight-checks/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - role: endpoints
+  - role: v7k-defaults

--- a/roles/v7k-defaults/defaults/main.yml
+++ b/roles/v7k-defaults/defaults/main.yml
@@ -2,3 +2,12 @@
 v7k:
   enabled: False
   ssh_port: 22
+  multipath:
+    enabled: False
+    ubuntu:
+      package_name: multipath-tools
+      service_name: multipath-tools
+    rhel:
+      package_name: device-mapper-multipath
+      service_name: multipathd
+  


### PR DESCRIPTION
multiple path support includes the three parts

- install the package(multipath-tools for ubuntu or  device-mapper-multipath for redhat)
- add etc/multipath.conf 
- add iscsi_use_multipath = True to nova.conf
