### PR TITLE
update the pg per osd

### DIFF
--- a/roles/ceph-osd/tasks/bcache.yml
+++ b/roles/ceph-osd/tasks/bcache.yml
@@ -168,6 +168,9 @@
   ceph_pool:
     pool_name: "{{ hybrid_pool }}"
     osds: "{{ groups['ceph_osds_hybrid']|length * ceph.disks|length }}"
+    target_pgs_per_osd: "{{ ceph.target_pgs_per_osd }}"
+    max_pgs_per_osd: "{{ ceph.max_pgs_per_osd }}"
+    pool_size: "{{ ceph.pool_default_size }}"
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
   when: inventory_hostname == (play_hosts | intersect(groups['ceph_osds_hybrid']))[0]
 

--- a/roles/ceph-osd/tasks/standard.yml
+++ b/roles/ceph-osd/tasks/standard.yml
@@ -48,6 +48,9 @@
   ceph_pool:
     pool_name: "{{ ssd_pool }}"
     osds: "{{ groups['ceph_osds_ssd']|length * ceph.disks|length }}"
+    target_pgs_per_osd: "{{ ceph.target_pgs_per_osd }}"
+    max_pgs_per_osd: "{{ ceph.max_pgs_per_osd }}"
+    pool_size: "{{ ceph.pool_default_size }}"
   delegate_to: "{{ groups['ceph_monitors'][0] }}"
   when: inventory_hostname == (play_hosts | intersect(groups['ceph_osds_ssd']))[0]
 


### PR DESCRIPTION
According to [ceph docs](http://ceph.com/pgcalc), pgs_per_osd could be
100-300. It was 100 in former releases, we increase it to 200 to get
better PG distribution. We had changed the value of pgs_per_osd in
ceph-defaults role, we make the ceph_pool module use that parameter in
this commit.