### PR TITLE
add six to requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 tox
 pep8
+six
 oslo.utils
 shade>=1.7.0
 ansible>=2.1.0.0,<3,<=2.1.3


### PR DESCRIPTION
setuptool 36.0 is breaking venv creation as it requires six module be already installed. This is a upstream regression caused in setuptools 36.0 - https://github.com/pypa/setuptools/issues/1042