### PR TITLE
Fixed log entry tagging bug

### DIFF
--- a/roles/aodh/defaults/main.yml
+++ b/roles/aodh/defaults/main.yml
@@ -37,27 +37,37 @@ aodh:
       - /var/log/aodh/aodh-api.log
       fields:
         type: openstack
-        tags: aodh,aodh-api
+        tags:
+          - aodh
+          - aodh-api
     - paths:
       - /var/log/aodh/aodh-listener.log
       fields:
         type: openstack
-        tags: aodh,aodh-listener
+        tags:
+          - aodh
+          - aodh-listener
     - paths:
       - /var/log/aodh/aodh-notifier.log
       fields:
         type: openstack
-        tags: aodh,aodh-notifier
+        tags:
+          - aodh
+          - aodh-notifier
     - paths:
       - /var/log/aodh/aodh-expirer.log
       fields:
         type: openstack
-        tags: aodh,aodh-expirer
+        tags:
+          - aodh
+          - aodh-expirer
     - paths:
       - /var/log/aodh/aodh-evaluator.log
       fields:
         type: openstack
-        tags: aodh,aodh-evaluator
+        tags:
+          - aodh
+          - aodh-evaluator
   cafile: "{{ ssl.cafile }}"
   alarm_history_time_to_live: 864000
   monitoring:

--- a/roles/barbican/defaults/main.yml
+++ b/roles/barbican/defaults/main.yml
@@ -53,7 +53,9 @@ barbican:
       - /var/log/barbican/api.log
       fields:
         type: openstack
-        tags: barbican,barbican-api
+        tags:
+          - barbican
+          - barbican-api
   backlog: 4096
   max_allowed_secret_in_bytes: 10000
   max_allowed_request_size_in_bytes: 1000000

