### PR TITLE
v7k monitoring

### DIFF
--- a/roles/cinder-control/tasks/monitoring.yml
+++ b/roles/cinder-control/tasks/monitoring.yml
@@ -15,6 +15,10 @@
 - include: nimble-monitoring.yml
   when: sensu.nimble_san_ip is defined
 
+- include: v7k-monitoring.yml
+  when: v7k.enabled|default(false)
+
+
 - name: cinder metrics
   template: src=etc/collectd/plugins/cinder.conf dest=/etc/collectd/plugins/cinder.conf
   notify: restart collectd

--- a/roles/cinder-control/tasks/v7k-monitoring.yml
+++ b/roles/cinder-control/tasks/v7k-monitoring.yml
@@ -1,0 +1,19 @@
+---
+- name: create v7k sshkey directory
+  file: dest=/etc/cinder/v7k/ssh/monitoring state=directory owner=root
+        group=root mode=0755
+
+- name: drop a cinder private key
+  template: src=etc/v7k/ssh/monitoring/id_rsa
+            dest=/etc/cinder/v7k/ssh/monitoring/id_rsa owner=root
+            group=root mode=0600
+
+- name: v7k canister status check
+  sensu_check: name=canister-status plugin=check-v7k-canister.py
+               args='-v {{v7k.management_ip}} -u {{v7k.users.monitoring.name}} -i /etc/cinder/v7k/ssh/monitoring/id_rsa -p {{v7k.ssh_port}} --criticality critical' use_sudo=true
+  notify: restart sensu-client
+
+- name: v7k canister load metrics
+  sensu_metrics_check: name=canister-load plugin=metrics-v7k.py
+               args='-v {{v7k.management_ip}} -u {{v7k.users.monitoring.name}} -i /etc/cinder/v7k/ssh/monitoring/id_rsa  -p {{v7k.ssh_port}} --scheme {{ monitoring.graphite.cluster_prefix }}' use_sudo=true
+  notify: restart sensu-client

--- a/roles/cinder-control/templates/etc/v7k/ssh/monitoring/id_rsa
+++ b/roles/cinder-control/templates/etc/v7k/ssh/monitoring/id_rsa
@@ -1,0 +1,1 @@
+{{ v7k.users.monitoring.ssh_pvt_key }}

--- a/roles/common/templates/monitoring/sensu-sudoers
+++ b/roles/common/templates/monitoring/sensu-sudoers
@@ -34,3 +34,5 @@ sensu ALL= NOPASSWD: /etc/sensu/plugins/check-netif.rb
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check-haproxy.rb
 sensu ALL= NOPASSWD: /etc/sensu/plugins/execute-on-ip.sh
 sensu ALL= NOPASSWD: /etc/sensu/plugins/metrics-nova-oversub.sh
+sensu ALL= NOPASSWD: /etc/sensu/plugins/check-v7k-canister.py
+sensu ALL= NOPASSWD: /etc/sensu/plugins/metrics-v7k.py


### PR DESCRIPTION
add v7k monitoring

- Canister check

- Canister metrics, the following mertics can be collected.  The metrics can be used to draw graph and we can see system health according graph.
```
root@ds0054:~# ssh -i /etc/cinder/v7k/ssh/monitoring/id_rsa  openstackuser@10.254.66.43 lsnodecanisterstats
node_id node_name stat_name          stat_current stat_peak stat_peak_time
1       node1     compression_cpu_pc 0            0         170504005353
1       node1     cpu_pc             2            3         170504005323
1       node1     fc_mb              0            0         170504005353
1       node1     fc_io              0            0         170504005353
1       node1     sas_mb             0            570       170504005018
1       node1     sas_io             0            2272      170504005018
1       node1     iscsi_mb           0            0         170504005353
1       node1     iscsi_io           0            0         170504005353
1       node1     write_cache_pc     0            0         170504005353
1       node1     total_cache_pc     0            0         170504005353
1       node1     vdisk_mb           0            0         170504005353
1       node1     vdisk_io           0            0         170504005353
1       node1     vdisk_ms           0            0         170504005353
1       node1     mdisk_mb           0            0         170504005353
1       node1     mdisk_io           0            0         170504005353
1       node1     mdisk_ms           0            0         170504005353
1       node1     drive_mb           0            570       170504005018
1       node1     drive_io           0            2272      170504005018
1       node1     drive_ms           0            11        170504005223
1       node1     vdisk_r_mb         0            0         170504005353
1       node1     vdisk_r_io         0            0         170504005353
1       node1     vdisk_r_ms         0            0         170504005353
1       node1     vdisk_w_mb         0            0         170504005353
1       node1     vdisk_w_io         0            0         170504005353
1       node1     vdisk_w_ms         0            0         170504005353
1       node1     mdisk_r_mb         0            0         170504005353
1       node1     mdisk_r_io         0            0         170504005353
1       node1     mdisk_r_ms         0            0         170504005353
1       node1     mdisk_w_mb         0            0         170504005353
1       node1     mdisk_w_io         0            0         170504005353
1       node1     mdisk_w_ms         0            0         170504005353
1       node1     drive_r_mb         0            570       170504005018
1       node1     drive_r_io         0            2272      170504005018
1       node1     drive_r_ms         0            11        170504005223
1       node1     drive_w_mb         0            0         170504005353
1       node1     drive_w_io         0            0         170504005353
1       node1     drive_w_ms         0            0         170504005353
1       node1     iplink_mb          0            0         170504005353
1       node1     iplink_io          0            0         170504005353
1       node1     iplink_comp_mb     0            0         170504005353
2       node2     iplink_comp_mb     0            0         170504005355
```