### PR TITLE
refactor openstack-envs for v7k

### DIFF
--- a/roles/cinder-common/meta/main.yml
+++ b/roles/cinder-common/meta/main.yml
@@ -35,3 +35,5 @@ dependencies:
     project_packages: "{{ cinder.distro.project_packages }}"
     rootwrap: True
     when: openstack_install_method == 'distro'
+  - role: v7k-defaults
+

--- a/roles/cinder-common/templates/etc/cinder/cinder.conf
+++ b/roles/cinder-common/templates/etc/cinder/cinder.conf
@@ -82,9 +82,10 @@ use_forwarded_for = true
 [{{ pool_name }}]
 host=v7k
 volume_driver = cinder.volume.drivers.ibm.storwize_svc.storwize_svc_iscsi.StorwizeSVCISCSIDriver
-san_ip ={{ v7k.login.management_ip }}
-san_login = {{ v7k.login.user }}
-san_private_key = /etc/cinder/v7k/ssh/id_rsa
+san_ip ={{ v7k.management_ip }}
+san_ssh_port={{ v7k.ssh_port }}
+san_login = {{ v7k.users.cinder.name }}
+san_private_key = /etc/cinder/v7k/ssh/cinder/id_rsa
 storwize_svc_volpool_name = {{ pool_name }}
 volume_backend_name = {{pool_name }}
 

--- a/roles/cinder-control/tasks/v7k_integration.yml
+++ b/roles/cinder-control/tasks/v7k_integration.yml
@@ -1,9 +1,10 @@
 ---
 - name: create v7k sshkey directory
-  file: dest=/etc/cinder/v7k/ssh state=directory owner=cinder
+  file: dest=/etc/cinder/v7k/ssh/cinder state=directory owner=cinder
         group=cinder mode=0755
 
 - name: drop a cinder private key
-  template: src=etc/v7k/ssh/id_rsa
-            dest=/etc/cinder/v7k/ssh/id_rsa owner=cinder
+  template: src=etc/v7k/ssh/cinder/id_rsa
+            dest=/etc/cinder/v7k/ssh/cinder/id_rsa owner=cinder
             group=cinder mode=0600
+

--- a/roles/cinder-control/templates/etc/v7k/ssh/cinder/id_rsa
+++ b/roles/cinder-control/templates/etc/v7k/ssh/cinder/id_rsa
@@ -1,0 +1,1 @@
+{{ v7k.users.cinder.ssh_pvt_key }}

--- a/roles/cinder-control/templates/etc/v7k/ssh/id_rsa
+++ b/roles/cinder-control/templates/etc/v7k/ssh/id_rsa
@@ -1,1 +1,0 @@
-{{ v7k.login.ssh_keys.private_key }}

--- a/roles/preflight-checks/tasks/check_items.yml
+++ b/roles/preflight-checks/tasks/check_items.yml
@@ -65,3 +65,8 @@
     - ceph.enabled
     - "'ceph_monitors' in group_names or 'ceph_osds' in group_names"
   tags: ['precheck_ceph']
+
+- include: v7k.yml
+  when: v7k.enabled
+  tags: ['precheck_v7k']
+  run_once: true

--- a/roles/preflight-checks/tasks/v7k.yml
+++ b/roles/preflight-checks/tasks/v7k.yml
@@ -1,0 +1,35 @@
+---
+- name: ensure v7k.users is define
+  assert:
+    that: "v7k.users is defined"
+    msg: "v7k.users must be defined because v7k is enabled"
+
+- name: ensure v7k.management_ip is define
+  assert:
+    that: "v7k.management_ip is defined"
+    msg: "v7k.management_ip must be defined because v7k is enabled"
+
+- name: ensure v7k.users.cinder.ssh_pvt_key is define
+  assert:
+    that: "v7k.users.cinder.ssh_pvt_key is defined"
+    msg: "v7k.users.cinder.ssh_pvt_key must be defined because v7k is enabled"
+
+- name: ensure v7k.users.cinder.name is define
+  assert:
+    that: "v7k.users.cinder.name is defined"
+    msg: "v7k.users.cinder.name must be defined because v7k is enabled"
+
+- name: ensure v7k.users.monitoring.ssh_pvt_key is define
+  assert:
+    that: "v7k.users.monitoring.ssh_pvt_key is defined"
+    msg: "v7k.users.monitoring.ssh_pvt_key must be defined because v7k is enabled"
+
+- name: ensure v7k.users.monitoring.name is define
+  assert:
+    that: "v7k.users.monitoring.name is defined"
+    msg: "v7k.users.monitoring.name must be defined because v7k is enabled"
+
+- name: ensure v7k.storage_pools is define
+  assert:
+    that: "v7k.storage_pools is defined"
+    msg: "v7k.storage_pools must be defined because v7k is enabled"

--- a/roles/v7k-defaults/defaults/main.yml
+++ b/roles/v7k-defaults/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+v7k:
+  enabled: False
+  ssh_port: 22


### PR DESCRIPTION
update v7k openstack-envs, the new structure is as the following:
```
v7k:
  enabled: True
  management_ip: 10.254.66.43
  ssh_port: 22
  users:
    cinder:
      name: bbcadmin
      password:
      ssh_pvt_key: 
      ssh_pub_key:
    monitoring:
      name: bbcmonitor
      password:
      ssh_pvt_key:
      ssh_pub_key:
  storage_pools:
    - v7k_pool1

```