### PR TITLE
Workaround for DiskFilter

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -97,6 +97,7 @@ nova:
         - "librbd1-{{ ceph.client_version[ursula_os] }}"
         - openstack-selinux
         - openstack-nova-compute
+    python_post_dependencies: []
   source:
     rev: 'stable/newton'
     upper_constraints: '{{ openstack_meta.upper_constraints }}'
@@ -107,6 +108,7 @@ nova:
       - { name: uwsgi }
       #TODO: Remove barbican client in Ocata because it will get installed by Castellan
       - { name: python-barbicanclient }
+      - { name: "git+https://github.com/blueboxgroup/bbc-openstack-plugins.git#egg=bbc_openstack_plugins" }
     system_dependencies:
       ubuntu:
         - libjs-jquery-tablesorter
@@ -194,3 +196,6 @@ nova:
   auditing:
     enabled: False
     logging: False
+  custom_disk_filter:
+    enabled: False
+    reserved_ratio: 0.06

--- a/roles/nova-common/meta/main.yml
+++ b/roles/nova-common/meta/main.yml
@@ -33,6 +33,7 @@ dependencies:
   - role: openstack-distro
     project_name: nova
     project_packages: "{{ nova.distro.controller.project_packages }}"
+    python_post_dependencies: "{{ nova.distro.python_post_dependencies }}"
     rootwrap: True
     when:
       - openstack_install_method == 'distro'

--- a/roles/nova-common/templates/etc/nova/nova.conf
+++ b/roles/nova-common/templates/etc/nova/nova.conf
@@ -26,7 +26,12 @@ debug = {{ nova.logging.debug }}
 use_stderr = false
 
 # Scheduler #
-scheduler_default_filters = {{ nova.scheduler_default_filters }}
+{% if nova.custom_disk_filter.enabled|bool -%}
+scheduler_available_filters = nova.scheduler.filters.all_filters
+scheduler_available_filters = bbc_openstack_plugins.nova.scheduler.filters.bbc_disk_filter.BBCDiskFilter
+reserved_host_disk_ratio = {{ nova.custom_disk_filter.reserved_ratio }}
+{% endif -%}
+scheduler_default_filters = {{ nova.scheduler_default_filters }}{{ ',BBCDiskFilter' if nova.custom_disk_filter.enabled|bool else '' }}
 scheduler_host_subset_size = {{ nova.scheduler_host_subset_size }}
 
 {% if nova.default_availability_zone is defined -%}


### PR DESCRIPTION
Before community provide https://bugs.launchpad.net/nova/+bug/1593155
related fix, we need this workaround to enable disk filter.