### PR TITLE
setup the correct base virtual env for federation sp

### DIFF
--- a/roles/keystone-setup/tasks/federation.yml
+++ b/roles/keystone-setup/tasks/federation.yml
@@ -1,5 +1,8 @@
 ---
 - name: Register keystone sp info on keystone idp
+  environment:
+    OS_IDENTITY_API_VERSION: 3
+    PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
   keystone_service_provider:
     validate_certs: "{{ validate_certs|default(omit) }}"
     auth:


### PR DESCRIPTION
For the federation module keystone_service_provider, the base virtual env was not setup correctly. This sets up the env for it.