### PR TITLE
[3.1.x]Set url as default Shibboleth metadata provider type

### DIFF
--- a/roles/keystone/tasks/saml.yml
+++ b/roles/keystone/tasks/saml.yml
@@ -21,7 +21,7 @@
 - name: Create idp metadata file
   template: src=etc/shibboleth/idp_metadata.xml
             dest=/etc/shibboleth/idp_metadata.xml
-  when: keystone.federation.sp.saml.providers[0].metadata_provider_type == 'file'
+  when: keystone.federation.sp.saml.providers[0].metadata_provider_type|default('url') == 'file'
   notify: restart shibboleth
 
 - name: configure shibboleth settings

--- a/roles/keystone/templates/etc/shibboleth/shibboleth2.xml
+++ b/roles/keystone/templates/etc/shibboleth/shibboleth2.xml
@@ -48,10 +48,10 @@
             helpLocation="/about.html"
             styleSheet="/shibboleth-sp/main.css"/>
 
-{% if keystone.federation.sp.saml.providers[0].metadata_provider_type == 'file' %}
+{% if keystone.federation.sp.saml.providers[0].metadata_provider_type|default('url') == 'file' %}
         <MetadataProvider type="XML" path="{{keystone.federation.sp.saml.providers[0].metadata_file_path}}" />
 {% endif %}
-{% if keystone.federation.sp.saml.providers[0].metadata_provider_type == 'url' %}
+{% if keystone.federation.sp.saml.providers[0].metadata_provider_type|default('url') == 'url' %}
         <MetadataProvider type="XML" uri="{{ keystone.federation.sp.saml.providers[0].idp_metadata_url }}"
           backingFilePath="idp-metadata-provider-backup.xml"
           {% if keystone.federation.sp.saml.providers[0].idp_metadata_min_refresh_delay is defined %}


### PR DESCRIPTION
This sets the url as the default Shibboleth metadata provider type. This way we do not have to set the metadata provider type by default.