### PR TITLE
hardcode ansible_managed

### DIFF
--- a/roles/ceph-config/templates/etc/ceph/ceph.conf
+++ b/roles/ceph-config/templates/etc/ceph/ceph.conf
@@ -1,5 +1,5 @@
 #jinja2: trim_blocks: "true", lstrip_blocks: "true"
-# {{ ansible_managed }}
+# This file is managed by ansible, don't make changes here - they will be overwritten.
 
 [global]
 {% if ceph.cephx %}


### PR DESCRIPTION
ansible_managed always change, it results in ceph.conf change. Finally
it causes unexpected CEPH service restart.

This patch is to hard code ansible_managed to prevent unexpected CEPH
service restart.