### PR TITLE
increase nofile for cinder-volume/backup services

### DIFF
--- a/library/systemd_service.py
+++ b/library/systemd_service.py
@@ -49,6 +49,9 @@ Type={{ type }}
 {% if notify_access -%}
 NotifyAccess={{ notify_access }}
 {% endif %}
+{% if limit_nofile -%}
+LimitNOFILE={{ limit_nofile }}
+{% endif %}
 {% if user -%}
 User={{ user }}
 {% endif %}
@@ -112,6 +115,7 @@ def main():
             kill_mode=dict(default=None, choices=['control-group', 'process',
                                                   'mixed', 'none']),
             pidfile=dict(default=None),
+            limit_nofile=dict(default=None),
             path=dict(default=None)
         )
     )

--- a/library/upstart_service.py
+++ b/library/upstart_service.py
@@ -47,6 +47,10 @@ end script
 respawn
 {% endif -%}
 
+{% if limit_nofile -%}
+limit nofile {{ limit_nofile }}
+{% endif -%}
+
 exec start-stop-daemon --start --chuid {{ user }} {{ pidfile }} --exec {{ cmd }} {{ args }}
 """
 
@@ -68,6 +72,7 @@ def main():
             prestart_script=dict(default=None),
             respawn=dict(default=True),
             path=dict(default=None),
+            limit_nofile=dict(default=None),
             pidfile=dict(default=None)
         )
     )

--- a/roles/cinder-data/tasks/main.yml
+++ b/roles/cinder-data/tasks/main.yml
@@ -25,8 +25,10 @@
       user: "{{ item.user }}"
       cmd: "{{ item.cmd }}"
       config_dirs: "{{ item.config_dirs }}"
+      limit_nofile: "16384 16384"
     with_items:
       - "{{ cinder.services.cinder_volume }}"
+    notify: restart cinder backup service
 
   - name: install cinder backup service (ubuntu)
     upstart_service:
@@ -34,7 +36,9 @@
       user: "{{ item.user }}"
       cmd: "{{ item.cmd }}"
       config_dirs: "{{ item.config_dirs }}"
+      limit_nofile: "16384 16384"
     when: swift.enabled|default("false")|bool
+    notify: restart cinder backup service
     with_items:
       - "{{ cinder.services.cinder_backup }}"
   when: ursula_os == 'ubuntu'
@@ -52,8 +56,10 @@
       config_files: "{{ item.config_files }}"
       restart: "{{ item.restart }}"
       kill_mode: "{{ item.kill_mode }}"
+      limit_nofile: "16384"
     with_items:
       - "{{ cinder.services.cinder_volume }}"
+    notify: restart cinder services
 
   - name: install cinder backup service (rhel)
     systemd_service:
@@ -64,9 +70,11 @@
       cmd: "{{ item.cmd }}"
       config_files: "{{ item.config_files }}"
       restart: "{{ item.restart }}"
+      limit_nofile: "16384"
     when: swift.enabled|default("false")|bool
     with_items:
       - "{{ cinder.services.cinder_backup }}"
+    notify: restart cinder backup service
   when: ursula_os == 'rhel'
 
 - name: trigger restart on upgrades


### PR DESCRIPTION
the default nofile limit is 1024, it's not enough for large ceph
cluster. deleting one volume needs osd_num opening files, so if we have
300 osds, we can't deleting 4 volumes at the same time(300*4 > 1024).
We increase the nofile to 16384 in this commit