### PR TITLE
disable old cinder scheduler service

### DIFF
--- a/roles/openstack-setup/tasks/cinder.yml
+++ b/roles/openstack-setup/tasks/cinder.yml
@@ -19,6 +19,12 @@
     - (item.name in ['cinder','cinderv2','cinderv3'])
   run_once: true
 
+# FIXME: this task should be removed once old service is disabled for all envs
+- name: delete old cinder scheduler service
+  shell: mysql -ucinder -p{{ secrets.db_password }} -e "delete from cinder.services where host = 'ceph' and topic = 'cinder-scheduler';"
+  no_log: true
+  run_once: true
+
 - name: create cinder volume types(ceph backend)
   environment:
     PYTHONPATH: "{{ basevenv_lib_dir|default(omit) }}"


### PR DESCRIPTION
'ceph' was the cinder scheduler service host name. As we add v7k in this
release. So we use new host name for cinder scheduler service. After
upgrade, we can see new scheduler services are up, old service is down.
sensu alert error because of service down. 
This commit is to disable old scheduler service.