### PR TITLE
vendored upper_contrain to fix performance issues.

### DIFF
--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -122,7 +122,7 @@ apt_repos:
     key_url: https://apt-mirror.openstack.blueboxgrid.com/keys/percona.key
   rabbitmq:
     repo: https://apt-mirror.openstack.blueboxgrid.com/rabbitmq/debian
-    key_url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
+    key_url: https://apt-mirror.openstack.blueboxgrid.com/keys/rabbitmq.key
   cloud_archive:
     repo: https://apt-mirror.openstack.blueboxgrid.com/cloud_archive/ubuntu
   erlang:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pep8
 oslo.utils
 shade>=1.7.0
 ansible>=2.1.0.0,<3,<=2.1.3
-python-novaclient<8.0.0
+python-novaclient
 python-glanceclient
 python-cinderclient
 python-neutronclient

--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 client:
-  upper_constraints: '{{ openstack_meta.upper_constraints }}'
+  upper_constraints: "{{ openstack_meta.upper_constraints }}"
+  use_constraints: False
   write_stackrc: True
   self_signed_cert: false
   dep_pkgs:
@@ -9,7 +10,7 @@ client:
     pip_pkgs:
       - python-keystoneclient
       - python-glanceclient
-      - python-novaclient<8.0.0
+      - python-novaclient
       - python-neutronclient
       - python-cinderclient
       - python-heatclient

--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -12,16 +12,6 @@
   until: result|succeeded
   retries: 5
 
-- name: install required packages for clients
-  package:
-    name: "{{ item }}"
-    state: present
-  with_items: "{{ client.names['yum_pkgs'] }}"
-  register: result
-  until: result|succeeded
-  retries: 5
-  when: ursula_os == 'rhel' and openstack_install_method == 'distro'
-
 - block:
   - name: make sure /opt/stack/ exists
     file: dest=/opt/stack state=directory
@@ -31,14 +21,16 @@
       src: ../../openstack-source/files/constraints.txt
       dest: /opt/stack/constraints.txt
       force: true
-    when: client.upper_constraints == None
+    when: client.upper_constraints == None or client.upper_constraints == ""
 
   - name: get constraints file
     get_url:
       url: "{{ client.upper_constraints }}"
       dest: /opt/stack/constraints.txt
       force: true
-    when: client.upper_constraints != None
+    when:
+      - client.upper_constraints != None
+      - client.upper_constraints != ""
 
   - name: upgrade system setuptools using upper_contraints
     pip:
@@ -47,18 +39,38 @@
     register: result
     until: result|succeeded
     retries: 5
+
+  - name: install openstack clients (not distro using upper_contraints)
+    pip: name={{ item }} extra_args='-c /opt/stack/constraints.txt'
+    with_items: "{{ client.names['pip_pkgs'] }}"
+    when: client.use_constraints|bool
+    notify:
+      - update ca certs
+    register: result
+    until: result|succeeded
+    retries: 5
+
+  - name: install python-openstackclient (not distro without using upper_contraints)
+    pip: name={{ item }}
+    with_items: "{{ client.names['pip_pkgs'] }}"
+    when: not client.use_constraints|bool
+    notify:
+      - update ca certs
+    register: result
+    until: result|succeeded
+    retries: 5
   when:
     - openstack_install_method != 'distro'
 
-- name: install openstack clients
-  pip: name={{ item }} extra_args='-c /opt/stack/constraints.txt'
-  with_items: "{{ client.names['pip_pkgs'] }}"
-  notify:
-    - update ca certs
+- name: install openstack clients (distro)
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ client.names['yum_pkgs'] }}"
   register: result
   until: result|succeeded
   retries: 5
-  when: openstack_install_method != 'distro'
+  when: ursula_os == 'rhel' and openstack_install_method == 'distro'
 
 - name: fix ssl certs for requests for keystone-client on trusty
   file: src=/etc/ssl/certs/ca-certificates.crt

--- a/roles/openstack-meta/defaults/main.yml
+++ b/roles/openstack-meta/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 openstack_meta:
-  upper_constraints: 'https://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt'
+  upper_constraints: 'https://file-mirror.openstack.blueboxgrid.com/upper_constraints/newton/upper-constraints.txt'
   keystone:
     services:
       keystone_api:

--- a/roles/openstack-source/files/constraints.txt
+++ b/roles/openstack-source/files/constraints.txt
@@ -64,7 +64,7 @@ alembic===0.8.7
 amqp===1.4.9
 anyjson===0.3.3
 aodhclient===0.7.0
