### PR TITLE
adjust upgrade flow to account cinder port change.

### DIFF
--- a/playbooks/cinder-upgrade.yml
+++ b/playbooks/cinder-upgrade.yml
@@ -15,14 +15,67 @@
       run_once: True
       tags: dbdump
       delegate_to: "{{ groups['db'][0] }}"
+    - name: disable cinder from haproxy
+      file:
+        path: /etc/cinder/healthcheck_disable
+        state: touch
+    - name: wait for haproxy to notice
+      pause:
+        seconds: 8
 
   roles:
+    - role: stop-services
+      services:
+        - cinder-api
+
     - role: cinder-control
       force_sync: true
       restart: True
       database_create:
         changed: false
   environment: "{{ env_vars|default({}) }}"
+
+- name: restart cinder-api at updated port
+  hosts: controller
+  serial: 1
+  max_fail_percentage: 1
+  tags:
+    - cinder
+    - cinder-control
+  roles:
+    - role: endpoints
+  tasks:
+    - name: restart cinder-api service
+      service:
+        name: cinder-api
+        state: restarted
+
+    - name: discover nova-placement haproxy config entry
+      command: grep -q "^frontend placement" /etc/haproxy/haproxy.cfg
+      register: nova_placement
+      failed_when: false
+
+    - name: fixup cinder backend port in haproxy
+      replace:
+        dest: /etc/haproxy/haproxy.cfg
+        regexp: "8778 check maxconn"
+        replace: "{{ endpoints.cinder.port.backend_api }} check maxconn"
+        backup: yes
+      when: not nova_placement|succeeded
+
+    - name: reload haproxy service
+      service:
+        name: haproxy
+        state: reloaded
+
+    - name: enable cinder for haproxy
+      file:
+        path: /etc/cinder/healthcheck_disable
+        state: absent
+
+    - name: wait for haproxy to notice
+      pause:
+        seconds: 8
 
 - name: upgrade cinder data software
   hosts: cinder_volume

--- a/playbooks/unit.yml
+++ b/playbooks/unit.yml
@@ -1,0 +1,37 @@
+---
+- name: upgrade cinder control
+  hosts: controller-0
+  max_fail_percentage: 1
+
+  tasks:
+    - name: restart cinder-api service
+      service:
+        name: cinder-api
+        state: restarted
+
+    - name: discover nova-placement haproxy config entry
+      command: grep -q "^frontend placement" /etc/haproxy/haproxy.cfg
+      register: nova_placement
+      failed_when: false
+
+    - name: fixup cinder backend port in haproxy
+      replace:
+        dest: /etc/haproxy/haproxy.cfg
+        regexp: "8778 check maxconn"
+        replace: "{{ endpoints.cinder.port.backend_api }} check maxconn"
+        backup: yes
+      when: not nova_placement|succeeded
+
+    - name: reload haproxy service
+      service:
+        name: haproxy
+        state: reloaded
+
+    - name: enable cinder for haproxy
+      file:
+        path: /etc/cinder/healthcheck_disable
+        state: absent
+
+    - name: wait for haproxy to notice
+      pause:
+        seconds: 8

--- a/roles/nova-control/tasks/main.yml
+++ b/roles/nova-control/tasks/main.yml
@@ -47,6 +47,15 @@
     with_items:
       - "{{ nova.services.nova_cert }}"
 
+  - name: get nova-cert service ids
+    shell: . /root/stackrc; nova service-list --binary nova-cert | grep nova-cert | awk '{print $2}'
+    register: nova_cert_srvc_ids
+    failed_when: false
+
+  - name: remove retired nova-cert from nova service
+    shell: . /root/stackrc; nova service-delete {{ item }}
+    with_items: "{{ nova_cert_srvc_ids.stdout_lines }}"
+
   - name: install nova controller services (ubuntu)
     upstart_service:
       name: "{{ item.name }}"


### PR DESCRIPTION
In Ubuntu/Newton as we enabled nova-placement we had to change cinder backend port 9776.
This PR fixes the mitaka to newton upgrade play to update existing haproxy with new cinder port after cinder is staged for upgrade.

Also, nova-cert service is retired in newton, this PR fixes removing nova-cert from nova service so that sensu does not raise false alarm for nova service being down.