### PR TITLE
Allow for custom m12 configuration

### DIFF
--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -170,3 +170,4 @@ neutron:
   auditing:
     enabled: False
     logging: False
+  m12_customization: False

--- a/roles/neutron-common/templates/etc/neutron/plugins/ml2/ml2_plugin.ini
+++ b/roles/neutron-common/templates/etc/neutron/plugins/ml2/ml2_plugin.ini
@@ -1,5 +1,8 @@
 # {{ ansible_managed }}
 
+{% if neutron.m12_customization %}
+{{ neutron.m12_config }}
+{% else %}
 [ml2]
 {% set type_drivers = ['local'] %}
 {% if neutron.network_vlan_ranges is defined %}
@@ -68,3 +71,4 @@ root_helper = sudo /usr/local/bin/neutron-rootwrap /etc/neutron/rootwrap.conf
 [securitygroup]
 enable_security_group = True
 firewall_driver = neutron.agent.linux.iptables_firewall.IptablesFirewallDriver
+{% endif %}


### PR DESCRIPTION
The current jinja2 template for m12_plugin.ini doesn't allow for extra configurations to be added or for configurations to be moved. For example, if someone wants to not use the vlan tunnel type and configuraton, they don't have the ability to turn it off. This would allow users to overide the m12_plugin jinja2 directly in the ansible inventory for more specialized deployments.