### PR TITLE
remove ntp dependency from ceph

### DIFF
--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -64,7 +64,6 @@ ceph:
   # Packages
   depend_pkgs:
     - python-pycurl
-    - ntp
     - hdparm
   osd_dep_pkgs:
     - parted


### PR DESCRIPTION
Either ntp or chrony can be used to sync time. We shouldn't install ntp
for ceph if chrony is configured.