### PR TITLE
updated ubuntu package versions for libvirt and qemu and rabbitmq-server

### DIFF
--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -59,9 +59,9 @@ nova:
   vnc_keymap: en-us
   scheduler_default_filters: RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,CoreFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,AggregateInstanceExtraSpecsFilter,NUMATopologyFilter
   scheduler_host_subset_size: 1
-  libvirt_bin_version: 1.3.1-1ubuntu10.9~cloud0
+  libvirt_bin_version: 1.3.1-1ubuntu10.12~cloud0
   python_libvirt_version: 1.3.1-1ubuntu1~cloud0
-  qemu_kvm_version: 1:2.5+dfsg-5ubuntu10.13~cloud0
+  qemu_kvm_version: 1:2.5+dfsg-5ubuntu10.14~cloud0
   # librbd1 version should match the ceph client version
   librbd1_version: "{{ ceph.client_version[ursula_os] }}"
   qemu_system_package: qemu-system-x86

--- a/roles/rabbitmq/defaults/main.yml
+++ b/roles/rabbitmq/defaults/main.yml
@@ -12,7 +12,7 @@ rabbitmq:
   numqueues_critical_multiplier: 120
   nofile: 10240
   version:
-    rabbitmq_server: '3.6.10*'
+    rabbitmq_server: '3.6.11*'
     esl_erlang: '1:19*'
   monitoring:
     sensu_checks:


### PR DESCRIPTION
testing a ci fix which involves updating package versions.  I updated the vars directly in `roles/nova-common/defaults/main.yml`, but can be updated in `envs/example/ci-full-ubuntu/group_vars/all.yml` instead if needed.