### PR TITLE
nova-placement-api enablement.

### DIFF
--- a/envs/example/ci-ceph-redhat/heat_stack.yml
+++ b/envs/example/ci-ceph-redhat/heat_stack.yml
@@ -136,6 +136,14 @@ resources:
           port_range_max: 8774
         - remote_ip_prefix: 0.0.0.0/0
           protocol: tcp
+          port_range_min: 8778
+          port_range_max: 8778
+        - remote_ip_prefix: 0.0.0.0/0
+          protocol: tcp
+          port_range_min: 9311
+          port_range_max: 9311
+        - remote_ip_prefix: 0.0.0.0/0
+          protocol: tcp
           port_range_min: 8776
           port_range_max: 8776
         - remote_ip_prefix: 0.0.0.0/0

--- a/envs/example/ci-ceph-swift-rhel/heat_stack.yml
+++ b/envs/example/ci-ceph-swift-rhel/heat_stack.yml
@@ -148,6 +148,14 @@ resources:
           port_range_max: 8774
         - remote_ip_prefix: 0.0.0.0/0
           protocol: tcp
+          port_range_min: 8778
+          port_range_max: 8778
+        - remote_ip_prefix: 0.0.0.0/0
+          protocol: tcp
+          port_range_min: 9311
+          port_range_max: 9311 
+        - remote_ip_prefix: 0.0.0.0/0
+          protocol: tcp
           port_range_min: 8776
           port_range_max: 8776
         - remote_ip_prefix: 0.0.0.0/0

--- a/envs/example/ci-ceph-swift-ubuntu/heat_stack.yml
+++ b/envs/example/ci-ceph-swift-ubuntu/heat_stack.yml
@@ -110,6 +110,14 @@ resources:
           port_range_max: 8774
         - remote_ip_prefix: 0.0.0.0/0
           protocol: tcp
+          port_range_min: 8778
+          port_range_max: 8778
+        - remote_ip_prefix: 0.0.0.0/0
+          protocol: tcp
+          port_range_min: 9311
+          port_range_max: 9311
+        - remote_ip_prefix: 0.0.0.0/0
+          protocol: tcp
           port_range_min: 8776
           port_range_max: 8776
         - remote_ip_prefix: 0.0.0.0/0

--- a/envs/example/ci-ceph-ubuntu/heat_stack.yml
+++ b/envs/example/ci-ceph-ubuntu/heat_stack.yml
@@ -136,6 +136,14 @@ resources:
           port_range_max: 8774
         - remote_ip_prefix: 0.0.0.0/0
           protocol: tcp
+          port_range_min: 8778
+          port_range_max: 8778
+        - remote_ip_prefix: 0.0.0.0/0
+          protocol: tcp
+          port_range_min: 9311
+          port_range_max: 9311 
+        - remote_ip_prefix: 0.0.0.0/0
+          protocol: tcp
           port_range_min: 8776
           port_range_max: 8776
         - remote_ip_prefix: 0.0.0.0/0

--- a/envs/example/ci-full-centos/heat_stack.yml
+++ b/envs/example/ci-full-centos/heat_stack.yml
@@ -104,6 +104,14 @@ resources:
           port_range_max: 8774
         - remote_ip_prefix: 0.0.0.0/0
           protocol: tcp
+          port_range_min: 8778
+          port_range_max: 8778
+        - remote_ip_prefix: 0.0.0.0/0
+          protocol: tcp
+          port_range_min: 9311
+          port_range_max: 9311 
+        - remote_ip_prefix: 0.0.0.0/0
+          protocol: tcp
           port_range_min: 8776
           port_range_max: 8776
         - remote_ip_prefix: 0.0.0.0/0

--- a/envs/example/ci-full-rhel/heat_stack.yml
+++ b/envs/example/ci-full-rhel/heat_stack.yml
@@ -104,6 +104,14 @@ resources:
           port_range_max: 8774
         - remote_ip_prefix: 0.0.0.0/0
           protocol: tcp
+          port_range_min: 8778
+          port_range_max: 8778
+        - remote_ip_prefix: 0.0.0.0/0
+          protocol: tcp
+          port_range_min: 9311
+          port_range_max: 9311 
+        - remote_ip_prefix: 0.0.0.0/0
+          protocol: tcp
           port_range_min: 8776
           port_range_max: 8776
         - remote_ip_prefix: 0.0.0.0/0

