### PR TITLE
Update Policy file for barbican to update servie_admin

### DIFF
--- a/roles/barbican/templates/etc/barbican/policy.json
+++ b/roles/barbican/templates/etc/barbican/policy.json
@@ -3,7 +3,7 @@
     "observer": "role:observer",
     "creator": "role:creator",
     "audit": "role:audit",
-    "service_admin": "role:key-manager:service-admin",
+    "service_admin": "role:admin or role:cloud_admin",
     "admin_or_user_does_not_work": "project_id:%(project_id)s",
     "admin_or_user": "rule:admin or project_id:%(project_id)s",
     "admin_or_creator": "rule:admin or rule:creator",


### PR DESCRIPTION
Currently service_admin is using a role that doesnt exitst. Switching it out
to point to role:admin or role:cloud_admin. This can be changed later to more fine
grained access control if needed.