### PR TITLE
Add ceilometer user to libvirt socket group

### DIFF
--- a/roles/ceilometer-common/defaults/main.yml
+++ b/roles/ceilometer-common/defaults/main.yml
@@ -70,3 +70,6 @@ ceilometer:
   auditing:
     enabled: False
     logging: False
+  libvirt_group:
+    ubuntu: libvirtd
+    rhel: libvirt

--- a/roles/ceilometer-data/tasks/main.yml
+++ b/roles/ceilometer-data/tasks/main.yml
@@ -33,6 +33,13 @@
   notify: restart ceilometer data services
   when: openstack_install_method == 'source'
 
+- name: add ceilometer user to libvirt group
+  user:
+    name: ceilometer
+    groups: "{{ ceilometer.libvirt_group[ursula_os] }}"
+    append: yes
+  notify: restart ceilometer data services
+
 - name: trigger restart on upgrades
   debug:
     msg: "Triggering service restart for upgrade"


### PR DESCRIPTION
This adds the ceilometer user to the group
that has access to the libvirt socket. This will allow
ceilometer to gain access and prevent an error that shows:
'AttributeError: can't set attribute'