--- a/envs/example/ci-full-ubuntu/heat_stack.yml
+++ b/envs/example/ci-full-ubuntu/heat_stack.yml
@@ -105,6 +105,14 @@ resources:
           port_range_max: 8774
         - remote_ip_prefix: 0.0.0.0/0
           protocol: tcp
+          port_range_min: 8778
+          port_range_max: 8778
+        - remote_ip_prefix: 0.0.0.0/0
+          protocol: tcp
+          port_range_min: 9311
+          port_range_max: 9311 
+        - remote_ip_prefix: 0.0.0.0/0
+          protocol: tcp
           port_range_min: 8776
           port_range_max: 8776
         - remote_ip_prefix: 0.0.0.0/0

--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -387,6 +387,9 @@ keystone:
     - name: barbican
       password: "{{ secrets.service_password }}"
       tenant: service
+    - name: placement
+      password: "{{ secrets.service_password }}"
+      tenant: service
   user_roles:
     - user: admin
       tenant: admin
@@ -445,6 +448,9 @@ keystone:
     - user: barbican
       tenant: service
       role: admin
+    - user: placement
+      role: admin
+      tenant: service
   services:
     - name: keystone
       type: identity
@@ -464,6 +470,12 @@ keystone:
       public_url: "{{ endpoints.nova.url.public }}/{{ endpoints.nova.url.path }}"
       internal_url: "{{ endpoints.nova.url.internal }}/{{ endpoints.nova.url.path }}"
       admin_url: "{{ endpoints.nova.url.admin }}/{{ endpoints.nova.url.path }}"
+    - name: placement
+      type: placement
+      description: 'Placement Service'
+      public_url: "{{ endpoints.placement.url.public }}"
+      internal_url: "{{ endpoints.placement.url.internal }}"
+      admin_url: "{{ endpoints.placement.url.admin }}"
     - name: glance
       type: image
       description: 'Image Service'

--- a/roles/endpoints/defaults/main.yml
+++ b/roles/endpoints/defaults/main.yml
@@ -24,6 +24,22 @@ endpoints:
       health_check: 'httpchk GET /healthcheck'
       balance: 'roundrobin'
       prefer_primary_backend: False
+  placement:
+    name: placement
+    type: placement
+    description: Placement Service
+    version: v1.0
+    url:
+      admin: https://{{ fqdn }}:8778
+      internal: https://{{ fqdn }}:8778
+      public: https://{{ fqdn }}:8778
+    port:
+      backend_api: 9778
+      haproxy_api: 8778
+    haproxy:
+      health_check: 'tcp-check /'
+      balance: 'roundrobin'
+      prefer_primary_backend: False
   glance:
     name: glance
     type: image
@@ -50,7 +66,7 @@ endpoints:
       public: https://{{ fqdn }}:8776
       path: v1/%(project_id)s
     port:
-      backend_api: 8778
+      backend_api: 9776
       haproxy_api: 8776
     haproxy:
       health_check: 'httpchk GET /healthcheck'

