### PR TITLE
Revert "add six to requirements.txt."

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 tox
 pep8
-six
 oslo.utils
 shade>=1.7.0
 ansible>=2.1.0.0,<3,<=2.1.3


### PR DESCRIPTION
Reverts blueboxgroup/ursula#2888

will wait for upstream fix in setuptools - https://github.com/blueboxgroup/ursula-cli/pull/71

For time following workaround can be used when preparing venv
pip install --upgrade "setuptools < 36"