### PR TITLE
set pool_names completed flag at the end of pool_name.yml

### DIFF
--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -8,7 +8,7 @@
   # so we use inventory_hostname == play_hosts[0] instead of run_once
   when:
     - inventory_hostname == play_hosts[0]
-    - ssd_pool is undefined
+    - pool_names_completed is undefined
   tags: ['monitoring', 'openstack', 'control', 'glance', 'cinder',
          'cinder-data', 'nova', 'nova-data', 'data', 'openstack-setup']
 

--- a/roles/ceph-osd/tasks/pool_names.yml
+++ b/roles/ceph-osd/tasks/pool_names.yml
@@ -182,3 +182,10 @@
   with_items:
     - "{{ groups['controller'] }}"
     - "{{ groups['cinder_volume'] }}"
+
+# this flag has to be defined at the end of this yml file
+# because main.yml passes condition 'pool_names_completed is defined' to
+# every task in this yml file
+- name: set pool_names_completed to indicate pool_names.yml has been run
+  set_fact:
+    pool_names_completed: true


### PR DESCRIPTION
Ansible passes the parent condition to every sub task in included yml
file. In following example, `ssd_pool is undefined` is passed to be condition of every task in pool_names.yml.
So we have to defined the flag at the end of the yml file, to make sure
all tasks in the yml file is executed.

```
- include: pool_names.yml
  delegate_to: "{{ groups['ceph_monitors'][0] }}"
  when:
    - inventory_hostname == play_hosts[0]
    - ssd_pool is undefined
 ```