### PR TITLE
adjust to cloudarchive version bump.

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -9,7 +9,7 @@ ceph:
   #bcache_ssd_device: sdg
 
   version: 10.2.3~bbc1
-  ceph_cloud_archive_version: 10.2.6-0ubuntu0.16.04.1~cloud0
+  ceph_cloud_archive_version: 10.2.7-0ubuntu0.16.04.1~cloud0
 
   openstack_keys:
     - { name: client.glance, value: "mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx'" }

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -25,10 +25,10 @@ nova:
   vnc_keymap: en-us
   scheduler_default_filters: RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,CoreFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,AggregateInstanceExtraSpecsFilter,NUMATopologyFilter
   scheduler_host_subset_size: 1
-  libvirt_bin_version: 1.3.1-1ubuntu10.8~cloud0
+  libvirt_bin_version: 1.3.1-1ubuntu10.9~cloud0
   python_libvirt_version: 1.3.1-1ubuntu1~cloud0
-  qemu_kvm_version: 1:2.5+dfsg-5ubuntu10.9~cloud0
-  librdb1_version: 10.2.6-0ubuntu0.16.04.1~cloud0
+  qemu_kvm_version: 1:2.5+dfsg-5ubuntu10.13~cloud0
+  librdb1_version: 10.2.7-0ubuntu0.16.04.1~cloud0
   qemu_system_package: qemu-system-x86
   glance_endpoint: http://{{ endpoints.main }}:9393
   reserved_host_disk_mb: 51200


### PR DESCRIPTION
ceph-client, libvirt-bina dn qemu-kvm version got bumped in upstream cloudarchive repo. This PR is to adjust the defaults to new version.