### PR TITLE
add run_once for removing nova-cert service.

### DIFF
--- a/roles/nova-control/tasks/main.yml
+++ b/roles/nova-control/tasks/main.yml
@@ -49,12 +49,15 @@
 
   - name: get nova-cert service ids
     shell: . /root/stackrc; nova service-list --binary nova-cert | grep nova-cert | awk '{print $2}'
+    run_once: true
     register: nova_cert_srvc_ids
     failed_when: false
+    changed_when: false
 
   - name: remove retired nova-cert from nova service
     shell: . /root/stackrc; nova service-delete {{ item }}
     with_items: "{{ nova_cert_srvc_ids.stdout_lines }}"
+    run_once: true
 
   - name: install nova controller services (ubuntu)
     upstart_service:


### PR DESCRIPTION
removing nova-cert from nova-service list must be only run once. 