### PR TITLE
backport novaclient pin to rhosp release branch.

### DIFF
--- a/envs/example/ci-full-rhel/group_vars/all.yml
+++ b/envs/example/ci-full-rhel/group_vars/all.yml
@@ -74,3 +74,6 @@ ironic:
 
 cinder:
   enabled: False
+
+cinderv2:
+  enabled: False

--- a/playbooks/tests/tasks/controller.yml
+++ b/playbooks/tests/tasks/controller.yml
@@ -120,7 +120,10 @@
       - nova
       - neutron
       - glance
-      - cinder
+
+  - name: keystone should include Cinder OpenStack services
+    shell: . /root/stackrc; openstack service list | grep cinder
+    when: cinder.enabled|bool
 
   - name: cinder has a working api
     shell: . /root/stackrc; cinder list | grep ID

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pep8
 oslo.utils
 shade>=1.7.0
 ansible>=2.1.0.0,<3,<=2.1.3
-python-novaclient
+python-novaclient<8.0.0
 python-glanceclient
 python-cinderclient
 python-neutronclient

--- a/test/setup
+++ b/test/setup
@@ -117,11 +117,12 @@ fi
 
 #workaround security group issue for defect 344951 and security rules can take effect after retouch securitygroup
 
-secgroup=$(nova secgroup-list|grep ${SECURITYGROUP_NAME})
+secgroup=$(openstack security group list|grep ${SECURITYGROUP_NAME})
 secgroup_id=$(echo ${secgroup}|awk '{print $2}')
 
-nova secgroup-add-rule    ${secgroup_id} tcp 23 23 192.168.1.1/32
-nova secgroup-delete-rule ${secgroup_id} tcp 23 23 192.168.1.1/32
+openstack security group rule create  --protocol tcp --ingress --dst-port 23:23 --remote-ip 192.168.1.1/32 ${secgroup_id}
+secgroup_rule_id=$(openstack security group rule list|grep 192.168.1.1/32|awk '{print $2}')
+openstack security group rule delete ${secgroup_rule_id}
 
 ring_bell
 echo "vms are up: ${VMS} !!"


### PR DESCRIPTION
Backporting novaclient-pin to < 8.0.0 for CI to able to create security groups.