### PR TITLE
roll back rbd_max_clone_depth to 5

### DIFF
--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -178,7 +178,9 @@ ceph:
     rbd_user: cinder
     rbd_ceph_conf: /etc/ceph/ceph.conf
     rbd_flatten_volume_from_snapshot: false
-    rbd_max_clone_depth: 0
+    # FIXME: this variable should be set to 0 once the bug is fixed
+    # https://bugs.launchpad.net/cinder/+bug/1658037
+    rbd_max_clone_depth: 5
     glance_api_version: 2
 
   # Logging


### PR DESCRIPTION
As there is a bug of cinder, which doesn't support high concurrency of
volume full clone. So we roll back rbd_max_clone_depth to 5, to use
copy-on-write clone by default.
For these who want to apply full-clone, they can set this variable in
all.yml.