-appdirs===1.4.2
+appdirs===1.4.0
 astroid===1.3.8
 autobahn===0.16.0
 automaton===1.4.0
@@ -92,7 +92,7 @@ contextlib2===0.5.4
 coverage===4.2
 crc16===0.1.1
 croniter===0.3.12
-cryptography===1.5
+cryptography===1.8.1
 cursive===0.1.1
 ddt===1.1.0
 debtcollector===1.8.0
@@ -100,7 +100,7 @@ decorator===4.0.10
 demjson===2.2.4
 dib-utils===0.0.10
 discover===0.4.0
-diskimage-builder===1.18.2
+diskimage-builder===1.19.0
 django-appconf===1.0.2
 django-babel===0.5.1
 django-compressor===2.1
@@ -157,7 +157,7 @@ kafka-python===0.9.5
 kazoo===2.2.1
 keyring===9.3.1
 keystoneauth1===2.12.3
-keystonemiddleware===4.9.0
+keystonemiddleware===4.9.1
 kombu===3.0.35
 krest===1.3.1
 ldap3===1.4.0
@@ -199,7 +199,7 @@ openstacksdk===0.9.5
 ordereddict===1.1
 os-api-ref===1.0.0
 os-apply-config===0.1.32
-os-brick===1.6.1
+os-brick===1.6.2
 os-client-config===1.21.1
 os-cloud-config===5.1.0
 os-collect-config===5.1.0
@@ -216,9 +216,9 @@ oslo.db===4.13.5
 oslo.i18n===3.9.0
 oslo.log===3.16.0
 oslo.messaging===5.10.1
-oslo.middleware===3.19.0
+oslo.middleware===3.19.1
 oslo.policy===1.14.0
-oslo.privsep===1.13.1
+oslo.privsep===1.13.2
 oslo.reports===1.14.0
 oslo.rootwrap===5.1.1
 oslo.serialization===2.13.0
@@ -251,7 +251,7 @@ psutil===1.2.1
 psycopg2===2.6.2
 ptyprocess===0.5.1
 py===1.4.31
-pyOpenSSL===16.1.0
+pyOpenSSL===16.2.0
 pyScss===1.3.4
 pyasn1===0.1.9
 pyasn1-modules===0.0.8
@@ -290,7 +290,7 @@ python-ironic-inspector-client===1.10.0
 python-ironicclient===1.7.1
 python-k8sclient===0.3.0
 python-karborclient===0.0.9
-python-keystoneclient===3.5.0
+python-keystoneclient===3.5.1
 python-magnumclient===2.3.1
 python-manilaclient===1.11.0
 python-memcached===1.58
@@ -397,6 +397,6 @@ wsgi-intercept===1.3.1
 xattr===0.8.0
 xmltodict===0.10.2
 xvfbwrapper===0.2.8
-yaql===1.1.1
+yaql===1.1.2
 zake===0.2.2
 zope.interface===4.3.1

--- a/roles/openstack-source/tasks/main.yml
+++ b/roles/openstack-source/tasks/main.yml
@@ -39,14 +39,16 @@
     src: files/constraints.txt
     dest: /opt/stack/constraints.txt
     force: true
-  when: upper_constraints == None
+  when: upper_constraints == None or upper_constraints == ""
 
 - name: get constraints file
   get_url:
     url: "{{ upper_constraints }}"
     dest: /opt/stack/constraints.txt
     force: true
-  when: upper_constraints != None
+  when:
+    - upper_constraints != None
+    - upper_constraints != ""
 
 - name: set pip constraints args
   set_fact:


### PR DESCRIPTION
This PR vendor's upper_contriants taking upstream upper_constraints.txt as of 05/19/2017 from https://github.com/openstack/requirements/blob/stable/newton/upper-constraints.txt with gitsha - e61e123c867d23ea1d341f9d1f04435bd5074257 and making following changes

Changes to upper_contraints.txt:
oslo.middleware===3.19.1  (originally was 3.19.0)
pyOpenSSL===16.2.0  (originally was 16.1.0)
cryptography===1.8.1 (originally was 1.5)

- To fix neutron rootwrapd performances issue
before:
user    0m0.297s
sys     0m0.049s
after:
real    0m0.155s
user    0m0.070s
sys     0m0.029s

- To fix security vunl around leaking sensitive information in logs when exception is raised
https://github.com/openstack/oslo.middleware/commit/6c0f50c1f5f4122b31dbfe25aacdce596bf4b648  (is already in newton/stable but upper_contraints still using 3.19.0

- install python-openstackclient version 3.4.1 for pick up livemigration cli fix
https://bugs.launchpad.net/python-openstackclient/+bug/1518059