### PR TITLE
disable ceph-utils

### DIFF
--- a/roles/ceph-monitor/tasks/main.yml
+++ b/roles/ceph-monitor/tasks/main.yml
@@ -131,10 +131,13 @@
     until: result|succeeded
     retries: 5
 
-  - name: add cron to adjust ceph pg number
-    cron: name='ceph-utils' minute='*/{{ ceph.adjust_inveral }}'
-          job='{{ basevenv+"/bin/" if basevenv else "" }}ceph-utils adjust-all'
-          cron_file='ceph_utils' user=root
+# disable ceph-utils cron job, as this is not good for old env which
+# upgraded from 3.0 or less
+#  - name: add cron to adjust ceph pg number
+#    cron: name='ceph-utils' minute='*/{{ ceph.adjust_inveral }}'
+#          job='{{ basevenv+"/bin/" if basevenv else "" }}ceph-utils adjust-all'
+#          cron_file='ceph_utils' user=root
+
   when: ceph.bbg_ceph_utils_pkg
 
 - include: monitoring.yml


### PR DESCRIPTION
ceph-utils was designed to adjust ceph for large cluster as whitewater.
We disable it as it doesn't work well with old env which upgraded from
3.0 or less

1. how to know if an env is old env which upgraded from 3.0 or less?
run following command on a mon node, if the word `default` is in the output, then it's an old env.
```
ceph osd lspools
```
2. how to disable ceph-utils for existing problem envs?
login to the master mon node and follow below steps:
1.1 edit /etc/cron.d/ceph_utils to comment all lines
1.2 find the osds which have `reweight` value less than 1.
```
ceph osd df
ID WEIGHT  REWEIGHT SIZE   USE    AVAIL  %USE VAR  PGS 
 1 0.85999  1.00000   883G  1940M   881G 0.21 1.05 178 
 2 0.85999  1.00000   883G  1744M   881G 0.19 0.94 152 
 3 0.85999  1.00000   883G  1904M   881G 0.21 1.03 172 
 4 0.85999  1.00000   883G  1808M   881G 0.20 0.98 171 
 5 0.85999  1.00000   883G  1852M   881G 0.20 1.00 173 
 0 0.85999  1.00000   883G  1904M   881G 0.21 1.03 180 
 6 0.85999  1.00000   883G  1797M   881G 0.20 0.97 169 
 7 0.85999  1.00000   883G  1629M   881G 0.18 0.88 154 
 8 0.85999  1.00000   883G  2031M   881G 0.22 1.10 178 
 9 0.85999  1.00000   883G  1761M   881G 0.19 0.95 165 
10 0.85999  0.95001   883G  1884M   881G 0.21 1.02 172 
11 0.85999  1.00000   883G  1957M   881G 0.22 1.06 179 
12 0.85999  1.00000   883G  1796M   881G 0.20 0.97 169 
13 0.85999  0.95001   883G  1921M   881G 0.21 1.04 180 
14 0.85999  0.95001   883G  1918M   881G 0.21 1.04 177 
15 0.85999  1.00000   883G  1712M   881G 0.19 0.92 153 
16 0.85999  1.00000   883G  1934M   881G 0.21 1.04 171 
17 0.85999  1.00000   883G  1840M   881G 0.20 0.99 166 
```
3. set `reweight` value to 1 for the osds found in step#2
for example, the osds are 10, 13, 14
```
ceph osd reweight 10 1
ceph osd reweight 13 1
ceph osd reweight 14 1
```
