### PR TITLE
flags for defaults-2.0.yml backward compatibility to 3.1.x.

### DIFF
--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 project_name: cinder
-cinder:
+cinder: 
   services:
     cinder_api: "{{ openstack_meta.cinder.services.cinder_api[ursula_os] }}"
     cinder_scheduler: "{{ openstack_meta.cinder.services.cinder_scheduler[ursula_os] }}"

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -13,6 +13,7 @@ nova:
     nova_cells: "{{ openstack_meta.nova.services.nova_cells[ursula_os] }}"
     libvirt: "{{ openstack_meta.nova.services.libvirt[ursula_os] }}"
   placement:
+    enabled: True # Added to keep keystone.services.endpoints.cinderv3 in default-2.0.yml backward compatible with 3.1.x
     workers: 3
     uwsgi:
       method: port


### PR DESCRIPTION
In 4.0.0.0c we have added new openstack service endpoints like barbican, cinderv3, placement in defaults-2.0.yml. These new endpoints are not defined in back releases (example 3.1.x) thus will break ursula run when using common defaults-2.0.yml.

This PR adds the flags that will help maintain backward compatibility in defaults-2.0.yml for 3.1.x release.