--- a/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
+++ b/roles/haproxy/templates/etc/haproxy/haproxy_openstack.cfg
@@ -34,6 +34,14 @@
       endpoints.nova.haproxy.balance
     ],
     [
+      'placement',
+      endpoints.placement.port.backend_api,
+      endpoints.placement.port.haproxy_api,
+      endpoints.placement.haproxy.prefer_primary_backend,
+      endpoints.placement.haproxy.health_check,
+      endpoints.placement.haproxy.balance
+    ],
+    [
       'novnc',
       endpoints.novnc.port.backend_api,
       endpoints.novnc.port.haproxy_api,

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -32,17 +32,17 @@
       permission: r
 
 - name: set uwsgi path (source install)
-  set_fact: uwsgi_path={{ openstack_source.virtualenv_base }}/keystone/bin/uwsgi
+  set_fact: keystone_uwsgi_path={{ openstack_source.virtualenv_base }}/keystone/bin/uwsgi
   when: openstack_install_method == 'source'
 
 - name: set uwsgi path (package install ubuntu)
   set_fact:
-    uwsgi_path: "{{ openstack_package.virtualenv_base }}/keystone/bin/uwsgi"
+    keystone_uwsgi_path: "{{ openstack_package.virtualenv_base }}/keystone/bin/uwsgi"
   when: openstack_install_method == 'package' and ursula_os == 'ubuntu'
 
 - name: set uwsgi path (package install rhel)
   set_fact:
-    uwsgi_path: "/usr/sbin/uwsgi"
+    keystone_uwsgi_path: "/usr/sbin/uwsgi"
   when: openstack_install_method == 'distro'
 
 - name: install keystone uwsgi service (ubuntu)
@@ -55,7 +55,7 @@
     systemd_service:
       name: "{{ item.name }}"
       description: "{{ item.desc }}"
-      cmd: "{{ uwsgi_path }}"
+      cmd: "{{ keystone_uwsgi_path }}"
       args: "{{ item.args }}"
       user: "{{ item.user }}"
       type: "{{ item.type }}"
@@ -65,7 +65,7 @@
     with_items:
       - "{{ openstack_meta.keystone.services.keystone_api[ursula_os] }}"
 
-  - name: Configure tmpfiles.d for creation of /run/uwsgi on reboot
+  - name: Configure tmpfiles.d for creation of /run/uwsgi/keystone on reboot
     template:
       src: usr/lib/tmpfiles.d/openstack-keystone.conf
       dest: /usr/lib/tmpfiles.d/openstack-keystone.conf
@@ -77,7 +77,7 @@
         owner=keystone group=keystone mode=0775
   with_items:
     - /etc/keystone/uwsgi
-    - /run/uwsgi
+    - /run/uwsgi/keystone
 
 - name: configure keystone admin wsgi
   template: src=etc/keystone/uwsgi/keystone-admin.ini

--- a/roles/keystone/templates/etc/init/keystone.conf
+++ b/roles/keystone/templates/etc/init/keystone.conf
@@ -7,17 +7,17 @@ stop on runlevel [!2345]
 respawn
 
 pre-start script
-  if [ ! -d /run/uwsgi ]; then
-      mkdir /run/uwsgi/
-      chown keystone /run/uwsgi
-      chmod 775 /run/uwsgi
+  if [ ! -d /run/uwsgi/keystone ]; then
+      mkdir -p /run/uwsgi/keystone
+      chown keystone /run/uwsgi/keystone
+      chmod 775 /run/uwsgi/keystone
   fi
 end script
 
 post-stop script
-  if [ -d /run/uwsgi ]; then
-     rm -r /run/uwsgi
+  if [ -d /run/uwsgi/keystone ]; then
+     rm -r /run/uwsgi/keystone
   fi
 end script
 
-exec {{ uwsgi_path }} --uid keystone --gid keystone --master --emperor /etc/keystone/uwsgi
+exec {{ keystone_uwsgi_path }} --uid keystone --gid keystone --master --emperor /etc/keystone/uwsgi

--- a/roles/keystone/templates/etc/keystone/uwsgi/keystone-admin.ini
+++ b/roles/keystone/templates/etc/keystone/uwsgi/keystone-admin.ini
@@ -6,12 +6,12 @@ chmod-socket = 666
 {% if openstack_install_method != 'distro' %}
 home = {{ keystone.uwsgi.home[openstack_install_method] }}
 {% endif %}
-pidfile = /run/uwsgi/keystone-admin.pid
+pidfile = /run/uwsgi/keystone/keystone-admin.pid
 logto = /var/log/keystone/keystone-all.log
 logfile-chmod = 644
 
 {% if keystone.uwsgi.method == 'socket' %}
-uwsgi-socket = /run/uwsgi/keystone-admin.socket
+uwsgi-socket = /run/uwsgi/keystone/keystone-admin.socket
 {% else %}
 uwsgi-socket = 127.0.0.1:{{ keystone.uwsgi.http_port.admin }}
 {% endif %}

--- a/roles/keystone/templates/etc/keystone/uwsgi/keystone-main.ini
+++ b/roles/keystone/templates/etc/keystone/uwsgi/keystone-main.ini
@@ -6,12 +6,12 @@ chmod-socket = 666
 {% if openstack_install_method != 'distro' %}
 home = {{ keystone.uwsgi.home[openstack_install_method] }}
 {% endif %}
-pidfile = /run/uwsgi/keystone-main.pid
+pidfile = /run/uwsgi/keystone/keystone-main.pid
 logto = /var/log/keystone/keystone-all.log
 logfile-chmod = 644
 
 {% if keystone.uwsgi.method == 'socket' %}
-uwsgi-socket = /run/uwsgi/keystone-main.socket
+uwsgi-socket = /run/uwsgi/keystone/keystone-main.socket
 {% else %}
 uwsgi-socket = 127.0.0.1:{{ keystone.uwsgi.http_port.public }}
 {% endif %}

--- a/roles/keystone/templates/usr/lib/tmpfiles.d/openstack-keystone.conf
+++ b/roles/keystone/templates/usr/lib/tmpfiles.d/openstack-keystone.conf
@@ -1,1 +1,1 @@
-d /run/uwsgi   755 keystone keystone
+d /run/uwsgi/keystone   755 keystone keystone

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -7,10 +7,20 @@ nova:
     nova_compute: "{{ openstack_meta.nova.services.nova_compute[ursula_os] }}"
     nova_consoleauth: "{{ openstack_meta.nova.services.nova_consoleauth[ursula_os] }}"
     nova_novncproxy: "{{ openstack_meta.nova.services.nova_novncproxy[ursula_os] }}"
+    nova_placement_api: "{{ openstack_meta.nova.services.nova_placement_api[ursula_os] }}"
     nova_scheduler: "{{ openstack_meta.nova.services.nova_scheduler[ursula_os] }}"
     nova_cert: "{{ openstack_meta.nova.services.nova_cert[ursula_os] }}"
     nova_cells: "{{ openstack_meta.nova.services.nova_cells[ursula_os] }}"
     libvirt: "{{ openstack_meta.nova.services.libvirt[ursula_os] }}"
+  placement:
+    workers: 3
+    uwsgi:
+      method: port
+      http_port: "{{ endpoints.placement.port.backend_api }}"
+      home:
+        distro: /usr/lib/python2.7/site-packages/nova
+        source: /opt/openstack/current/nova
+        package: /opt/openstack/current/nova
   libvirt:
     ubuntu:
       config_file: libvirtd.conf
@@ -76,6 +86,7 @@ nova:
         - openstack-nova-scheduler
         - openstack-nova-novncproxy
         - openstack-nova-console
+        - openstack-nova-placement-api
     compute:
       project_packages:
         - "librbd1-{{ ceph.client_version[ursula_os] }}"
@@ -88,6 +99,7 @@ nova:
       - { name: PyMySQL }
       - { name: python-memcached }
       - { name: python-ironicclient }
+      - { name: uwsgi }
     system_dependencies:
       ubuntu:
         - libjs-jquery-tablesorter
@@ -110,6 +122,7 @@ nova:
     - nova-manage
     - nova-network
     - nova-novncproxy
+    - nova-placement-api
     - nova-rootwrap
     - nova-scheduler
     - nova-serialproxy
@@ -121,6 +134,11 @@ nova:
       fields:
         type: openstack
         tags: nova,nova-api
+    - paths:
+        - /var/log/nova/nova-placement-api.log
+      fields:
+        type: openstack
+        tags: nova,nova-placement-api
     - paths:
         - /var/log/nova/nova-compute.log
       fields:

--- a/roles/nova-common/handlers/main.yml
+++ b/roles/nova-common/handlers/main.yml
@@ -17,4 +17,5 @@
        "{{ nova.services.nova_compute }}",
        "{{ nova.services.nova_consoleauth }}",
        "{{ nova.services.nova_novncproxy }}",
+       "{{ nova.services.nova_placement_api }}",
        "{{ nova.services.nova_scheduler }}"]

