### PR TITLE
fix live migration

### DIFF
--- a/roles/common/templates/etc/hosts
+++ b/roles/common/templates/etc/hosts
@@ -29,7 +29,7 @@ ff02::2 ip6-allrouters
 
 {% if 'compute' in groups %}
 {% for host in groups['compute'] if inventory_hostname in groups['compute'] %}
-{{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].ansible_nodename }}
+{{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].hostname_fqdn }} {{ hostvars[host].hostname_short }}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
It's try to resolve a regression defect for live migration, to let source/target computes can know each other by long hostname or short hostname.
