### PR TITLE
some tiny fixes of ceph

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -10,7 +10,7 @@
   shell: uuidgen > /etc/ceph/fsid && truncate -s -1 /etc/ceph/fsid
          creates=/etc/ceph/fsid
   run_once: true
-  delegate_to:  "{{ groups['ceph_monitors'][0] }}"
+  delegate_to: "{{ groups['ceph_monitors'][0] }}"
 
 - name: fetch contents of fsid file
   slurp: path=/etc/ceph/fsid
@@ -30,7 +30,7 @@
   shell: uuidgen > /etc/ceph/cinder_uuid && truncate -s -1 /etc/ceph/cinder_uuid
          creates=/etc/ceph/cinder_uuid
   run_once: true
-  delegate_to:  "{{ groups['ceph_monitors'][0] }}"
+  delegate_to: "{{ groups['ceph_monitors'][0] }}"
 
 - name: fetch contents of uuid file
   slurp: path=/etc/ceph/cinder_uuid

--- a/roles/ceph-monitor/tasks/main.yml
+++ b/roles/ceph-monitor/tasks/main.yml
@@ -13,12 +13,15 @@
   until: result|succeeded
   retries: 5
 
+# FIXME: let's rename keyring.mon.{{ ansible_hostname }} in next relese.
+# Variable 'ansible_hostname' is not needed as part of the file name,
+# ceph.mon.keyring will be a good name
 - name: create monitor initial keyring
   command: ceph-authtool /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
            --create-keyring --name=mon. --gen-key --cap mon 'allow *'
            creates=/var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
   run_once: true
-  delegate_to:  "{{ groups['ceph_monitors'][0] }}"
+  delegate_to: "{{ groups['ceph_monitors'][0] }}"
 
 - name: fetch contents of mon_secret file
   slurp: path=/var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
@@ -94,9 +97,6 @@
 - name: wait for client.admin key exists
   wait_for: path=/etc/ceph/ceph.client.admin.keyring
 
-- name: make admin keyring owned by ceph
-  file: path=/etc/ceph/ceph.client.admin.keyring owner=ceph group=ceph
-
 - name: create openstack keys
   command: ceph auth get-or-create {{ item.name }} {{ item.value }}
            -o /etc/ceph/ceph.{{ item.name }}.keyring
@@ -107,6 +107,7 @@
 # we change the caps here
 - name: update openstack ceph user caps
   command: ceph auth caps {{ item.name }} {{ item.value }}
+  run_once: true
   with_items: "{{ ceph.openstack_keys }}"
 
 - include: restart_flags.yml
@@ -140,4 +141,4 @@
   tags:
     - monitoring
     - common
-  when: monitoring.enabled|default('True')|bool
+  when: monitoring.enabled|default(true)


### PR DESCRIPTION
1. Remove the task which changes owner of admi keyring file.
   It was used for upgrading from hammer to Jewel.
2. Add run_once for task which changes cap of CEPH users.
3. Fix `default('True')|bool`