--- a/roles/nova-common/meta/main.yml
+++ b/roles/nova-common/meta/main.yml
@@ -34,7 +34,7 @@ dependencies:
     project_name: nova
     project_packages: "{{ nova.distro.controller.project_packages }}"
     rootwrap: True
-    when: 
+    when:
       - openstack_install_method == 'distro'
       - inventory_hostname in groups['controller']
   - role: openstack-distro

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -219,6 +219,20 @@ driver = log
 [oslo_middleware]
 enable_proxy_headers_parsing = True
 
+[placement]
+auth_url = {{ endpoints.keystone.url.admin }}/{{ endpoints.keystonev3.version }}
+auth_type = password
+username = placement
+password = {{ secrets.service_password }}
+cafile = {{ nova.cafile }}
+project_name = service
+project_domain_id = default
+os_region_name = RegionOne
+user_domain_id = default
+{% if insecure|default('False')|bool %}
+insecure = true
+{% endif %}
+
 [cache]
 backend = oslo_cache.memcache_pool
 enabled = True

--- a/roles/nova-control/meta/main.yml
+++ b/roles/nova-control/meta/main.yml
@@ -18,3 +18,5 @@ dependencies:
     rules_type_input:
       - { protocol: tcp, port: "{{ endpoints.nova.port.haproxy_api }}" }
       - { protocol: tcp, port: "{{ endpoints.novnc.port.haproxy_api }}" }
