### PR TITLE
adding delay flag to check-neutron-l3-routers

### DIFF
--- a/roles/neutron-control/templates/check-neutron-l3-routers.sh
+++ b/roles/neutron-control/templates/check-neutron-l3-routers.sh
@@ -4,5 +4,6 @@
 # only run on node with the floating ip
 
 if ifconfig | grep {{ undercloud_floating_ip | default(floating_ip) }} > /dev/null 2>&1; then
-  /etc/sensu/plugins/check-neutron-l3-routers.py -r {{ sensu_checks.neutron.check_neutron_l3_routers.max_routers }}
+  /etc/sensu/plugins/check-neutron-l3-routers.py -r {{ sensu_checks.neutron.check_neutron_l3_routers.max_routers }} \
+  -d {{ sensu_checks.neutron.check_neutron_l3_routers.delay_seconds }}
 fi;

--- a/roles/sensu-check/defaults/main.yml
+++ b/roles/sensu-check/defaults/main.yml
@@ -86,6 +86,7 @@ sensu_checks:
       occurrences: 1
       interval: 600
       max_routers: 100
+      delay_seconds: 120
       standalone: true
       command: check-neutron-l3-routers.sh
       service_owner: openstack


### PR DESCRIPTION
Adding "delay_seconds" option to check-neutron-l3-router's template in order to accommodate for 30 second router creation time.