### PR TITLE
Use static ansible_managed line.

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -16,6 +16,7 @@ log_path=ursula.log
 forks = 25
 gathering = smart
 sudo_flags = -HE
+ansible_managed = "This file is managed by ansible, don't make changes here - they will be overwritten."
 
 [ssh_connection]
 pipelining = false


### PR DESCRIPTION
When templating files with {{ ansible_managed }} inside the template, the file is considered changed every time ansible runs because the default ansible_managed contains a timestamp that always changes (and other bits that often change, i.e. when deploying from different machines/users).

This PR defines a static constant value for ansible_managed thus avoiding unnecessary service restarts when config files have not changed.