### PR TITLE
workaround for setuptool regression to unbreak ci.

### DIFF
--- a/test/setup
+++ b/test/setup
@@ -8,6 +8,7 @@ if [[ "$CI" == "jenkins" ]]; then
     virtualenv $VENV
     source $VENV/bin/activate
     pip install -U pip
+    pip install --upgrade "setuptools < 36"
     pip install -U -r requirements.txt
 fi
 


### PR DESCRIPTION
Recent setuptool 36.0 caused a regression that is breaking CI runs by error'ing out at venv creation.
While we wait for ustream bug fix https://github.com/pypa/setuptools/issues/1042 this pr is downgrading setuptools to < 36.