### PR TITLE
bump swifttool version.

### DIFF
--- a/envs/example/ci-ceph_swift/group_vars/all.yml
+++ b/envs/example/ci-ceph_swift/group_vars/all.yml
@@ -38,7 +38,6 @@ serverspec:
 
 swift:
   enabled: True
-  allow_versions: True
   disks:
     - disk: vdb
 

--- a/envs/example/defaults-2.0.yml
+++ b/envs/example/defaults-2.0.yml
@@ -51,6 +51,10 @@ memcached:
 
 swift:
   enabled: False
+  allow_versions: True
+  swifttool_method: pip
+  swifttool_version: 0.0.2.dev29
+  swifttool_pypi_mirror: https://pypi-mirror.openstack.blueboxgrid.com/bluebox/openstack
   logging:
     debug: False
 


### PR DESCRIPTION
New paramiko 2.2 package is breaking swifttool. This PR points to new swifttool pkg that pins paramiko<2.2