### PR TITLE
avoid ansible warning/deprecation messages in ursula.log.

### DIFF
--- a/roles/barbican/tasks/main.yml
+++ b/roles/barbican/tasks/main.yml
@@ -87,7 +87,6 @@
     mode: 0775
     owner: barbican
     group: barbican
-    mode: 0775
   with_items:
     - /etc/barbican/uwsgi
     - /run/uwsgi/barbican

--- a/roles/inspec/tasks/main.yml
+++ b/roles/inspec/tasks/main.yml
@@ -46,7 +46,7 @@
       url: '{{ inspec.profiles[item].url }}'
       dest: '/etc/inspec/profiles/archive/{{ inspec.profiles[item].name}}-{{ inspec.profiles[item].version }}.tgz'
       mode: 0644
-    with_items: "{{ install_inspec_profiles }}"
+    with_items: "{{ install_inspec_profiles|default([]) }}"
     when: inspec.dependency_install_method == 'tar'
 
   - name: untar inspec dependencies
@@ -54,7 +54,7 @@
       src: '/etc/inspec/profiles/archive/{{ inspec.profiles[item].name }}-{{ inspec.profiles[item].version }}.tgz'
       dest: '/etc/inspec/profiles/'
       copy: no
-    with_items: "{{ install_inspec_profiles }}"
+    with_items: "{{ install_inspec_profiles|default([]) }}"
     when: inspec.dependency_install_method == 'tar'
 
   - name: create inspec dependency current symlink
@@ -63,7 +63,7 @@
       dest: "/etc/inspec/profiles/{{ inspec.profiles[item].name }}-current"
       state: link
       force: true
-    with_items: "{{ install_inspec_profiles }}"
+    with_items: "{{ install_inspec_profiles|default([]) }}"
     when: inspec.dependency_install_method == 'tar'
 
   - name: create path for inspec control

--- a/roles/keystone/tasks/openidc.yml
+++ b/roles/keystone/tasks/openidc.yml
@@ -43,7 +43,7 @@
     owner: www-data
     group: root
     mode: 0640
-  with_items: "{{ keystone.federation.sp.oidc.providers_info }}"
+  with_items: "{{ keystone.federation.sp.oidc.providers_info|default([]) }}"
 
 - name: create .conf file for the IdPs
   template:
@@ -52,7 +52,7 @@
     owner: www-data
     group: root
     mode: 0640
-  with_items: "{{ keystone.federation.sp.oidc.providers_info }}"
+  with_items: "{{ keystone.federation.sp.oidc.providers_info|default([]) }}"
 
 - name: create .provider file for the IdPs
   template:
@@ -62,9 +62,9 @@
     group: root
     mode: 0640
   when: item.provider_metadata_url is undefined
-  with_items: "{{ keystone.federation.sp.oidc.providers_info }}"
+  with_items: "{{ keystone.federation.sp.oidc.providers_info|default([]) }}"
 
 - name: create .provider file for the IdPs
   shell: "curl --fail {{ item.provider_metadata_url }}  > /etc/apache2/openidc/metadata/{{ item.metadata_file_name }}.provider"
   when: item.provider_metadata_url is defined
-  with_items: "{{ keystone.federation.sp.oidc.providers_info }}"
+  with_items: "{{ keystone.federation.sp.oidc.providers_info|default([]) }}"


### PR DESCRIPTION
This PR addresses following Warning / Deprecation ansible messages

#1:
[WARNING]: While constructing a mapping from /home/nirajdp/deployments/master/ursula/roles/barbican/tasks/main.yml, line 85, column 5, found a duplicate dict key (mode).  Using
last defined value only.

Soln: remove duplicate attribute

#2:
TASK [keystone : create .client file for the IdPs] *****************************
Tuesday 09 May 2017  15:40:59 +0000 (0:00:00.887)       0:03:54.766 ***********
[DEPRECATION WARNING]: Skipping task due to undefined Error, in the future this will be a fatal error.: 'dict object' has no attribute 'providers_info'.
This feature will be
removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

#3:
TASK [inspec : fetch inspec dependencies when install method is tar] ***********
Saturday 06 May 2017  07:21:35 +0000 (0:00:00.328)       1:15:01.978 **********
[DEPRECATION WARNING]: Skipping task due to undefined Error, in the future this
 will be a fatal error.: 'install_inspec_profiles' is undefined.

Soln: add default[] to with_items as when: gets executed INSIDE the with_ loop so it cannot be used to skip undefined vars in it.
