### PR TITLE
install libvirt-bin dependency of libnl-3-200=3.2.21-1ubuntu4

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -59,6 +59,7 @@ nova:
   vnc_keymap: en-us
   scheduler_default_filters: RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,CoreFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,AggregateInstanceExtraSpecsFilter,NUMATopologyFilter
   scheduler_host_subset_size: 1
+  libnl_3_200_version: 3.2.21-1ubuntu4
   libvirt_bin_version: 1.3.1-1ubuntu10.9~cloud0
   python_libvirt_version: 1.3.1-1ubuntu1~cloud0
   qemu_kvm_version: 1:2.5+dfsg-5ubuntu10.13~cloud0

--- a/roles/nova-data/tasks/libvirt.yml
+++ b/roles/nova-data/tasks/libvirt.yml
@@ -8,6 +8,7 @@
 - name: install nova-compute packages (ubuntu)
   package: name={{ item }}
   with_items:
+    - libnl-3-200={{ nova.libnl_3_200_version}}
     - librbd1={{ nova.librbd1_version }}
     - cpu-checker
     - libvirt-bin={{ nova.libvirt_bin_version }}


### PR DESCRIPTION
As of 5/7/2017 nova-compute is failing when install libvirt-bin with following error:
libvirt-bin : Depends: libnetcf1 (>= 1:0.2.2) but it is not going to be installed

Root cause:
libnetcf1 : Depends: libnl-route-3-200 (>= 3.2.7)
libnl-route-3-200 : Depends: libnl-3-200 (= 3.2.21-1ubuntu4) but 3.2.21-1ubuntu4.1 is to be installed

fix:
To install libnl-3-200=3.2.21-1ubuntu4