### PR TITLE
misc cleanups.

### DIFF
--- a/envs/example/ci-ceph-swift-ubuntu/group_vars/all.yml
+++ b/envs/example/ci-ceph-swift-ubuntu/group_vars/all.yml
@@ -14,6 +14,13 @@ etc_hosts:
   - name: "{{ swift_fqdn }}"
     ip: "{{ swift_floating_ip }}"
 
+keystone:
+  uwsgi:
+    method: port
+
+barbican:
+  enabled: True
+
 neutron:
   enable_external_interface: True
   l3ha:
@@ -43,6 +50,9 @@ cinder:
     # Determined automatically by Ceph roles
 
 serverspec:
+  enabled: True
+
+inspec:
   enabled: True
 
 swift:

--- a/envs/example/ci-full-ubuntu/group_vars/all.yml
+++ b/envs/example/ci-full-ubuntu/group_vars/all.yml
@@ -52,6 +52,9 @@ keystone:
   uwsgi:
     method: port
 
+barbican:
+  enabled: True
+
 nova:
   libvirt_type: kvm
 
@@ -59,7 +62,7 @@ serverspec:
   enabled: True
 
 inspec:
-  enabled: False
+  enabled: True
 
 ceph:
   enabled: false

--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -314,9 +314,6 @@ neutron:
     - router_name: default
       subnet_name: internal_v6
       tenant_name: admin
-  service:
-    envs:
-      - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
   tenant_nameservers:
     - 8.8.4.4
     - 8.8.8.8

--- a/roles/inspec/tasks/main.yml
+++ b/roles/inspec/tasks/main.yml
@@ -2,6 +2,9 @@
 - name: install inspec
   package:
     name: inspec
+  register: result
+  until: result|succeeded
+  retries: 5
 
 - name: ensure inspec directory exists
   file:

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -79,8 +79,6 @@ neutron:
     service_plugin:
       - neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPluginv2
     service_provider: LOADBALANCERV2:Haproxy:neutron_lbaas.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default
-  service:
-    envs: []
   distro:
     project_packages:
       - openstack-neutron
@@ -157,7 +155,7 @@ neutron:
         - /var/log/neutron/neutron-linuxbridge-agent.log
       fields:
         type: openstack
-        tags: neutron,neutron-linuxbridge-agent        
+        tags: neutron,neutron-linuxbridge-agent
   logging:
     debug: False
     verbose: True

--- a/roles/neutron-control/tasks/main.yml
+++ b/roles/neutron-control/tasks/main.yml
@@ -7,10 +7,10 @@
     upstart_service:
       name: "{{ item.name }}"
       user: "{{ item.user }}"
+      envs: "{{ item.envs }}"
       cmd: "{{ item.cmd }}"
       config_dirs: "{{ item.config_dirs }}"
       config_files: "{{ item.config_files }}"
-      envs: "{{ neutron.service.envs }}"
     with_items:
       - "{{ neutron.services.neutron_server }}"
   when: ursula_os == 'ubuntu'
@@ -23,7 +23,7 @@
       type: "{{ item.type }}"
       notify_access: "{{ item.notify_access|default(omit) }}"
       user: "{{ item.user }}"
-      environments: "{{ neutron.service.envs }}"
+      environments: "{{ item.environments }}"
       cmd: "{{ item.cmd }}"
       config_dirs: "{{ item.config_dirs }}"
       config_files: "{{ item.config_files }}"

--- a/roles/neutron-data-network/tasks/main.yml
+++ b/roles/neutron-data-network/tasks/main.yml
@@ -50,11 +50,11 @@
       start_on: "{{ item.start_on|default(omit) }}"
       stop_on: "{{ item.stop_on|default(omit) }}"
       user: "{{ item.user }}"
+      envs: "{{ item.envs }}"
       pidfile: "{{ item.pidfile|default(omit) }}"
       cmd: "{{ item.cmd }}"
       config_dirs: "{{ item.config_dirs }}"
       config_files: "{{ item.config_files|default(omit) }}"
-      envs: "{{ neutron.service.envs }}"
     with_items:
       - "{{ neutron.services.neutron_dhcp_agent }}"
       - "{{ neutron.services.neutron_l3_agent }}"
@@ -70,7 +70,7 @@
       cmd: "{{ item.cmd }}"
       config_dirs: "{{ item.config_dirs }}"
       config_files: "{{ item.config_files|default(omit) }}"
