### PR TITLE
to workaround mysql bug #84940

### DIFF
--- a/roles/percona-server/templates/etc/my.cnf
+++ b/roles/percona-server/templates/etc/my.cnf
@@ -7,7 +7,10 @@ log-warnings = 10
 datadir = /var/lib/mysql
 user = mysql
 bind-address = 0.0.0.0
-
+#workaround mysql bug #84940
+innodb-stats-persistent = 0
+innodb-stats-transient-sample-pages = 20
+innodb-stats-auto-recalc = 0
 
 
 !includedir /etc/mysql/conf.d


### PR DESCRIPTION
MySQL Server crash possibly introduced in InnoDB statistics calculation
for 5.6.35 . https://bugs.mysql.com/bug.php?id=84940

Before we got new persona xtradb cluster version, we need this fix as
workaround to avoid the crash possibility.