### PR TITLE
Remove check-logstash-forwarder-process check during upgrade

### DIFF
--- a/upgrade.yml
+++ b/upgrade.yml
@@ -56,6 +56,11 @@
   post_tasks:
     - name: uninstall logstash-forwarder
       package: name=logstash-forwarder state=absent
+    - name: remove logstash-forwarder process check
+      sensu_check: 
+        name: "check-logstash-forwarder-process"
+        plugin: check-procs.rb
+        state: absent
 
 - name: upgrade common bits first
   hosts: all:!vyatta-*


### PR DESCRIPTION
This is to fix the issue check-logstash-forwarder-process check still not removed.
This check's name is different from other traditional process check name.
