### PR TITLE
disable development mode of pip

### DIFF
--- a/roles/openstack-source/tasks/main.yml
+++ b/roles/openstack-source/tasks/main.yml
@@ -72,6 +72,7 @@
     version: "{{ item.version|default(omit) }}"
     virtualenv: "{{ openstack_source.virtualenv_base }}/{{ project_name }}"
     extra_args: "{{ pip_extra_args }}"
+    editable: false
   with_items: "{{ openstack_source.python_dependencies }}"
   register: result
   until: result|succeeded
@@ -82,6 +83,7 @@
     name: "/opt/stack/{{ project_name }}"
     extra_args: "{{ pip_extra_args }}"
     virtualenv: "{{ openstack_source.virtualenv_base }}/{{ project_name }}"
+    editable: false
   register: pip_result
   until: pip_result|success
   retries: 3
@@ -95,6 +97,7 @@
     version: "{{ item.version|default(omit) }}"
     virtualenv: "{{ openstack_source.virtualenv_base }}/{{ project_name }}"
     extra_args: "{{ pip_extra_args }} {{ item.pip_extra_args|default('') }}"
+    editable: false
   with_items: "{{ openstack_source.python_post_dependencies }}"
   register: result
   until: result|succeeded


### PR DESCRIPTION
When using "source" type to install some packages from source, pip would install them on src instead of site-packages. That is different from type of "packages" and "distro" and it would prevent some soft links from working. The PR is to sync the installation location to site-packages.