### PR TITLE
upgrade mongodb version from 3.0.6 to 3.0.15

### DIFF
--- a/roles/mongodb-common/defaults/main.yml
+++ b/roles/mongodb-common/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 mongodb:
-  version: 3.0.6
+  version: 3.0.15
   replica_name: mongoreplica
   db_password: "{{ secrets.mongodb_password }}"
   bind_ip: 0.0.0.0


### PR DESCRIPTION
for security fix of https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-6494