### PR TITLE
base virtualenv need heatclient for monitoring

### DIFF
--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -60,6 +60,15 @@
   retries: 5
   when: openstack_install_method != 'distro'
 
+- name: install openstack clients (basevenv)
+  pip: name={{ item }} virtualenv="{{ basevenv | default('/opt/openstack/base') }}"
+  with_items: "{{ client.names['pip_pkgs'] }}"
+  notify:
+    - update ca certs
+  register: result
+  until: result|succeeded
+  retries: 5
+
 - name: fix ssl certs for requests for keystone-client on trusty
   file: src=/etc/ssl/certs/ca-certificates.crt
         dest=/usr/local/lib/python2.7/dist-packages/requests/cacert.pem


### PR DESCRIPTION
current monitoring runs in base venv, and some checks need related openstack component clients. most of them are installed by shade, but heat client isn't. so need to install heatclient as extra packages in base venv.