### PR TITLE
switch uwsgi method socket for keystone - ubuntu.

### DIFF
--- a/envs/example/ci-ceph-swift-ubuntu/group_vars/all.yml
+++ b/envs/example/ci-ceph-swift-ubuntu/group_vars/all.yml
@@ -16,7 +16,7 @@ etc_hosts:
 
 keystone:
   uwsgi:
-    method: port
+    method: socket
 
 barbican:
   enabled: True

--- a/envs/example/ci-ceph-ubuntu/group_vars/all.yml
+++ b/envs/example/ci-ceph-ubuntu/group_vars/all.yml
@@ -60,7 +60,7 @@ haproxy:
 
 keystone:
   uwsgi:
-    method: port
+    method: socket
 
 nova:
   libvirt_type: kvm

--- a/envs/example/ci-full-ubuntu/group_vars/all.yml
+++ b/envs/example/ci-full-ubuntu/group_vars/all.yml
@@ -50,7 +50,7 @@ keystone:
     enabled: True
     domain: users
   uwsgi:
-    method: port
+    method: socket
 
 barbican:
   enabled: True


### PR DESCRIPTION
In ubuntu switching to uswgi method port where apache uses mod_proxy_uwsgi plugin is causing intermittent 502 - Bad Gateway errors when hitting keystone apis concurrently.

Further debug from apache log shows segementation faults happening under high concurrency at mod_proxy_uwsgi module.

In past releases, for ubuntu we used method socket for uwsgi and mod_uwsgi plugin.

This PR is switching back ubuntu cluster to use uwsgi socket method.