### PR TITLE
Revert "workaround for setuptool regression to unbreak ci."

### DIFF
--- a/test/setup
+++ b/test/setup
@@ -8,7 +8,6 @@ if [[ "$CI" == "jenkins" ]]; then
     virtualenv $VENV
     source $VENV/bin/activate
     pip install -U pip
-    pip install --upgrade "setuptools < 36"
     pip install -U -r requirements.txt
 fi
 


### PR DESCRIPTION
Reverts blueboxgroup/ursula#2890

setuptools 36.0.1 is out that fixes the regression caused in earlier release.