### PR TITLE
fix apache keystone.conf for uwsgi method socket

### DIFF
--- a/roles/keystone/templates/etc/apache2/sites-available/keystone.conf
+++ b/roles/keystone/templates/etc/apache2/sites-available/keystone.conf
@@ -119,7 +119,7 @@ ServerName https://{{ fqdn }}
         Options FollowSymLinks Indexes
         SetHandler uwsgi-handler
         uWSGImaxVars 255
-        uWSGISocket /run/uwsgi/keystone-admin.socket
+        uWSGISocket /run/uwsgi/keystone/keystone-admin.socket
 {% else %}
         ProxyPass uwsgi://127.0.0.1:{{ keystone.uwsgi.http_port.admin }}/
         SetEnv force-proxy-request-1.0 1
@@ -142,7 +142,7 @@ ServerName https://{{ fqdn }}
         Options FollowSymLinks Indexes
         SetHandler uwsgi-handler
         uWSGImaxVars 255
-        uWSGISocket /run/uwsgi/keystone-main.socket
+        uWSGISocket /run/uwsgi/keystone/keystone-main.socket
     {% else %}
         ProxyPass uwsgi://127.0.0.1:{{ keystone.uwsgi.http_port.public }}/
         SetEnv force-proxy-request-1.0 1


### PR DESCRIPTION
The apache site config for keystone was pointing to an incorrect socket location for the uwsgi method socket. This change fixes the location of the uwsgi socket in the config.

