### PR TITLE
add cinder rootwrap search dirs

### DIFF
--- a/roles/cinder-common/templates/etc/cinder/rootwrap.conf
+++ b/roles/cinder-common/templates/etc/cinder/rootwrap.conf
@@ -10,11 +10,7 @@ filters_path=/etc/cinder/rootwrap.d,/usr/share/cinder/rootwrap
 # explicitely specify a full path (separated by ',')
 # If not specified, defaults to system PATH environment variable.
 # These directories MUST all be only writeable by root !
-{% if openstack_install_method == "package" -%}
-exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin,{{ 'cinder'|ursula_package_path(openstack_package_version) }}/bin
-{% else -%}
-exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin
-{% endif -%}
+exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin,/opt/openstack/current/cinder/bin
 
 # Enable logging to syslog
 # Default value is False


### PR DESCRIPTION
We missed the venv bin dir in rootwrap.conf for source installation method.
I found this when I tried to create an encrapted volume from image.
It said that no privsep-helper, but in fact privsep-helper is in cinder venv bin dir.