### PR TITLE
Optionally replace ntpd with chronyd

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -19,6 +19,7 @@ common:
        - 2.north-america.pool.ntp.org
        - 3.north-america.pool.ntp.org
     #  - servertime.service.softlayer.com
+    allow_subnets: [] # ['10/8', '172.16/12']
   serial_console:
     enabled: True
     name: ttyS0

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -10,7 +10,9 @@ common:
     serial_console: ttyS1
     state: probe
     baud_rate: 115200
-  ntpd:
+  ntp:
+  # client: ntpd
+    client: chrony
     servers:
        - 0.north-america.pool.ntp.org
        - 1.north-america.pool.ntp.org
@@ -64,7 +66,6 @@ common:
         - lvm2
         - mtr
         - netcat
-        - ntp
         - pciutils
         - pv
         - resolvconf
@@ -96,7 +97,6 @@ common:
         - mlocate
         - mtr
         - net-tools
-        - ntp
         - nc
         - traceroute
         - tcpdump

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -24,6 +24,9 @@
 - name: restart-ntp
   service: name="{{ ntpd_service_name }}" state=restarted
 
+- name: restart-chrony
+  service: name="{{ chrony_service_name }}" state=restarted
+
 - name: load sensors
   shell: /usr/sbin/sensors-detect < /dev/null
 

--- a/roles/common/tasks/chrony.yml
+++ b/roles/common/tasks/chrony.yml
@@ -1,0 +1,37 @@
+---
+- set_fact:
+    chrony_service_name: chrony
+  when: ursula_os == 'ubuntu'
+- set_fact:
+    chrony_service_name: chronyd
+  when: ursula_os == 'rhel'
+
+- name: install chrony (ubuntu)
+  apt:
+    pkg: chrony
+  when: ursula_os == 'ubuntu'
+
+- name: install chrony.conf
+  template:
+    dest: "{{ '/etc' if ursula_os == 'rhel' else '/etc/chrony' }}/chrony.conf"
+    src: etc/chrony.conf
+    mode: 0644
+    owner: root
+  notify:
+    - restart-chrony
+
+# chrony conflicts with the ntp package on ubuntu and is auto-removed
+- name: disable ntpd
+  service:
+    name: ntpd
+    state: stopped
+    enabled: false
+    must_exist: false
+  failed_when: false
+  when: ursula_os == 'rhel'
+
+- name: enable chrony
+  service:
+    name: "{{ chrony_service_name }}"
+    state: started
+    enabled: true

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -113,8 +113,13 @@
   when: ursula_os == 'rhel'
   tags: firewall
 
-- include: ntp.yml
+- include: ntpd.yml
   tags: ntp
+  when: common.ntp.client == 'ntpd'
+
+- include: chrony.yml
+  tags: ntp
+  when: common.ntp.client == 'chrony'
 
 # Include serial console before kernel-tuning to build serial_console_cmdline
 - include: serial-console.yml tty={{ common.serial_console.name }}

--- a/roles/common/tasks/monitoring.yml
+++ b/roles/common/tasks/monitoring.yml
@@ -193,11 +193,19 @@
   notify: restart sensu-client
 
 - name: ntpd check
-  sensu_process_check: service=ntpd
+  sensu_process_check: service=ntpd state="{{ 'present' if common.ntp.client == 'ntpd' else 'absent' }}"
   notify: restart sensu-client
 
 - name: ntp-offset check
-  sensu_check: name=ntp-offset plugin=check-ntp.rb
+  sensu_check: name=ntp-offset plugin=check-ntp.rb state="{{ 'present' if common.ntp.client == 'ntpd' else 'absent' }}"
+  notify: restart sensu-client
+
+- name: chrony check
+  sensu_process_check: service=chronyd state="{{ 'present' if common.ntp.client == 'chrony' else 'absent' }}"
+  notify: restart sensu-client
+
+- name: chrony-offset check
+  sensu_check: name=chrony-offset plugin=check-chrony.rb state="{{ 'present' if common.ntp.client == 'chrony' else 'absent' }}" use_sudo=true
   notify: restart sensu-client
 
 - name: vmstat metrics check

--- a/roles/common/tasks/ntpd.yml
+++ b/roles/common/tasks/ntpd.yml
@@ -6,6 +6,16 @@
     ntpd_service_name: ntpd
   when: ursula_os == 'rhel'
 
