### PR TITLE
added libcurl3-gnutls to security-patches.yml

### DIFF
--- a/playbooks/security-patches.yml
+++ b/playbooks/security-patches.yml
@@ -12,6 +12,7 @@
       - openssl
       - curl
       - libcurl3
+      - libcurl3-gnutls
       - openssh-server
       - apache2
     register: pkgupdate


### PR DESCRIPTION
The result of testing the following 5 CVE's against a host that had already run `security-patches.yml` was that the only remaining package to upgrade was `libcurl3-gnutls`.  

```
CVE-2017-5335
CVE-2017-5336
CVE-2017-5337
CVE-2017-3735
CVE-2017-1000257
```