### PR TITLE
compile localized dashboard messages when installing from source/package

### DIFF
--- a/roles/horizon/defaults/main.yml
+++ b/roles/horizon/defaults/main.yml
@@ -33,9 +33,11 @@ horizon:
     system_dependencies:
       ubuntu:
         - apache2
+        - gettext
         - libapache2-mod-wsgi
       rhel:
         - httpd
+        - gettext
         - mod_wsgi
         - mod_proxy_uwsgi
   logs:

--- a/roles/horizon/tasks/main.yml
+++ b/roles/horizon/tasks/main.yml
@@ -182,6 +182,14 @@
       - "{{ horizon.horizon_lib_dir }}/bin/django-admin.py collectstatic --noinput"
       - "{{ horizon.horizon_lib_dir }}/bin/django-admin.py compress --force"
 
+  - name: compile localized messages for horizon
+    environment:
+      DJANGO_SETTINGS_MODULE: 'openstack_dashboard.settings'
+      PYTHONPATH: "$PYTHONPATH"
+    shell: "{{ horizon.horizon_lib_dir }}/bin/django-admin.py compilemessages"
+    args:
+      chdir: "{{ horizon.horizon_lib_dir }}/lib/python2.7/site-packages"
+
   when: openstack_install_method != 'distro'
 
 # Use custom policy to allow cloud_admin admin panel access


### PR DESCRIPTION
Leslie asked me to take a look at this and it was a simple enough fix.