### PR TITLE
WIP: fix_symbol_link

### DIFF
--- a/roles/current_symlink/tasks/main.yml
+++ b/roles/current_symlink/tasks/main.yml
@@ -9,24 +9,16 @@
   args:
     chdir: /opt/openstack/current
   register: pkgs
-  when: current.stat.islnk|default(False)
+  when: current.stat.isdir|default(False)
 
 - name: remove current link
   file:
     path: /opt/openstack/current
     state: absent
-  when: current.stat.islnk|default(False)
+  when: current.stat.isdir|default(False)
 
 - name: make current dir
   file:
     path: /opt/openstack/current
     state: directory
-  when: current.stat.islnk|default(False)
-
-- name: make package links
-  file:
-    path: /opt/openstack/current/{{ item }}
-    src: "{{ current.stat.lnk_source }}/{{ item }}"
-    state: link
-  when: current.stat.islnk|default(False)
-  with_items: "{{ pkgs.stdout_lines|default([]) }}"
+  when: current.stat.isdir|default(False)


### PR DESCRIPTION
- this (/opt/openstack/current) is directory, this check(current.stat.islnk) may be not appropriate
- when update package-version, /opt/openstack/current still point to old package version 

Maybe this role `current_symlink` should be deleted from site.yml and deploying via upgrade.yml( or site.yml --extra-vars=upgrade=true)  instead  of site.yml when have package version change
```
# OPENSTACK SERVICES
# # this next play can go away after 2.1.0+ is everywhere
- name: deal with current symlink
  hosts: all:!vyatta-*
  any_errors_fatal: true
  gather_facts: false
  roles:
    - role: current_symlink
      tags:
        - openstack
        - symlink
  environment: "{{ env_vars|default({}) }}"
```