+- name: install ntp package (rhel)
+  yum:
+    pkg: ntp
+  when: ursula_os == 'rhel'
+
+- name: install ntp package (ubuntu)
+  apt:
+    pkg: ntp
+  when: ursula_os == 'ubuntu'
+
 - name: install ntp.conf
   template:
     dest: /etc/ntp.conf

--- a/roles/common/templates/etc/chrony.conf
+++ b/roles/common/templates/etc/chrony.conf
@@ -11,18 +11,19 @@ driftfile /var/lib/chrony/{{ 'chrony.' if ursula_os == 'rhel' else '' }}drift
 bindcmdaddress 127.0.0.1
 bindcmdaddress ::1
 
-# Add 'allow' directives to run chronyd as an
-# NTP server as well as a client, e.g.
+# Add 'allow' directives to run chronyd as an NTP server as well as a client, e.g.
 # allow 10/8
+{% for subnet in common.ntp.client_subnets -%}
+allow {{ subnet }}
+{% endfor %}
 
 # enable logging
 log tracking measurements statistics
 logdir /var/log/chrony
 
-# Normally, chronyd slows or speeds the clock slightly to
-# adjust time. setting `makestep s n' will allow jumping the
-# clock forward if it is off by more than `s' seconds, for
-# the first `n' adjustments.
+# Normally, chronyd slows or speeds the clock slightly to adjust time.
+# setting `makestep s n' will allow jumping the clock forward if it is
+# off by more than `s' seconds, for the first `n' adjustments.
 makestep 10 3
 
 # Error bounds for estimated NTP time

--- a/roles/common/templates/etc/chrony.conf
+++ b/roles/common/templates/etc/chrony.conf
@@ -1,0 +1,38 @@
+{% for server in common.ntp.servers -%}
+server {{ server }} iburst
+{% endfor %}
+
+commandkey 1
+keyfile {{ '/etc' if ursula_os == 'rhel' else '/etc/chrony' }}/chrony.keys
+
+driftfile /var/lib/chrony/{{ 'chrony.' if ursula_os == 'rhel' else '' }}drift
+
+# only allow commands from localhost
+bindcmdaddress 127.0.0.1
+bindcmdaddress ::1
+
+# Add 'allow' directives to run chronyd as an
+# NTP server as well as a client, e.g.
+# allow 10/8
+
+# enable logging
+log tracking measurements statistics
+logdir /var/log/chrony
+
+# Normally, chronyd slows or speeds the clock slightly to
+# adjust time. setting `makestep s n' will allow jumping the
+# clock forward if it is off by more than `s' seconds, for
+# the first `n' adjustments.
+makestep 10 3
+
+# Error bounds for estimated NTP time
+maxupdateskew 100.0
+
+# Log to syslog if clock changes more than 0.5 seconds
+logchange 0.5
+
+# sync NTP clock to CMOS clock
+rtcsync
+
+# CMOS clock is UTC
+rtconutc

--- a/roles/common/templates/etc/chrony.conf
+++ b/roles/common/templates/etc/chrony.conf
@@ -13,7 +13,7 @@ bindcmdaddress ::1
 
 # Add 'allow' directives to run chronyd as an NTP server as well as a client, e.g.
 # allow 10/8
-{% for subnet in common.ntp.client_subnets -%}
+{% for subnet in common.ntp.allow_subnets -%}
 allow {{ subnet }}
 {% endfor %}
 

--- a/roles/common/templates/etc/ntp.conf
+++ b/roles/common/templates/etc/ntp.conf
@@ -12,7 +12,7 @@ filegen peerstats file peerstats type day enable
 filegen clockstats file clockstats type day enable
 
 # Specify one or more NTP servers.
-{% for server in common.ntpd.servers %}
+{% for server in common.ntp.servers %}
 server {{ server }} iburst maxpoll 10
 {% endfor %}
 

--- a/roles/common/templates/monitoring/sensu-sudoers
+++ b/roles/common/templates/monitoring/sensu-sudoers
@@ -37,3 +37,4 @@ sensu ALL= NOPASSWD: /etc/sensu/plugins/metrics-nova-oversub.sh
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check-v7k-canister.py
 sensu ALL= NOPASSWD: /etc/sensu/plugins/check-v7k-drive.py
 sensu ALL= NOPASSWD: /etc/sensu/plugins/metrics-v7k.py
+sensu ALL= NOPASSWD: /etc/sensu/plugins/check-chrony.rb


### PR DESCRIPTION
- [x] Figure out `chronyc` auth/firewalling for ubuntu, since version 1 must use password auth over UDP
- [x] process checks
- [x] make `allow` directives configurable