+      - { protocol: tcp, port: "{{ endpoints.placement.port.haproxy_api }}" }
+

--- a/roles/nova-control/tasks/main.yml
+++ b/roles/nova-control/tasks/main.yml
@@ -3,8 +3,41 @@
   when: openstack_install_method != 'distro'
   tags: novnc
 
+- name: set uwsgi path (source install)
+  set_fact: nova_uwsgi_path={{ openstack_source.virtualenv_base }}/nova/bin/uwsgi
+  when: openstack_install_method == 'source'
+
+- name: set uwsgi path (package install ubuntu)
+  set_fact:
+    nova_uwsgi_path: "{{ openstack_package.virtualenv_base }}/nova/bin/uwsgi"
+  when: openstack_install_method == 'package' and ursula_os == 'ubuntu'
+
+- name: set uwsgi path (package install rhel)
+  set_fact:
+    nova_uwsgi_path: "/usr/sbin/uwsgi"
+  when: openstack_install_method == 'distro'
+
+- name: Create nova placement api uwsgi and config directories
+  file: path={{ item }} state=directory
+        owner=nova group=nova mode=0775
+  with_items:
+    - /etc/nova/uwsgi
+    - /run/uwsgi/nova
+
+- name: configure nova placement api wsgi
+  template: src=etc/nova/uwsgi/placement.ini
+            dest=/etc/nova/uwsgi/placement.ini mode=0775
+            owner=nova group=nova
+
+- name: remove nova placement api apache conf (rhel)
+  file:
+    dest: /etc/httpd/conf.d/00-nova-placement-api.conf
+    state: absent
+  failed_when: false
+  when: openstack_install_method == 'distro'
+
 - block:
-  - name: remove retired nova controller services
+  - name: remove retired nova controller services (ubuntu)
     upstart_service:
       name: "{{ item.name }}"
       user: "{{ item.user }}"
@@ -26,10 +59,14 @@
       - "{{ nova.services.nova_consoleauth }}"
       - "{{ nova.services.nova_scheduler }}"
       - "{{ nova.services.nova_novncproxy }}"
+
+  - name: install nova placement api uwsgi service (ubuntu)
+    template: src=etc/init/nova-placement-api.conf
+              dest=/etc/init/nova-placement-api.conf mode=0644
   when: ursula_os == 'ubuntu'
 
 - block:
-  - name: remove retired nova controller services
+  - name: remove retired nova controller services (rhel)
     systemd_service:
       name: "{{ item.name }}"
       cmd: "{{ item.cmd }}"
@@ -55,6 +92,26 @@
       - "{{ nova.services.nova_consoleauth }}"
       - "{{ nova.services.nova_scheduler }}"
       - "{{ nova.services.nova_novncproxy }}"
+
+  - name: install nova placement api uwsgi service (rhel)
+    systemd_service:
+      name: "{{ item.name }}"
+      description: "{{ item.desc }}"
+      cmd: "{{ nova_uwsgi_path }}"
+      args: "{{ item.args }}"
+      user: "{{ item.user }}"
+      type: "{{ item.type }}"
+      notify_access: "{{ item.notify_access }}"
+      restart: "{{ item.restart }}"
+      kill_signal: "SIGINT"
+    with_items:
+      - "{{ openstack_meta.nova.services.nova_placement_api[ursula_os] }}"
+
+  - name: Configure tmpfiles.d for creation of /run/uwsgi/nova on reboot
+    template:
+      src: usr/lib/tmpfiles.d/openstack-nova-placement-api.conf
+      dest: /usr/lib/tmpfiles.d/openstack-nova-placement-api.conf
+      mode: 0644
   when: ursula_os == 'rhel'
 
 #FIXME do we need this on rhosp?
@@ -103,6 +160,7 @@
     - "{{ nova.services.nova_consoleauth }}"
     - "{{ nova.services.nova_scheduler }}"
     - "{{ nova.services.nova_novncproxy }}"
+    - "{{ nova.services.nova_placement_api }}"
 
 - include: monitoring.yml
   tags:

