### PR TITLE
Bump pip version to 9.0.1

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -30,7 +30,7 @@ common:
     disable_root: False
     disable_dns: True
     client_alive_interval: 1800
-  pip_version: 8.0.2
+  pip_version: 9.0.1
   setuptools_version: system
   ursula_monitoring:
     path: /opt/ursula-monitoring

--- a/roles/common/tasks/python.yml
+++ b/roles/common/tasks/python.yml
@@ -48,7 +48,7 @@
 
 - name: update pip (base venv)
   pip: name=pip version={{ common.pip_version }}
-       extra_args="-i {{ openstack.pypi_mirror }}"
+       extra_args="{{ pip_extra_args }}"
        virtualenv="{{ common.python.base_venv }}"
   register: result
   until: result|succeeded
@@ -77,6 +77,7 @@
   pip:
     name: "{{ item }}"
     virtualenv: "{{ common.python.base_venv }}"
+    extra_args: "{{ pip_extra_args }}"
   with_items:
     - shade>=1.9.0
   register: result
@@ -138,6 +139,7 @@
   - name: install shade bits for ansible modules
     pip:
       name: "{{ item }}"
+      extra_args: "{{ pip_extra_args }}"
     with_items:
       - six>=1.10.0
       - shade>=1.9.0


### PR DESCRIPTION
with new request python pkg (2.14) shade install fails with following error
NameError: name 'platform_system' is not defined

This PR bumps the pip version to 9.0.1 which takes care of this issue.