### PR TITLE
Allow admin users to list stacks from all projects

### DIFF
--- a/roles/heat/templates/etc/heat/policy.json
+++ b/roles/heat/templates/etc/heat/policy.json
@@ -47,7 +47,7 @@
     "stacks:detail": "rule:deny_stack_user",
     "stacks:export": "rule:deny_stack_user",
     "stacks:generate_template": "rule:deny_stack_user",
-    "stacks:global_index": "rule:deny_everybody",
+    "stacks:global_index": "rule:context_is_admin or rule:deny_everybody",
     "stacks:index": "rule:deny_stack_user",
     "stacks:list_resource_types": "rule:deny_stack_user",
     "stacks:list_template_versions": "rule:deny_stack_user",


### PR DESCRIPTION
By default a user with the `admin` role is not allowed to list stacks that do not belong to the admin project. This causes an issue for operators as they cannot see any stacks that are in other projects.