### PR TITLE
increase osd out interval

### DIFF
--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -120,7 +120,7 @@ ceph:
 
   # Monitor options
   monitor_interface: bond0
-  mon_osd_down_out_interval: 600
+  mon_osd_down_out_interval: 1200
   mon_clock_drift_allowed: .15
   mon_clock_drift_warn_backoff: 30
   mon_osd_full_ratio: .95


### PR DESCRIPTION
Once any osd is down, CEPH will set these OSD out after interval.
We increase osd out interval so that the ops will have more time before
osd out.