### PR TITLE
increase ceph healthcheck timeout

### DIFF
--- a/playbooks/tests/tasks/ceph.yml
+++ b/playbooks/tests/tasks/ceph.yml
@@ -78,5 +78,5 @@
       shell: ceph health
       register: results
       until: results.stdout == 'HEALTH_OK'
-      retries: 5
-      delay: 30
+      retries: 10
+      delay: 60


### PR DESCRIPTION
Increase max timeout and retry count to avoid clock skew during CI