### PR TITLE
use pool_names.yml to populate vars in upgrade.yml

### DIFF
--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -6,7 +6,9 @@
   # https://github.com/ansible/ansible/issues/15365
   # delegate_facts does not work with run_once
   # so we use inventory_hostname == play_hosts[0] instead of run_once
-  when: inventory_hostname == play_hosts[0]
+  when:
+    - inventory_hostname == play_hosts[0]
+    - ssd_pool is undefined
   tags: ['monitoring', 'openstack', 'control', 'glance', 'cinder',
          'cinder-data', 'nova', 'nova-data', 'data', 'openstack-setup']
 

--- a/roles/ceph-osd/tasks/pool_names.yml
+++ b/roles/ceph-osd/tasks/pool_names.yml
@@ -53,7 +53,7 @@
 # if default pool exists, ssd/hybrid pool exists too
 - name: set pool names if default pool and ssd pool exist
   set_fact:
-    ssd_pool:  "rbd_ssd"
+    ssd_pool: "rbd_ssd"
     hybrid_pool: "default"
   when:
     - existing_pools.stdout | search("default")
@@ -61,7 +61,7 @@
 
 - name: set pool names if default pool and hybrid pool exist
   set_fact:
-    hybrid_pool:  "rbd_hybrid"
+    hybrid_pool: "rbd_hybrid"
     ssd_pool: "default"
   when:
     - existing_pools.stdout | search("default")
@@ -77,7 +77,7 @@
 
 - name: populate pool names to all osd nodes
   set_fact:
-    hybrid_pool:  "{{ hybrid_pool }}"
+    hybrid_pool: "{{ hybrid_pool }}"
     ssd_pool: "{{ ssd_pool }}"
   delegate_to: "{{ item }}"
   delegate_facts: yes

--- a/upgrade.yml
+++ b/upgrade.yml
@@ -206,12 +206,12 @@
         changed: false
   environment: "{{ env_vars|default({}) }}"
 
-- name: ceph osds
-  hosts: ceph_osds
+- name: populate ceph related vars
+  hosts: ceph_monitors[0]
   max_fail_percentage: 1
   any_errors_fatal: true
-  roles:
-    - role: ceph-osd
+  tasks:
+    - include: roles/ceph-osd/tasks/pool_names.yml
       when: ceph.enabled
       tags: ['ceph', 'ceph-osd']
   environment: "{{ env_vars|default({}) }}"


### PR DESCRIPTION
pool_names.yml has all tasks those populate vars, so we use
pool_names.yml to populate vars instead of using ceph-osd role.

Also prevent running pool_names.yml more than one time.