--- a/roles/nova-control/templates/etc/init/nova-placement-api.conf
+++ b/roles/nova-control/templates/etc/init/nova-placement-api.conf
@@ -1,0 +1,23 @@
+description "uwsgi for nova"
+
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+
+pre-start script
+  if [ ! -d /run/uwsgi/nova ]; then
+      mkdir -p /run/uwsgi/nova
+      chown nova /run/uwsgi/nova
+      chmod 775 /run/uwsgi/nova
+  fi
+end script
+
+post-stop script
+  if [ -d /run/uwsgi/nova ]; then
+     rm -r /run/uwsgi/nova
+  fi
+end script
+
+exec {{ nova_uwsgi_path }} --uid nova --gid nova --master --emperor /etc/nova/uwsgi

--- a/roles/nova-control/templates/etc/nova/uwsgi/placement.ini
+++ b/roles/nova-control/templates/etc/nova/uwsgi/placement.ini
@@ -1,0 +1,29 @@
+[uwsgi]
+master = true
+processes = {{ nova.placement.workers }}
+chmod-socket = 666
+
+{% if openstack_install_method != 'distro' %}
+home = {{ nova.placement.uwsgi.home[openstack_install_method] }}
+{% endif %}
+pidfile = /run/uwsgi/nova/nova-placement-api.pid
+logto = /var/log/nova/nova-placement-api.log
+logfile-chmod = 644
+
+{% if nova.placement.uwsgi.method == 'socket' %}
+socket = /run/uwsgi/nova/nova-placement-api.socket
+{% else %}
+http-socket = 0.0.0.0:{{ nova.placement.uwsgi.http_port }}
+{% endif %}
+
+name = placement
+uid = nova
+gid = nova
+
+plugins = python
+
+{% if openstack_install_method == 'distro' %}
+wsgi-file = /bin/nova-placement-api
+{% else %}
+wsgi-file = /usr/local/bin/nova-placement-api
+{% endif %}

--- a/roles/nova-control/templates/usr/lib/tmpfiles.d/openstack-nova-placement-api.conf
+++ b/roles/nova-control/templates/usr/lib/tmpfiles.d/openstack-nova-placement-api.conf
@@ -1,0 +1,1 @@
+d /run/uwsgi/nova   755 nova nova

--- a/roles/nova-data/tasks/main.yml
+++ b/roles/nova-data/tasks/main.yml
@@ -76,31 +76,63 @@
   notify: restart nova compute
   when: cinder.fixed_key is not defined
 
-- name: install nova-compute service (ubuntu)
-  upstart_service:
-    name: "{{ item.name }}"
-    user: "{{ item.user }}"
-    cmd: "{{ item.cmd }}"
-    config_dirs: "{{ item.config_dirs }}"
-  with_items:
-    - "{{ nova.services.nova_compute }}"
+- block:
+  # Handle update to nova-compute service with env information.
+  - name: check {{ nova.services.nova_compute.name }} has REQUESTS_CA_BUNDLE information (ubuntu)
+    command: grep -q REQUESTS_CA_BUNDLE /etc/init/{{ nova.services.nova_compute.name }}.conf
+    register: srvc_has_env
+    failed_when: false
+    changed_when: false
+
+  - name: remove {{ nova.services.nova_compute.name }} service for update (ubuntu)
+    upstart_service:
+      name: "{{ nova.services.nova_compute.name }}"
+      user: "{{ nova.services.nova_compute.user }}"
+      cmd: "{{ nova.services.nova_compute.cmd }}"
+      state: absent
+    when: srvc_has_env|failed
+
+  - name: install nova-compute service (ubuntu)
+    upstart_service:
+      name: "{{ item.name }}"
+      user: "{{ item.user }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+      envs: "{{ item.envs }}"
+    with_items:
+      - "{{ nova.services.nova_compute }}"
   when: ursula_os == 'ubuntu'
 