--- a/roles/ceilometer-common/defaults/main.yml
+++ b/roles/ceilometer-common/defaults/main.yml
@@ -43,22 +43,30 @@ ceilometer:
         - /var/log/ceilometer/*api.log
       fields:
         type: openstack
-        tags: ceilometer,ceilometer-api
+        tags:
+          - ceilometer
+          - ceilometer-api
     - paths:
         - /var/log/ceilometer/*agent-notification.log
       fields:
         type: openstack
-        tags: ceilometer,ceilometer-agent-notification
+        tags:
+          - ceilometer
+          - ceilometer-agent-notification
     - paths:
         - /var/log/ceilometer/*collector.log
       fields:
         type: openstack
-        tags: ceilometer,ceilometer-collector
+        tags:
+          - ceilometer
+          - ceilometer-collector
     - paths:
         - /var/log/ceilometer/*polling.log
       fields:
         type: openstack
-        tags: ceilometer,ceilometer-polling
+        tags:
+          - ceilometer
+          - ceilometer-polling
   logging:
     debug: False
     verbose: True

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -198,12 +198,16 @@ ceph:
         - /var/log/ceph/ceph-osd*.log
       fields:
         type: openstack
-        tags: ceph,ceph-osd
+        tags:
+          - ceph
+          - ceph-osd
     - paths:
         - /var/log/ceph/ceph.audit.log
       fields:
         type: openstack
-        tags: ceph,ceph-audit,archive
+        tags:
+          - ceph
+          - ceph-audit,archive
     - paths:
         - /var/log/ceph/ceph.log
       fields:
@@ -213,7 +217,9 @@ ceph:
         - /var/log/ceph/ceph-mon*.log
       fields:
         type: openstack
-        tags: ceph,ceph-mon
+        tags:
+          - ceph
+          - ceph-mon
 
   monitoring:
     sensu_checks:

--- a/roles/cinder-common/defaults/main.yml
+++ b/roles/cinder-common/defaults/main.yml
@@ -74,27 +74,37 @@ cinder:
       - /var/log/cinder/cinder-api.log
     fields:
       type: openstack
-      tags: cinder,cinder-api
+      tags:
+        - cinder
+        - cinder-api
   - paths:
       - /var/log/cinder/cinder-manage.log
     fields:
       type: openstack
-      tags: cinder,cinder-manage
+      tags:
+        - cinder
+        - cinder-manage
   - paths:
       - /var/log/cinder/cinder-scheduler.log
     fields:
       type: openstack
-      tags: cinder,cinder-scheduler
+      tags:
+        - cinder
+        - cinder-scheduler
   - paths:
       - /var/log/cinder/cinder-volume.log
     fields:
       type: openstack
-      tags: cinder,cinder-volume
+      tags:
+        - cinder
+        - cinder-volume
   - paths:
       - /var/log/upstart/tgt.log
     fields:
       type: openstack
-      tags: cinder,tgt
+      tags:
+        - cinder
+        - tgt
   logging:
     debug: False
     verbose: True

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -165,7 +165,9 @@ common:
         - /var/log/audit/audit.log
       fields:
         type: syslog
-        tags: audit,common
+        tags:
+          - audit
+          - common
     - paths:
         - /var/log/sensu/sensu-client.log
       fields:

--- a/roles/glance/defaults/main.yml
+++ b/roles/glance/defaults/main.yml
@@ -62,17 +62,23 @@ glance:
         - /var/log/glance/glance-api.log
       fields:
         type: openstack
-        tags: glance,glance-api
+        tags:
+          - glance
+          - glance-api
     - paths:
         - /var/log/glance/glance-manage.log
       fields:
         type: openstack
-        tags: glance,glance-manage
+        tags:
+          - glance
+          - glance-manage
     - paths:
         - /var/log/glance/glance-registry.log
       fields:
         type: openstack
-        tags: glance,glance-registry
+        tags:
+          - glance
+          - glance-registry
   logging:
     debug: False
     verbose: True

--- a/roles/heat/defaults/main.yml
+++ b/roles/heat/defaults/main.yml
@@ -41,17 +41,23 @@ heat:
         - /var/log/heat/heat-api.log
       fields:
         type: openstack
-        tags: heat,heat-api
+        tags:
+          - heat
+          - heat-api
     - paths:
         - /var/log/heat/heat-engine.log
       fields:
         type: openstack
-        tags: heat,heat-engine
+        tags:
+          - heat
+          - heat-engine
     - paths:
         - /var/log/heat/heat-manage.log
       fields:
         type: openstack
-        tags: heat,heat-manage
+        tags:
+          - heat
+          - heat-manage
   logging:
     debug: False
     verbose: True

--- a/roles/ironic-common/defaults/main.yml
+++ b/roles/ironic-common/defaults/main.yml
@@ -39,12 +39,16 @@ ironic:
         - /var/log/ironic/ironic-api.log
       fields:
         type: openstack
-        tags: ironic,ironic-api
+        tags:
+          - ironic
+          - ironic-api
     - paths:
         - /var/log/ironic/ironic-conductor.log
       fields:
         type: openstack
-        tags: ironic,ironic-conductor
+        tags:
+          - ironic
+          - ironic-conductor
   logging:
     debug: False
     verbose: True

--- a/roles/keystone-defaults/defaults/main.yml
+++ b/roles/keystone-defaults/defaults/main.yml
@@ -68,17 +68,23 @@ keystone:
       - /var/log/keystone/keystone-all.log
       fields:
         type: openstack
-        tags: keystone,keystone-all
+        tags:
+          - keystone
+          - keystone-all
     - paths:
         - /var/log/keystone/keystone-manage.log
       fields:
         type: openstack
-        tags: keystone,keystone-manage
+        tags:
+          - keystone
+          - keystone-manage
     - paths:
         - /var/log/keystone/keystone.log
       fields:
         type: openstack
-        tags: keystone,keystone-log
+        tags:
+          - keystone
+          - keystone-log
   logging:
     debug: False
     verbose: True

--- a/roles/magnum/defaults/main.yml
+++ b/roles/magnum/defaults/main.yml
@@ -22,12 +22,16 @@ magnum:
       - /var/log/magnum/magnum-api.log
       fields:
         type: openstack
-        tags: magnum,api,api
+        tags:
+          - magnum
+          - api,api
     - paths:
       - /var/log/magnum/magnum-conductor.log
       fields:
         type: openstack
-        tags: magnum,conductor
+        tags:
+          - magnum
+          - conductor
   logging:
     debug: False
     verbose: True

--- a/roles/neutron-common/defaults/main.yml
+++ b/roles/neutron-common/defaults/main.yml
@@ -130,32 +130,44 @@ neutron:
         - /var/log/neutron/neutron-server.log
       fields:
         type: openstack
-        tags: neutron,neutron-server
+        tags:
+          - neutron
+          - neutron-server
     - paths:
         - /var/log/neutron/neutron-dhcp-agent.log
       fields:
         type: openstack
-        tags: neutron,neutron-dhcp-agent
+        tags:
+          - neutron
+          - neutron-dhcp-agent
     - paths:
         - /var/log/neutron/neutron-l3-agent.log
       fields:
         type: openstack
-        tags: neutron,neutron-l3-agent
+        tags:
+          - neutron
+          - neutron-l3-agent
     - paths:
         - /var/log/neutron/neutron-metadata-agent.log
       fields:
         type: openstack
-        tags: neutron,neutron-metadata-agent
+        tags:
+          - neutron
+          - neutron-metadata-agent
     - paths:
         - /var/log/neutron/neutron-lbaasv2-agent.log
       fields:
         type: openstack
-        tags: neutron,neutron-lbaasv2-agent
+        tags:
+          - neutron
+          - neutron-lbaasv2-agent
     - paths:
         - /var/log/neutron/neutron-linuxbridge-agent.log
       fields:
         type: openstack
-        tags: neutron,neutron-linuxbridge-agent
+        tags:
+          - neutron
+          - neutron-linuxbridge-agent
   logging:
     debug: False
     verbose: True

--- a/roles/nova-common/defaults/main.yml
+++ b/roles/nova-common/defaults/main.yml
@@ -142,47 +142,65 @@ nova:
         - /var/log/nova/nova-api.log
       fields:
         type: openstack
-        tags: nova,nova-api
+        tags:
+          - nova
+          - nova-api
     - paths:
         - /var/log/nova/nova-placement-api.log
       fields:
         type: openstack
-        tags: nova,nova-placement-api
+        tags:
+          - nova
+          - nova-placement-api
     - paths:
         - /var/log/nova/nova-compute.log
       fields:
         type: openstack
-        tags: nova,nova-compute
+        tags:
+          - nova
+          - nova-compute
     - paths:
         - /var/log/nova/nova-conductor.log
       fields:
         type: openstack
-        tags: nova,nova-conductor
+        tags:
+          - nova
+          - nova-conductor
     - paths:
         - /var/log/nova/nova-consoleauth.log
       fields:
         type: openstack
-        tags: nova,nova-consoleauth
+        tags:
+          - nova
+          - nova-consoleauth
     - paths:
         - /var/log/nova/nova-manage.log
       fields:
         type: openstack
-        tags: nova,nova-manage
+        tags:
+          - nova
+          - nova-manage
     - paths:
         - /var/log/nova/nova-novncproxy.log
       fields:
         type: openstack
-        tags: nova,novnc
+        tags:
+          - nova
+          - novnc
     - paths:
         - /var/log/nova/nova-scheduler.log
       fields:
         type: openstack
-        tags: nova,nova-scheduler
+        tags:
+          - nova
+          - nova-scheduler
     - paths:
         - /var/log/nova/nova-cert.log
       fields:
         type: openstack
-        tags: nova,nova-cert
+        tags:
+          - nova
+          - nova-cert
   logging:
     debug: False
     verbose: True

--- a/roles/swift-common/defaults/main.yml
+++ b/roles/swift-common/defaults/main.yml
@@ -84,22 +84,30 @@ swift:
         - /var/log/swift/account.log
       fields:
         type: openstack
-        tags: swift,swift-account
+        tags:
+          - swift
+          - swift-account
     - paths:
         - /var/log/swift/container.log
       fields:
         type: openstack
-        tags: swift,swift-container
+        tags:
+          - swift
+          - swift-container
     - paths:
         - /var/log/swift/object.log
       fields:
         type: openstack
-        tags: swift,swift-object
+        tags:
+          - swift
+          - swift-object
     - paths:
         - /var/log/swift/proxy.log
       fields:
         type: openstack
-        tags: swift,swift-proxy
+        tags:
+          - swift
+          - swift-proxy
     - paths:
         - /var/log/swift/swift.log
       fields:


### PR DESCRIPTION
csv tags were being interpreted as a single string, so not usable in kibana for filtering. Converted to list values to fix.