### PR TITLE
delegate pool_names_completed variable to all ceph nodes

### DIFF
--- a/roles/ceph-osd/tasks/pool_names.yml
+++ b/roles/ceph-osd/tasks/pool_names.yml
@@ -189,3 +189,8 @@
 - name: set pool_names_completed to indicate pool_names.yml has been run
   set_fact:
     pool_names_completed: true
+  delegate_to: "{{ item }}"
+  delegate_facts: yes
+  with_items:
+    - "{{ groups['ceph_osds'] }}"
+    - "{{ groups['ceph_monitors'] }}"


### PR DESCRIPTION
As we check if pool_names_completed is defined on osd nodes, so we
should delegate the variable to all osd nodes. I also delegate the
variable to ceph monitor nodes for potential case.