-- name: install nova-compute service (rhel)
-  systemd_service:
-    name: "{{ item.name }}"
-    description: "{{ item.desc }}"
-    after: "{{ item.after }}"
-    type: "{{ item.type }}"
-    notify_access: "{{ item.notify_access|default(omit) }}"
-    user: "{{ item.user }}"
-    environments: "{{ item.environments }}"
-    cmd: "{{ item.cmd }}"
-    config_dirs: "{{ item.config_dirs }}"
-    config_files: "{{ item.config_files }}"
-    restart: "{{ item.restart }}"
-  with_items:
-    - "{{ nova.services.nova_compute }}"
+- block:
+  # Handle update to nova-compute service with env information.
+  - name: check {{ nova.services.nova_compute.name }} has REQUESTS_CA_BUNDLE information (rhel)
+    command: grep -q REQUESTS_CA_BUNDLE /etc/systemd/system/{{ nova.services.nova_compute.name }}.service
+    register: srvc_has_env
+    failed_when: false
+    changed_when: false
+
+  - name: remove {{ nova.services.nova_compute.name }} service for update (rhel)
+    systemd_service:
+      name: "{{ nova.services.nova_compute.name }}"
+      cmd: "{{ nova.services.nova_compute.cmd }}"
+      state: absent
+    when: srvc_has_env|failed
+
+  - name: install nova-compute service (rhel)
+    systemd_service:
+      name: "{{ item.name }}"
+      description: "{{ item.desc }}"
+      after: "{{ item.after }}"
+      type: "{{ item.type }}"
+      notify_access: "{{ item.notify_access|default(omit) }}"
+      user: "{{ item.user }}"
+      environments: "{{ item.environments }}"
+      cmd: "{{ item.cmd }}"
+      config_dirs: "{{ item.config_dirs }}"
+      config_files: "{{ item.config_files }}"
+      restart: "{{ item.restart }}"
+    with_items:
+      - "{{ nova.services.nova_compute }}"
   when: ursula_os == 'rhel'
 
 - name: trigger restart on upgrades

--- a/roles/openstack-meta/defaults/main.yml
+++ b/roles/openstack-meta/defaults/main.yml
@@ -153,6 +153,7 @@ openstack_meta:
           user: nova
           cmd: /usr/local/bin/nova-compute
           config_dirs: /etc/nova
+          envs: "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
         rhel:
           name: openstack-nova-compute
           desc: OpenStack Nova Compute Service
@@ -162,6 +163,7 @@ openstack_meta:
           user: nova
           environments:
             - "LIBGUESTFS_ATTACH_METHOD=appliance"
+            - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
           cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}nova-compute"
           config_dirs: /etc/nova
           config_files: /etc/nova/nova.conf
@@ -199,6 +201,18 @@ openstack_meta:
           config_dirs: /etc/nova
           config_files: /etc/nova/nova.conf
           restart: always
+      nova_placement_api:
+          ubuntu:
+            name: nova-placement-api
+            desc: OpenStack Nova Placement Service
+          rhel:
+            name: openstack-nova-placement-api
+            desc: OpenStack Nova Placement Service
+            type: notify
+            notify_access: all
+            user: nova
+            args: --uid nova --gid nova --master --emperor /etc/nova/uwsgi
+            restart: always
       nova_scheduler:
         ubuntu:
           name: nova-scheduler

--- a/upgrade.yml
+++ b/upgrade.yml
@@ -337,11 +337,21 @@
       run_once: True
       tags: dbdump
       delegate_to: "{{ groups['db'][0] }}"
+    - name: disable keystone from haproxy
+      file:
+        path: /etc/keystone/healthcheck_disable
+        state: touch
+    - name: wait for haproxy to notice
+      pause:
+        seconds: 8
 
   roles:
+    - role: stop-services
+      services:
+        - keystone
     - role: keystone
       force_sync: False
-      restart: False
+      restart: True
       database_create:
         changed: False
   environment: "{{ env_vars|default({}) }}"
@@ -365,15 +375,6 @@
   max_fail_percentage: 1
   tags: keystone
   tasks:
-    - name: disable keystone from haproxy
-      file:
-        path: /etc/keystone/healthcheck_disable
-        state: touch
-
-    - name: wait for haproxy to notice
-      pause:
-        seconds: 8
-
     - name: restart keystone service
       service:
         name: keystone


### PR DESCRIPTION
Enables nova-placement-api using uwsgi. 

Most of the work came from PR https://github.com/blueboxgroup/ursula/pull/2733.

port 8778 is the default openstack port for nova-placement-api. currently ursua uses 8778 for cinde volume backend port. This PR also switches cinder volume backend port to 9776 and nova-placement-api uses 8778 as it's frontend port.

Our upgrade.yml handles cinder controller services before it will upgrade nova so 8778 will be released in time for nova to use it when enabling nova-placement service.