### PR TITLE
pin libvirt0 version on jenkins ci

### DIFF
--- a/roles/openstack-package/tasks/main.yml
+++ b/roles/openstack-package/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+# NOTE: This task runs on Jenkins CI, since only needed on new installs.
+# depending on package versions in the repos, the openstack-nova* package
+# may install the wrong version of libvirt0 as a dependency. That will
+# cause a failure later when we intall libvirt* package.
+# This runs first to prevent that.
+- name: install proper version of libvirt0
+  package:
+    name: "libvirt0={{ nova.libvirt_bin_version }}"
+  when: project_name == 'nova' and lookup('env', 'BUILD_ID') != ""
+
 - name: "install {{ project_name }} package"
   apt: pkg="{{ package_name|default(openstack_package.package_name) }}"
        update_cache=yes cache_valid_time=3600


### PR DESCRIPTION
Since its only needed for new installs, the 2nd conditional in the task ensures it will only run on Jenkins CI.