### PR TITLE
pin ceph client and libvirt-bin/qemu to new version 

### DIFF
--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -38,7 +38,7 @@ ceph:
     ubuntu: 10.2.3~bbc1
     rhel: 10.2.3
   client_version:
-    ubuntu: 10.2.6-0ubuntu0.16.04.1~cloud0
+    ubuntu: 10.2.7-0ubuntu0.16.04.1~cloud0
     rhel: 10.2.3
 
   openstack_keys:

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -55,9 +55,9 @@ nova:
   vnc_keymap: en-us
   scheduler_default_filters: RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,CoreFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,AggregateInstanceExtraSpecsFilter,NUMATopologyFilter
   scheduler_host_subset_size: 1
-  libvirt_bin_version: 1.3.1-1ubuntu10.8~cloud0
+  libvirt_bin_version: 1.3.1-1ubuntu10.9~cloud0
   python_libvirt_version: 1.3.1-1ubuntu1~cloud0
-  qemu_kvm_version: 1:2.5+dfsg-5ubuntu10.9~cloud0
+  qemu_kvm_version: 1:2.5+dfsg-5ubuntu10.13~cloud0
   # librbd1 version should match the ceph client version
   librbd1_version: "{{ ceph.client_version[ursula_os] }}"
   qemu_system_package: qemu-system-x86


### PR DESCRIPTION
- ceph client version have been updated to version 10.2.7-0ubuntu0.16.04.1~cloud0
  pin ceph client to new version(10.2.7-0ubuntu0.16.04.1~cloud0)

- pin libvirt-bin version to libvirt-bin_1.3.1-1ubuntu10.9~cloud0_i386.deb