### PR TITLE
not restrict minor version number of CEPH client

### DIFF
--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -38,7 +38,7 @@ ceph:
     ubuntu: 10.2.3~bbc1
     rhel: 10.2.3
   client_version:
-    ubuntu: 10.2.7-0ubuntu0.16.04.1~cloud0
+    ubuntu: 10.2.*-0ubuntu0.16.04.1~cloud0
     rhel: 10.2.3
 
   openstack_keys:


### PR DESCRIPTION
Old minor version of CEPH is removed from repo when new version comes.
Our ursula will fail if we point to the old version of CEPH.
This commit is to replace minor version number with * to "avoid package
not found error".