### PR TITLE
Replace out-dated aodh conf

### DIFF
--- a/roles/aodh/templates/etc/aodh/aodh.conf
+++ b/roles/aodh/templates/etc/aodh/aodh.conf
@@ -47,10 +47,13 @@ cafile = {{ aodh.cafile }}
 identity_uri = {{ endpoints.keystone.url.admin }}
 
 [service_credentials]
-os_auth_url = {{ endpoints.keystone.url.admin }}/{{ endpoints.keystone.version }}
+auth_type = password
+auth_url = {{ endpoints.keystone.url.admin }}
+username = aodh
+project_name = service
+password = {{ secrets.service_password }}
+project_domain_name = Default
+user_domain_name = Default
 cafile = {{ aodh.cafile }}
-os_username = aodh
-os_tenant_name = service
-os_password = {{ secrets.service_password }}
 region_name = RegionOne
 interface = internal


### PR DESCRIPTION
To avoid error like “MissingAuthPlugin: An auth plugin is required to
determine endpoint URL”