### PR TITLE
Increase buffer size for Keystone uwsgi

### DIFF
--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -8,6 +8,7 @@ keystone:
   admin_project_domain_name: Default
   uwsgi:
     method: port
+    buffer_size: 114688
     http_port:
       admin: 9091
       public: 9092

--- a/roles/keystone/templates/etc/keystone/uwsgi/keystone-admin.ini
+++ b/roles/keystone/templates/etc/keystone/uwsgi/keystone-admin.ini
@@ -25,3 +25,4 @@ wsgi-file = /bin/keystone-wsgi-admin
 {% else %}
 wsgi-file = /usr/local/bin/keystone-wsgi-admin
 {% endif %}
+buffer-size = {{ keystone.uwsgi.buffer_size }}

--- a/roles/keystone/templates/etc/keystone/uwsgi/keystone-main.ini
+++ b/roles/keystone/templates/etc/keystone/uwsgi/keystone-main.ini
@@ -27,3 +27,4 @@ wsgi-file = /bin/keystone-wsgi-public
 {% else %}
 wsgi-file = /usr/local/bin/keystone-wsgi-public
 {% endif %}
+buffer-size = {{ keystone.uwsgi.buffer_size }}


### PR DESCRIPTION
This increases the buffer size for Keystone uwsgi. The default for uwsgi
is 4096. The new size will be 114688 bytes, which will match the default
size limit setting for the oslo 'sizelimit' middleware which exists in
the pipline. This will fix some issues where we get dropped federated
requests to Keystone because of SAML assertion sizes.