### PR TITLE
Restrict shade version to avoid some monitoring check failure.

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -108,6 +108,7 @@ common:
         - vim
   python:
     base_venv: "{{ basevenv | default('/opt/openstack/base') }}"
+    shade_version: 'shade>=1.9.0,<1.21.0'
     ubuntu:
       system_packages:
         - python-pip

--- a/roles/common/tasks/python.yml
+++ b/roles/common/tasks/python.yml
@@ -79,7 +79,7 @@
     virtualenv: "{{ common.python.base_venv }}"
     extra_args: "{{ pip_extra_args }}"
   with_items:
-    - shade>=1.9.0
+    - "{{ common.python.shade_version }}"
   register: result
   until: result|succeeded
   retries: 5
@@ -134,16 +134,3 @@
     register: result
     until: result|succeeded
     retries: 5
-
-  #Given we are using baseven for ansible shade, do we need to install at system level?
-  - name: install shade bits for ansible modules
-    pip:
-      name: "{{ item }}"
-      extra_args: "{{ pip_extra_args }}"
-    with_items:
-      - six>=1.10.0
-      - shade>=1.9.0
-    register: result
-    until: result|succeeded
-    retries: 5
-  when: openstack_install_method != 'distro'


### PR DESCRIPTION
The latest test env installed with shade version 1.21.0, which cause some
check has error like below, and another test env with version 1.20.0 no
error.

 File
"/opt/openstack/base/local/lib/python2.7/site-packages/shade/_legacy_cli
ents.py", line 64, in neutron_client return
self._create_or_return_legacy_client('neutron', 'network')
AttributeError: 'OpenStackCloud' object has no attribute
'_create_or_return_legacy_client'