### PR TITLE
add logic for adding flavors to skip when flavors are already present

### DIFF
--- a/roles/openstack-meta/defaults/main.yml
+++ b/roles/openstack-meta/defaults/main.yml
@@ -111,6 +111,7 @@ openstack_meta:
           config_files: /etc/cinder/cinder.conf
           restart: on-failure
   nova:
+    force_flavors: false
     flavors:
       - flavorid: 1
         name: m1.tiny

--- a/roles/openstack-setup/tasks/flavors.yml
+++ b/roles/openstack-setup/tasks/flavors.yml
@@ -1,4 +1,9 @@
 ---
+- name: register flavor count
+  shell: . /root/stackrc; openstack flavor list -f value --all
+  register: flavorcount
+  run_once: true
+  
 - name: Add flavors
   environment:
     PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"
@@ -21,7 +26,9 @@
       password: "{{ secrets.admin_password  }}"
   with_items: '{{ openstack_meta.nova.flavors | default([]) }}'
   run_once: true
-  # FIXME flavors are always added, even if it's just an Ironic cloud
+  when: 
+    - flavorcount.stdout == "" or openstack_meta.nova.force_flavors|bool
+    - not ironic.enabled|bool
 
 - name: Add ironic flavors
   environment:


### PR DESCRIPTION
if cloud users have added their own flavors, adding the default flavors may not be needed.  if any flavors are present, no default flavors will be created.