### PR TITLE
disable barbican for ci envs.

### DIFF
--- a/envs/example/ci-ceph-swift-ubuntu/group_vars/all.yml
+++ b/envs/example/ci-ceph-swift-ubuntu/group_vars/all.yml
@@ -19,7 +19,7 @@ keystone:
     method: socket
 
 barbican:
-  enabled: True
+  enabled: False
 
 neutron:
   enable_external_interface: True

--- a/envs/example/ci-full-ubuntu/group_vars/all.yml
+++ b/envs/example/ci-full-ubuntu/group_vars/all.yml
@@ -52,7 +52,7 @@ keystone:
     method: socket
 
 barbican:
-  enabled: True
+  enabled: False
 
 nova:
   libvirt_type: kvm


### PR DESCRIPTION
Given Barbican is still a tech preview this PR is disabling it from the CI envs.