### PR TITLE
add retry for pip install bbg-ceph-utils

### DIFF
--- a/roles/ceph-monitor/tasks/main.yml
+++ b/roles/ceph-monitor/tasks/main.yml
@@ -126,6 +126,9 @@
          virtualenv={{ basevenv|default(omit)  }}
          extra_args={{ ceph.bbg_ceph_utils_pkg.pip_extra_args|default(omit) }}
     no_log: true
+    register: result
+    until: result|succeeded
+    retries: 5
 
   - name: add cron to adjust ceph pg number
     cron: name='ceph-utils' minute='*/{{ ceph.adjust_inveral }}'


### PR DESCRIPTION
pip install may fails for the first time, so adding retry.