### PR TITLE
lowering verbosity of ceph status check

### DIFF
--- a/roles/ceph-monitor/tasks/monitoring.yml
+++ b/roles/ceph-monitor/tasks/monitoring.yml
@@ -25,7 +25,7 @@
 
 - name: ceph status check
   sensu_check: name=check-ceph-status plugin=check-ceph.rb
-               use_sudo=true args='--criticality {{ ceph.monitoring.sensu_checks.check_ceph_status.criticality }} {{ ceph.monitoring.sensu_checks.check_ceph_status.escalate_flags }} -f -p'
+               use_sudo=true args='--criticality {{ ceph.monitoring.sensu_checks.check_ceph_status.criticality }} {{ ceph.monitoring.sensu_checks.check_ceph_status.escalate_flags }}'
   notify: restart sensu-client
 
 - name: ceph cluster usage check

--- a/roles/ceph-monitor/tasks/monitoring.yml
+++ b/roles/ceph-monitor/tasks/monitoring.yml
@@ -25,7 +25,7 @@
 
 - name: ceph status check
   sensu_check: name=check-ceph-status plugin=check-ceph.rb
-               use_sudo=true args='--criticality {{ ceph.monitoring.sensu_checks.check_ceph_status.criticality }} {{ ceph.monitoring.sensu_checks.check_ceph_status.escalate_flags }} -o -f -p'
+               use_sudo=true args='--criticality {{ ceph.monitoring.sensu_checks.check_ceph_status.criticality }} {{ ceph.monitoring.sensu_checks.check_ceph_status.escalate_flags }} -f -p'
   notify: restart sensu-client
 
 - name: ceph cluster usage check


### PR DESCRIPTION
PagerDuty api has a limit of 1024 in messages and including the osd tree was pushing the messages over that limit so even though critical alerts were being triggered, pagerduty would reject the request.