-      envs: "{{ neutron.service.envs }}"
+      envs: "{{ item.envs }}"
     when: ((neutron.lbaas.enabled == "smart" and
            groups['controller'][0] not in groups['compute']) or
            neutron.lbaas.enabled|bool)
@@ -85,7 +85,7 @@
       description: "{{ item.desc }}"
       type: "{{ item.type }}"
       user: "{{ item.user }}"
-      environments: "{{ neutron.service.envs }}"
+      environments: "{{ item.environments }}"
       cmd: "{{ item.cmd }}"
       config_dirs: "{{ item.config_dirs }}"
       config_files: "{{ item.config_files }}"
@@ -103,7 +103,7 @@
       description: "{{ item.desc }}"
       type: "{{ item.type }}"
       user: "{{ item.user }}"
-      environments: "{{ neutron.service.envs }}"
+      environments: "{{ item.environments }}"
       cmd: "{{ item.cmd }}"
       config_dirs: "{{ item.config_dirs }}"
       config_files: "{{ item.config_files }}"

--- a/roles/neutron-data/tasks/main.yml
+++ b/roles/neutron-data/tasks/main.yml
@@ -21,6 +21,7 @@
     upstart_service:
       name: "{{ item.name }}"
       user: "{{ item.user }}"
+      envs: "{{ item.envs }}"
       cmd: "{{ item.cmd }}"
       config_dirs: "{{ item.config_dirs }}"
       config_files: "{{ item.config_files|default(omit) }}"
@@ -35,7 +36,7 @@
     description: "{{ item.desc }}"
     type: "{{ item.type }}"
     user: "{{ item.user }}"
-    environments: "{{ neutron.service.envs }}"
+    environments: "{{ item.environments }}"
     #FIXME added prestart to match up osp systemd
     #prestart_script: "{{ item.prestart_script }}"
     cmd: "{{ item.cmd }}"

--- a/roles/openstack-meta/defaults/main.yml
+++ b/roles/openstack-meta/defaults/main.yml
@@ -151,9 +151,10 @@ openstack_meta:
           name: nova-compute
           desc: OpenStack Nova Compute Service
           user: nova
+          envs:
+            - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
           cmd: /usr/local/bin/nova-compute
           config_dirs: /etc/nova
-          envs: "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
         rhel:
           name: openstack-nova-compute
           desc: OpenStack Nova Compute Service
@@ -282,6 +283,8 @@ openstack_meta:
           name: neutron-server
           desc: OpenStack Neutron Server Service
           user: neutron
+          envs:
+            - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
           cmd: /usr/local/bin/neutron-server
           config_dirs: /etc/neutron
           config_files: /etc/neutron/neutron.conf,/etc/neutron/plugins/ml2/ml2_plugin.ini
@@ -291,6 +294,8 @@ openstack_meta:
           type: notify
           notify_access: all
           user: neutron
+          environments:
+            - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
           cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}neutron-server"
           config_dirs: /etc/neutron
           config_files: /etc/neutron/neutron.conf,/etc/neutron/plugins/ml2/ml2_plugin.ini
@@ -301,6 +306,8 @@ openstack_meta:
           name: neutron-dhcp-agent
           desc: OpenStack Neutron DHCP Agent Service
           user: neutron
+          envs:
+            - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
           cmd: /usr/local/bin/neutron-dhcp-agent
           config_dirs: /etc/neutron
           config_files: /etc/neutron/neutron.conf,/etc/neutron/dhcp_agent.ini
@@ -311,6 +318,8 @@ openstack_meta:
           desc: OpenStack Neutron DHCP Agent Service
           type: simple
           user: neutron
+          environments:
+            - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
           cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}neutron-dhcp-agent"
           config_dirs: /etc/neutron
           config_files: /etc/neutron/neutron.conf,/etc/neutron/dhcp_agent.ini
@@ -321,6 +330,8 @@ openstack_meta:
           name: neutron-l3-agent
           desc: OpenStack Neutron L3 Agent Service
           user: neutron
+          envs:
+            - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
           cmd: /usr/local/bin/neutron-l3-agent
           config_dirs: /etc/neutron
           config_files: /etc/neutron/neutron.conf,/etc/neutron/l3_agent.ini
