### PR TITLE
Specify version 4.0.0 of libvirt-python

### DIFF
--- a/roles/ceilometer-data/tasks/main.yml
+++ b/roles/ceilometer-data/tasks/main.yml
@@ -24,7 +24,7 @@
   when: ursula_os == 'rhel'
 
 - name: install libvirt-python in package venv
-  command: "{{ 'ceilometer'|ursula_package_path(openstack_package_version) }}/bin/pip install libvirt-python"
+  command: "{{ 'ceilometer'|ursula_package_path(openstack_package_version) }}/bin/pip install 'libvirt-python==4.0.0'"
   notify: restart ceilometer data services
   when: openstack_install_method == 'package'
 

--- a/roles/nova-data/tasks/libvirt.yml
+++ b/roles/nova-data/tasks/libvirt.yml
@@ -58,8 +58,10 @@
 # # This is done with command rather than pip due to a bug where the venv
 # # would get re-created on this task, breaking things badly. pip module
 # # needs to be fixed first.
+# # # specify v4.0.0 because latest will not compile against older libvirts
+# # # see openstack bug # 1753539
 - name: install libvirt-python in package venv (ubuntu)
-  command: "{{ 'nova'|ursula_package_path(openstack_package_version) }}/bin/pip install libvirt-python"
+  command: "{{ 'nova'|ursula_package_path(openstack_package_version) }}/bin/pip install 'libvirt-python==4.0.0'"
   register: lvpout
   changed_when: lvpout.stdout|search("Successfully installed")
   notify: restart nova services


### PR DESCRIPTION
Problem is that the version fails to compile against older libvirt system packages.  See openstack bug # 1753539