### PR TITLE
WIP: ILMT Agent Enablement.

### DIFF
--- a/playbooks/ilmt-agent.yml
+++ b/playbooks/ilmt-agent.yml
@@ -1,0 +1,8 @@
+---
+# ilmt-agent
+#
+# enable ilmt BESAgent on every compute host
+
+- hosts: compute
+  roles:
+    - ../roles/ilmt

--- a/roles/ilmt/defaults/main.yml
+++ b/roles/ilmt/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+  ilmt_agent:
+    enabled: False
+    service: besclient
+    package:
+      name: BESAgent
+      version: latest
+    actionsite:
+      method: url
+      protocol: https
+      server: ~
+      port: 52311
+      url_path: /cgi-bin/bfgather.exe/actionsite
+      file_content: ~

--- a/roles/ilmt/meta/main.yml
+++ b/roles/ilmt/meta/main.yml
@@ -1,0 +1,9 @@
+---
+dependencies:
+  - role: monitoring-common
+    when: monitoring.enabled|default(True)|bool
+  - role: openstack-firewall
+    rule_name: "{{ ilmt_agent.service }}"
+    rules_type_input:
+      - { protocol: tcp, port: "{{ ilmt_agent.actionsite.port }}" }
+      - { protocol: udp, port: "{{ ilmt_agent.actionsite.port }}" }

--- a/roles/ilmt/tasks/main.yml
+++ b/roles/ilmt/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+- include: validator.yml
+  tags: ['precheck']
+
+# TODO: Can BESClient be configures to run under it's own user
+
+- name: /etc/opt/BESClient
+  file:
+    dest: /etc/opt/BESClient
+    state: directory
+    owner: root
+    group: root
+
+- name: install BESClient package
+  package:
+    name: "{{ ilmt_agent.package.name }}={{ ilmt_agent.package.version }}"
+  register: result
+  until: result|succeeded
+  retries: 5
+
+- name: download actionsite masthead file to /etc/opt/BESClient
+  get_url:
+    url: "{{ ilmt_agent.actionsite.protocol }}//{{ ilmt_agent.actionsite.server }}:{{ ilmt_agent.actionsite.port }}/{{ ilmt_agent.actionsite.protocol }}"
+    dest: /etc/opt/BESClient/actionsite.afxm
+  when: ilmt_agent.actionsite.method == 'url'
+
+- name: copy actionsite masthead file to /etc/opt/BESClient
+  template:
+    src: etc/opt/BESClient/actionsite.afxm
+    dest: /etc/opt/BESClient/actionsite.afxm
+    owner: root
+    group: root
+    mode: 0640
+  when: ilmt_agent.actionsite.method == 'file'
+
+- name: restart ilmt agent service
+  service:
+    name: "{{ ilmt_agent.service }}"
+    state: restarted
+    enabled: True
+    must_exist: false
+
+- include: monitoring.yml
+  tags:
+    - monitoring
+    - common
+  when: monitoring.enabled|default('True')|bool

--- a/roles/ilmt/tasks/monitoring.yml
+++ b/roles/ilmt/tasks/monitoring.yml
@@ -1,0 +1,5 @@
+---
+- name: besclient process check installation
+  sensu_process_check:
+    service: "{{ ilmt_agent.service }}"
+  notify: restart sensu-client

--- a/roles/ilmt/tasks/validator.yml
+++ b/roles/ilmt/tasks/validator.yml
@@ -1,0 +1,22 @@
+---
+- name: ensure ilmt_agent is enabled
+  assert:
+    that: "ilmt_agent.enabled"
+    msg: "ilmt_agent.enabled must be set to true to get BESClient installed on compute hosts."
+  run_once: true
+
+- name: ensure ILMT server information to download actionsite file is defined
+  assert:
+    that: "ilmt_agent.actionsite.server is defined"
+    msg: "ilmt_agent.actionsite.server must be defined when using method url"
+  run_once: true
+  when: ilmt_agent.actionsite.method == 'url'
+
+- name: ensure ILMT actionsite file content is defined
+  assert:
+    that: "ilmt_agent.actionsite.file_content is defined"
+    msg: "ilmt_agent.actionsite.file_content must be defined when using method file"
+  run_once: true
+  when: ilmt_agent.actionsite.method == 'file'
+
+# TODO Add check to validate connectivity to ILMT server

--- a/roles/ilmt/templates/etc/opt/BESClient/actionsite.afxm
+++ b/roles/ilmt/templates/etc/opt/BESClient/actionsite.afxm
@@ -1,0 +1,2 @@
+# {{ ansible_managed }}
+{{ ilmt_agent.actionsite.file_content }}


### PR DESCRIPTION
PR provide a playbook and a role to enable installation of ILMT agent on compute hosts.

To enable ILMT agent, one must be having ILMT Server deployed and running that is reachable from compute host. Also, one needs to set `ilmt_agent.enabled: True` in $env\group_vars/all.yml and perform a ursula run using playbooks/ilmt.yml