### PR TITLE
[3.1.x]Increase buffer size for Keystone uwsgi

### DIFF
--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -4,6 +4,8 @@ keystone:
   token_expiration_in_seconds: 86400
   admin_workers: 5
   public_workers: 5
+  uwsgi:
+    buffer_size: 114688
   source:
     rev: 'stable/mitaka'
     constrain: True

--- a/roles/keystone/templates/etc/keystone/uwsgi/keystone-admin.ini
+++ b/roles/keystone/templates/etc/keystone/uwsgi/keystone-admin.ini
@@ -14,3 +14,4 @@ uid = keystone
 gid = keystone
 
 wsgi-file = /usr/local/bin/keystone-wsgi-admin
+buffer-size = {{ keystone.uwsgi.buffer_size }}

--- a/roles/keystone/templates/etc/keystone/uwsgi/keystone-main.ini
+++ b/roles/keystone/templates/etc/keystone/uwsgi/keystone-main.ini
@@ -14,3 +14,4 @@ uid = keystone
 gid = keystone
 
 wsgi-file = /usr/local/bin/keystone-wsgi-public
+buffer-size = {{ keystone.uwsgi.buffer_size }}


### PR DESCRIPTION
This increases the buffer size for Keystone uwsgi. The default for uwsgi
is 4096. The new size will be 114688 bytes, which will match the default
size limit setting for the oslo 'sizelimit' middleware which exists in
the pipline. This will fix some issues where we get dropped federated
requests to Keystone because of SAML assertion sizes.