### PR TITLE
Force start of filebeat on reboot

### DIFF
--- a/roles/logging/tasks/filebeat.yml
+++ b/roles/logging/tasks/filebeat.yml
@@ -73,3 +73,4 @@
 # do with the mix of sysv/upstart service handling. --cmt
 - name: force the start of filebeat
   command: /usr/sbin/update-rc.d filebeat defaults
+  when: ursula_os == "ubuntu"

--- a/roles/logging/tasks/filebeat.yml
+++ b/roles/logging/tasks/filebeat.yml
@@ -67,3 +67,9 @@
   until: result|success
   retries: 3
   delay: 10
+
+# FIXME: despite "enabled=yes" in previous task, filebeat does not autostart
+# on reboot. Adding this until we root cause the failure above. Likely to 
+# do with the mix of sysv/upstart service handling. --cmt
+- name: force the start of filebeat
+  command: /usr/sbin/update-rc.d filebeat defaults


### PR DESCRIPTION
Despite enablement of filebeat service as "enabled=yes", it does not
start on reboot. Adding this additional measure to make sure it starts.