### PR TITLE
Enable SAML federation on RHEL

### DIFF
--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -86,6 +86,14 @@ keystone:
     sensu_checks:
       check_keystone_api:
         criticality: 'critical'
+  shibboleth:
+    package_name:
+      ubuntu: libapache2-mod-shib2
+      rhel: shibboleth.x86_64
+    user_group:
+      ubuntu: _shibd
+      rhel: shibd
+    cafile: '{{ ssl.cafile }}'
   federation:
     enabled: False
     idp:

--- a/roles/keystone/meta/main.yml
+++ b/roles/keystone/meta/main.yml
@@ -44,3 +44,6 @@ dependencies:
       - { protocol: tcp, port: "{{ endpoints.keystone.port.haproxy_api }}" }
       - { protocol: tcp, port: "{{ endpoints.keystone_admin.port.haproxy_api }}" }
       - { protocol: tcp, port: "{{ endpoints.keystone_legacy.port.haproxy_api }}" }
+  - role: repos
+    repo: opensuse
+    when: ursula_os == 'rhel'

--- a/roles/keystone/tasks/saml.yml
+++ b/roles/keystone/tasks/saml.yml
@@ -1,6 +1,8 @@
 ---
-- name: install libapache2-mod-shib2
-  apt: name=libapache2-mod-shib2 state=present
+- name: install shibboleth
+  package:
+    name: "{{ keystone.shibboleth.package_name[ursula_os] }}"
+    state: present
   register: result
   until: result|succeeded
   retries: 5
@@ -33,23 +35,45 @@
 - name: set shibboleth conf file permissions
   file:
     path: /etc/shibboleth/
-    owner: _shibd
-    group: _shibd
+    owner: "{{ keystone.shibboleth.user_group[ursula_os] }}"
+    group: "{{ keystone.shibboleth.user_group[ursula_os] }}"
     mode: 0640
   notify: restart shibboleth
 
 - name: set shibboleth conf folder permissions
   file:
     path: /etc/shibboleth/
-    owner: _shibd
-    group: _shibd
+    owner: "{{ keystone.shibboleth.user_group[ursula_os] }}"
+    group: "{{ keystone.shibboleth.user_group[ursula_os] }}"
     mode: 0755
     state: directory
   notify: restart shibboleth
 
 - name: add apache user to _shibd group
-  user: name=www-data shell=/bin/bash groups=_shibd append=yes
+  user:
+    name: www-data
+    shell: /bin/bash
+    groups: "{{ keystone.shibboleth.user_group[ursula_os] }}"
+    append: yes
 
 - name: enable apache mod shib2
   apache2_module: name=shib2
   notify: reload apache
+  when: ursula_os == 'ubuntu'
+
+- block:
+  - name: enable httpd mod shib
+    template:
+      src: etc/httpd/conf.modules.d/47-mod_shib.conf
+      dest: /etc/httpd/conf.modules.d/47-mod_shib.conf
+      mode: 0644
+      owner: root
+      group: root
+    notify: reload apache
+    when: keystone.federation.enabled|bool and keystone.federation.sp.saml.enabled|bool
+  - name: make sure default shibd config does not exist
+    file:
+      path: /etc/httpd/conf.d/shib.conf
+      state: absent
+    notify: reload apache
+  when: ursula_os == 'rhel'

--- a/roles/keystone/templates/etc/apache2/sites-available/keystone.conf
+++ b/roles/keystone/templates/etc/apache2/sites-available/keystone.conf
@@ -1,4 +1,5 @@
 
+
 Listen {{ endpoints.keystone_admin.port.backend_api }}
 Listen {{ endpoints.keystone.port.backend_api }}
 {% macro setup_shibboleth() %}
@@ -8,6 +9,9 @@ Listen {{ endpoints.keystone.port.backend_api }}
     <Location /Shibboleth.sso>
         ProxyPass !
         SetHandler shib
+{% if ursula_os == 'rhel' %}
+        Require all granted
+{% endif %}
     </Location>
 
 {% for sp in keystone.federation.sp.saml.providers %}

--- a/roles/keystone/templates/etc/httpd/conf.modules.d/47-mod_shib.conf
+++ b/roles/keystone/templates/etc/httpd/conf.modules.d/47-mod_shib.conf
@@ -1,0 +1,1 @@
+LoadModule mod_shib /usr/lib64/shibboleth/mod_shib_24.so

--- a/roles/keystone/templates/etc/shibboleth/shibboleth2.xml
+++ b/roles/keystone/templates/etc/shibboleth/shibboleth2.xml
@@ -66,7 +66,7 @@
           {% if keystone.federation.sp.saml.providers[0].verify_idp_cert|default(True)|bool -%}
           <TransportOption provider="CURL" option="64">1</TransportOption>
           <TransportOption provider="CURL" option="81">2</TransportOption>
-          <TransportOption provider="CURL" option="10065">/etc/ssl/certs/ca-certificates.crt</TransportOption>
+          <TransportOption provider="CURL" option="10065">{{ keystone.shibboleth.cafile }}</TransportOption>
           {% endif -%}
         </MetadataProvider>
 {% endif %}

--- a/roles/repos/defaults/main.yml
+++ b/roles/repos/defaults/main.yml
@@ -50,6 +50,11 @@ apt_repos:
 yum_repos:
   epel:
     package: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+  opensuse:
+    repo: http://download.opensuse.org/repositories/security:/shibboleth/CentOS_7/
+    description: Shibboleth SAML service provider module for Keystone
+    gpgcheck: yes
+    key_url: http://download.opensuse.org/repositories/security:/shibboleth/CentOS_7//repodata/repomd.xml.key
   percona:
     package: http://www.percona.com/downloads/percona-release/redhat/0.1-3/percona-release-0.1-3.noarch.rpm
   sensu:


### PR DESCRIPTION
This enables Shibboleth and SAML federation to be installed on RHEL.