### PR TITLE
avoid deprecation messages from magnum role.

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -80,7 +80,6 @@ endpoints:
   main:     "{{ fqdn }}"
   db:       "{{ undercloud_floating_ip }}"
   rabbit:   "{{ undercloud_floating_ip }}"
-  magnum: "{{ fqdn }}"
   identity_uri: https://{{ fqdn }}:35357
   auth_uri: https://{{ fqdn }}:5000/v2.0
 
@@ -528,9 +527,9 @@ keystone:
     - name: magnum
       type: container
       description: 'Magnum Container Service'
-      public_url: https://{{ endpoints.main }}:9511
-      internal_url: https://{{ endpoints.main }}:9511
-      admin_url: https://{{ endpoints.main }}:9511
+      public_url: "{{ endpoints.magnum.url.public }}"
+      internal_url: "{{ endpoints.magnum.url.internal }}"
+      admin_url: "{{ endpoints.magnum.url.admin }}"
     - name: aodh
       type: alarming
       description: 'aodh alarming service'

--- a/roles/endpoints/defaults/main.yml
+++ b/roles/endpoints/defaults/main.yml
@@ -5,7 +5,6 @@ endpoints:
   db: "{{ undercloud_floating_ip }}:3307"
   rabbit: "{{ undercloud_floating_ip }}"
   memcache: "{{ undercloud_floating_ip }}:11211"
-  magnum: "{{ fqdn }}"
   identity_uri: https://{{ fqdn }}:35357
   auth_uri: https://{{ fqdn }}:5000/v2.0
   nova:
@@ -199,6 +198,21 @@ endpoints:
       haproxy_api: 8777
     haproxy:
       health_check: 'tcp-check /'
+      balance: 'source'
+      prefer_primary_backend: False
+  magnum:
+    name: magnum
+    type: container
+    description: 'Magnum Container Service'
+    url:
+      admin: https://{{ fqdn }}:9511
+      internal: https://{{ fqdn }}:9511
+      public: https://{{ fqdn }}:9511
+    port:
+      backend_api: 9512
+      haproxy_api: 9511
+    haproxy:
+      health_check: 'httpchk /'
       balance: 'source'
       prefer_primary_backend: False
   ironic:

--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -77,11 +77,11 @@
 {% endif -%}
 {% if magnum.enabled|default('False')|bool -%}
     {% set _ = haproxy_services.append(['magnum',
-                                        9512,
-                                        9511,
-                                        false,
-                                        'httpchk /',
-                                        'source']) %}
+                                        endpoints.magnum.port.backend_api,
+                                        endpoints.magnum.port.haproxy_api,
+                                        endpoints.magnum.haproxy.prefer_primary_backend,
+                                        endpoints.magnum.haproxy.health_check,
+                                        endpoints.magnum.haproxy.balance]) %}
 {% endif -%}
 {% if heat.enabled -%}
     {% set _ = haproxy_services.append(['heat',
@@ -165,7 +165,7 @@ frontend {{ name }}
   {% if name == "horizon" -%}
   rspadd Strict-Transport-Security:\ max-age=31536000;\ includeSubDomains
   rspadd X-Content-Type-Options:\ nosniff
-  rspadd X-XSS-Protection:\ 1 
+  rspadd X-XSS-Protection:\ 1
   bind :::80
   redirect scheme https if !{ ssl_fc }
   {% endif -%}


### PR DESCRIPTION
This PR aligns magnum to be consistent with other openstack project roles on it get's defined in endpoints/defaults. The change will address below deprecation message

TASK [openstack-firewall : permit access to magnum] ****************************
Saturday 06 May 2017  07:24:32 +0000 (0:00:00.382)       1:17:58.685 **********
[DEPRECATION WARNING]: Skipping task due to undefined Error, in the future this
 will be a fatal error.: [{u'protocol': u'tcp', u'port': u'{{
endpoints.magnum.port.haproxy_api }}'}]: 'unicode object' has no attribute
'port'.

Soln: Adjust mangum to follow other openstack project roles on it get's deifned in endpoints/defaults