### PR TITLE
use neutron-lbaas-dashboard version 1.0.0 for newton.

### DIFF
--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -25,7 +25,7 @@ horizon:
     python_dependencies:
       - { name: PyMySQL }
       - { name: python-memcached }
-      - { name: neutron-lbaas-dashboard }
+      - { name: neutron-lbaas-dashboard, version: '1.0.0' }
       - { name: django_openstack_auth, version: '2.2.1.dev1' }
     system_dependencies:
       ubuntu:


### PR DESCRIPTION
Latest neutron-lbaas-dashboard is not compatible with newton release. Leverage version 1.0.0 for Newton.

This PR changes were made based on discussion in https://bugs.launchpad.net/neutron-lbaas-dashboard/+bug/1621403