### PR TITLE
Preserve default_volume_type for ceph.

### DIFF
--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -53,14 +53,14 @@ enabled_backends =
 
 {% if cinder.default_volume_type | default(false) -%}
 default_volume_type = {{ cinder.default_volume_type }}
+{% elif ceph.enabled|bool %}
+default_volume_type = {{ceph_pools[ceph_default_backend]['volume_type'] }}
 {% elif v7k.enabled|bool -%}
 {% for pool_name in v7k.storage_pools %}
 {% if loop.first %}
 default_volume_type = {{ pool_name|upper }}
 {% endif %}
 {% endfor %}
-{% elif ceph.enabled|bool %}
-default_volume_type = {{ceph_pools[ceph_default_backend]['volume_type'] }}
 {% elif lvm.enabled|bool %}
 default_volume_type ='LVM'
 {% endif %}


### PR DESCRIPTION
This PR preserves default_volume_type for ceph when v7K is to be enabled on a cluster that has ceph enabled.
