### PR TITLE
Fix auth parameters for the service providers module

### DIFF
--- a/roles/keystone-setup/tasks/federation.yml
+++ b/roles/keystone-setup/tasks/federation.yml
@@ -8,7 +8,8 @@
     auth:
       auth_url: "{{ endpoints.keystone.url.internal }}/v3"
       project_name: admin
-      domain_id: Default
+      project_domain_name: default
+      user_domain_name: default
       username: admin
       password: "{{ secrets.admin_password }}"
     service_provider_id: "{{ item.id }}"


### PR DESCRIPTION
This fixes an issue where we get a 401 unauthorized error. The list
of parameters used for authentication should be the same
as the other federation modules.