### PR TITLE
reinstall and reenable ntp service after OAS run

### DIFF
--- a/playbooks/run-openstack-ansible-security.yml
+++ b/playbooks/run-openstack-ansible-security.yml
@@ -2,5 +2,15 @@
 - name: os-hardening for all hosts
   hosts: all:!vyatta-*
   any_errors_fatal: true
+
   roles:
     - role: ../../openstack-ansible-security
+
+  tasks:
+    - name: install ntp on ubuntu
+      package:
+        name: ntp
+        state: latest
+      register: result
+      until: result|succeeded
+      retries: 5


### PR DESCRIPTION
Openstack-ansible-security role uninstalls the ntp service from the system and installs chrony. This reinstalls ntp service (which automatically removes chrony).