@@ -332,6 +343,8 @@ openstack_meta:
           desc: OpenStack Neutron L3 Agent Service
           type: simple
           user: neutron
+          environments:
+            - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
           cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}neutron-l3-agent"
           config_dirs: /etc/neutron
           config_files: /etc/neutron/neutron.conf,/etc/neutron/l3_agent.ini
@@ -343,12 +356,16 @@ openstack_meta:
           name: neutron-openvswitch-agent
           desc: OpenStack Neutron Open VSwitch Service
           user: neutron
+          envs:
+            - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
           cmd: /usr/local/bin/neutron-openvswitch-agent
           config_dirs: /etc/neutron
         rhel:
           name: neutron-openvswitch-agent
           desc: OpenStack Neutron Open VSwitch Service
           user: neutron
+          environments:
+            - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
           cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}neutron-openvswitch-agent"
           config_dirs: /etc/neutron
       neutron_linuxbridge_agent:
@@ -356,6 +373,8 @@ openstack_meta:
           name: neutron-linuxbridge-agent
           desc: OpenStack Neutron Linuxbridge Agent Service
           user: neutron
+          envs:
+            - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
           cmd: /usr/local/bin/neutron-linuxbridge-agent
           config_dirs: /etc/neutron
           config_files: /etc/neutron/neutron.conf,/etc/neutron/plugins/ml2/ml2_plugin.ini,/etc/neutron/plugins/ml2/ml2_plugin_dataplane.ini
@@ -364,6 +383,8 @@ openstack_meta:
           desc: OpenStack Neutron Linuxbridge Agent Service
           type: simple
           user: neutron
+          environments:
+            - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
           #prestart_script: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/neutron-enable-bridge-firewall.sh', '') }}"
           cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}neutron-linuxbridge-agent"
           config_dirs: /etc/neutron
@@ -375,6 +396,8 @@ openstack_meta:
           name: neutron-metadata-agent
           desc: OpenStack Neutron Metadata Agent Service
           user: neutron
+          envs:
+            - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
           cmd: /usr/local/bin/neutron-metadata-agent
           config_dirs: /etc/neutron
           config_files: /etc/neutron/neutron.conf,/etc/neutron/metadata_agent.ini
@@ -385,6 +408,8 @@ openstack_meta:
           desc: OpenStack Neutron Metadata Agent Service
           type: simple
           user: neutron
+          environments:
+            - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
           cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}neutron-metadata-agent"
           config_dirs: /etc/neutron
           config_files: /etc/neutron/neutron.conf,/etc/neutron/metadata_agent.ini
@@ -395,6 +420,8 @@ openstack_meta:
           name: neutron-lbaasv2-agent
           desc: OpenStack Neutron LBaasv2 Service
           user: neutron
+          envs:
+            - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
           cmd: /usr/local/bin/neutron-lbaasv2-agent
           config_dirs: /etc/neutron
           config_files: /etc/neutron/neutron.conf,/etc/neutron/services/loadbalancer/haproxy/lbaas_agent.ini,/etc/neutron/neutron_lbaas.conf
@@ -405,6 +432,8 @@ openstack_meta:
           desc: OpenStack Neutron LBaasv2 Service
           type: simple
           user: neutron
+          environments:
+            - "REQUESTS_CA_BUNDLE={{ ssl.cafile }}"
           cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}neutron-lbaasv2-agent"
           config_dirs: /etc/neutron
           config_files: /etc/neutron/neutron.conf,/etc/neutron/services/loadbalancer/haproxy/lbaas_agent.ini,/etc/neutron/neutron_lbaas.conf
@@ -833,9 +862,9 @@ openstack_meta:
           cmd: "{{ (ansible_distribution == 'RedHat') | ternary('/usr/bin/', '/usr/local/bin/') }}ceilometer-polling"
           args: "--polling-namespaces compute"
           restart: on-failure
-  barbican: 
+  barbican:
     services:
-      barbican_api: 
+      barbican_api:
         ubuntu:
           name: barbican
           desc: OpenStack Key Management Service


### PR DESCRIPTION
- enable barbican for ci-full-ubuntu and ci-ceph-swift-ubuntu
- enable inspec for ci-full-ubuntu and ci-ceph-swift-ubuntu
- enable keystone.uwsgi.port for ci-ceph-swift-ubuntu
- clean up neutron.service.envs to be consistent with nova-compute