### PR TITLE
move up rabbitmq version to 3.6.10*.

### DIFF
--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -81,11 +81,18 @@
   until: result|succeeded
   retries: 5
 
-- name: fix ssl certs for requests for keystone-client on trusty
-  file: src=/etc/ssl/certs/ca-certificates.crt
-        dest=/usr/local/lib/python2.7/dist-packages/requests/cacert.pem
-        owner=root
-        mode=0644 state=link force=yes
+- block:
+  - name: fix ssl certs for requests for keystone-client on trusty
+    file: src=/etc/ssl/certs/ca-certificates.crt
+          dest=/usr/local/lib/python2.7/dist-packages/requests/cacert.pem
+          owner=root
+          mode=0644 state=link force=yes
+
+  - name: fix ssl certs for certifi for keystone-client on trusty
+    file: src=/etc/ssl/certs/ca-certificates.crt
+          dest=/usr/local/lib/python2.7/dist-packages/certifi/cacert.pem
+          owner=root
+          mode=0644 state=link force=yes
   when: ansible_distribution_version == "14.04"
 
 - name: migrate neutron services script

--- a/roles/common/tasks/ssl.yml
+++ b/roles/common/tasks/ssl.yml
@@ -40,8 +40,13 @@
 # ugly hack: some python http libs don't honor the system ca-certs, and ship with
 # their own list, instead.
 # pre-install these client libs, and force them to use the system cert list.
-- name: force our ssl cert for python libs
+- name: force our ssl cert for python libs (requests)
   file: src={{ ssl.cafile }} dest="{{ basevenv_lib_dir }}/requests/cacert.pem"
+        owner=root mode=0644
+        state=link force=yes
+
+- name: force our ssl cert for python libs (certifi)
+  file: src={{ ssl.cafile }} dest="{{ basevenv_lib_dir }}/certifi/cacert.pem"
         owner=root mode=0644
         state=link force=yes
 

--- a/roles/rabbitmq/defaults/main.yml
+++ b/roles/rabbitmq/defaults/main.yml
@@ -12,7 +12,7 @@ rabbitmq:
   numqueues_critical_multiplier: 120
   nofile: 10240
   version:
-    rabbitmq_server: '3.6.9*'
+    rabbitmq_server: '3.6.10*'
     esl_erlang: '1:19*'
   monitoring:
     sensu_checks:


### PR DESCRIPTION
upstream rabbitmq.com repo release 3.6.10-1 on 5.25, This is only version in their repo which now forces us to move to this version.

Also, there is new request package releases which installs certifi that provides Where() for ca bundle to be used for self-signed certs. This new request package calls cetifi where(). Previous requests version were looking up in requests filepath for cacert.pem part of exception handling of import error for certifi. This PR is handling this new requests version of handling lookup of ca bundle by also adding symlink to certifi.