### PR TITLE
Add X-Content-Type-Options header

### DIFF
--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -156,6 +156,7 @@ frontend {{ name }}
 
   {% if name == "horizon" -%}
   rspadd Strict-Transport-Security:\ max-age=31536000;\ includeSubDomains
+  rspadd X-Content-Type-Options:\ nosniff
   rspadd X-XSS-Protection:\ 1 
   bind :::80
   redirect scheme https if !{ ssl_fc }


### PR DESCRIPTION
The "X-Content-Type-Options" header (with the "nosniff" value set) prevents IE, Mozilla and Chrome based browsers from ignoring the Content-Type header of a response.
This action may prevent untrusted content (e.g. user uploaded content) from being executed on the user browser (after a malicious naming, for example).
So add it in the haproxy config for the Horizon dashboard for all outgoing requests.