### PR TITLE
add logic for creating cinder endpoints

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -665,12 +665,6 @@ logging:
 keystonev3:
   enabled: True
 
-cinderv2:
-  enabled: True
-
-cinderv3:
-  enabled: True
-
 magnum:
   enabled: False
   debug: True

--- a/roles/openstack-setup/tasks/cinder.yml
+++ b/roles/openstack-setup/tasks/cinder.yml
@@ -1,4 +1,24 @@
 ---
+- name: cinder services
+  environment:
+    PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
+  keystone_service: name={{ item.name }}
+                    type={{ item.type }}
+                    description='{{ item.description }}'
+                    public_url={{ item.public_url }}
+                    internal_url={{ item.internal_url }}
+                    admin_url={{ item.admin_url }}
+                    region=RegionOne
+                    auth_url={{ endpoints.auth_uri }}
+                    tenant_name=admin
+                    login_user=admin
+                    login_password={{ secrets.admin_password }}
+                    insecure={{ insecure|default(omit) }}
+  with_items: "{{ keystone.services }}"
+  when: 
+    - (item.name in ['cinder','cinderv2','cinderv3'])
+  run_once: true
+
 - name: create cinder volume types(ceph backend)
   environment:
     PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"

--- a/roles/openstack-setup/tasks/users.yml
+++ b/roles/openstack-setup/tasks/users.yml
@@ -15,6 +15,8 @@
                     login_password={{ secrets.admin_password }}
                     insecure={{ insecure|default(omit) }}
   with_items: "{{ keystone.services }}"
-  when: "{{item.name}}.enabled is undefined or {{item.name}}.enabled|bool"
+  when: 
+    - (item.name.enabled is undefined or item.name.enabled|bool)
+    - item.name not in ['cinder','cinderv2','cinderv3']
   run_once: true
   register: services_setup


### PR DESCRIPTION
Cinder v2 and v3 endpoints were previously being created even when cinder.enabled=false, creating the need for cinderv2.enabled and cinderv3.enabled.  