### PR TITLE
Updated inspec horizon group to be based on OS

### DIFF
--- a/roles/inspec/defaults/main.yml
+++ b/roles/inspec/defaults/main.yml
@@ -154,7 +154,7 @@ inspec:
       enabled: true
       profile: openstack_security
       attributes:
-        horizon_config_group: apache
+        horizon_config_group: "{{ (ursula_os == 'rhel' )| ternary('apache', 'www-data') }}"
       required_controls:
         - check-dashboard-01
         - check-dashboard-02


### PR DESCRIPTION
Changed the default file in inspec role for horizon group to be
assigned based on OS.